### PR TITLE
GenerateAssemblyInfo now works with projects that use xam markup comp…

### DIFF
--- a/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <VersionCsFile>$(IntermediateOutputPath)\$(AssemblyName).Version.cs</VersionCsFile>
 
-    <PrepareResourceNamesDependsOn>
+    <PrepareResourcesDependsOn>
       GenerateAssemblyInfo;
-      $(PrepareResourceNamesDependsOn)
-    </PrepareResourceNamesDependsOn>
+      $(PrepareResourcesDependsOn)
+    </PrepareResourcesDependsOn>
 
     <BeforeCompileDependsOn>
       GenerateAssemblyInfo;
@@ -104,6 +104,10 @@
     <Copy Condition=" '$(AssemblyInfoChanged)' == 'true' " SourceFiles="$(NewVersionCsFile)" DestinationFiles="$(VersionCsFile)" />
     <ItemGroup>
       <Compile Include="$(VersionCsFile)" />
+
+      <!-- Markup compilation (for projects including xaml files) may also need this file (as it builds a copy of the original project that ignores the content of Compile).
+      Including it into _GeneratedCodeFiles that is used by the GenerateTemporaryTargetAssembly target to build the temporary project -->
+      <_GeneratedCodeFiles Include="$(VersionCsFile)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
…ilation (which also builds a copy of the project).

     - Updating the dependency list so that GenerateAssemblyInfo would be picked up before the markup compile targets
     - Including the version file into an additional collection that is used by the markup compile to build a temporary copy of the project (which uses a new clean copy of the Compile items)