### PR TITLE
Allow version.txt files to live in a subdirectory and have the major.minor picked up during the build

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
@@ -94,6 +94,17 @@ public class GitExtensionsTests : RepoTestBase
     }
 
     [Fact]
+    public void GetIdAsVersion_ReadsMajorMinorFromVersionTxtInSubdirectory()
+    {
+        this.WriteVersionFile("4.8", relativeDirectory:@"foo\bar");
+        var firstCommit = this.Repo.Commits.First();
+
+        Version v1 = firstCommit.GetIdAsVersion(@"foo\bar");
+        Assert.Equal(4, v1.Major);
+        Assert.Equal(8, v1.Minor);
+    }
+
+    [Fact]
     public void GetIdAsVersion_MissingVersionTxt()
     {
         this.AddCommits();

--- a/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
+++ b/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
@@ -68,14 +68,20 @@
             }
         }
 
-        protected void WriteVersionFile(string version = "1.2", string prerelease = "")
+        protected void WriteVersionFile(string version = "1.2", string prerelease = "", string relativeDirectory = null)
         {
-            VersionFile.SetVersion(this.RepoPath, new System.Version(version), prerelease);
+            if (relativeDirectory == null)
+            {
+                relativeDirectory = string.Empty;
+            }
+
+            VersionFile.SetVersion(Path.Combine(this.RepoPath, relativeDirectory), new System.Version(version), prerelease);
 
             if (this.Repo != null)
             {
-                this.Repo.Index.Add(VersionFile.FileName);
-                this.Repo.Commit($"Add/write {VersionFile.FileName} set to {version}", this.Signer);
+                var relativeFilePath = Path.Combine(relativeDirectory, VersionFile.FileName);
+                this.Repo.Index.Add(relativeFilePath);
+                this.Repo.Commit($"Add/write {relativeFilePath} set to {version}", this.Signer);
             }
         }
     }

--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -87,7 +87,7 @@
         }
 
         /// <summary>
-        /// Writes the version.txt file to the root of a repo with the specified version information.
+        /// Writes the version.txt file to a directory within a repo with the specified version information.
         /// </summary>
         /// <param name="projectDirectory">
         /// The path to the directory in which to write the version.txt file.
@@ -102,11 +102,13 @@
             Requires.NotNullOrEmpty(projectDirectory, nameof(projectDirectory));
             Requires.NotNull(version, nameof(version));
 
+            Directory.CreateDirectory(projectDirectory);
+
             string versionTxtPath = Path.Combine(projectDirectory, FileName);
             File.WriteAllLines(
                 versionTxtPath,
                 new[] { version.ToString(), prerelease });
-            return Path.Combine(projectDirectory, FileName);
+            return versionTxtPath;
         }
 
         /// <summary>

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -97,8 +97,13 @@
 
                     this.PrereleaseVersion = v.UnstableTag;
 
+                    var repoRoot = git?.Info?.WorkingDirectory;
+                    var relativeRepoProjectDirectory = !string.IsNullOrWhiteSpace(repoRoot) && GitRepoPath.StartsWith(repoRoot, StringComparison.OrdinalIgnoreCase)
+                        ? GitRepoPath.Substring(repoRoot.Length)
+                        : null;
+
                     // Override the typedVersion with the special build number and revision components, when available.
-                    typedVersion = commit?.GetIdAsVersion() ?? v.Version;
+                    typedVersion = commit?.GetIdAsVersion(relativeRepoProjectDirectory) ?? v.Version;
                 }
 
                 typedVersion = typedVersion ?? new Version();


### PR DESCRIPTION
Fixes a bug where if the version.txt file did not live at the repo root, it's contents would not be located in any historical git commit during the build, which would cause all version numbers to stat with 0.0.x. I added a regression test for the scenario, and some extra test coverage for the subdirectory case, in addition to some minor fixes/cleanup along the way.