### PR TITLE
Add support for version.json file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,13 +22,14 @@ After installing this NuGet package, you may need to configure the version gener
 in order for it to work properly.
 
 With NuGet 2.x, the configuration is handled automatically via the tools\Install.ps1 script.
-For NuGet 3.x, you can run the script tools\Create-VersionTxt.ps1 to help you create the
-version.txt file and remove the old assembly attributes.
+For NuGet 3.x, you can run the script tools\Create-VersionFile.ps1 to help you create the
+version.json file and remove the old assembly attributes.
 
-The scripts will look for the presence of a version.txt file. If it already exists, nothing
-happens. If the version.txt file does not exist, the script looks in your project for the
-Properties\AssemblyInfo.cs file and attempts to read the Major.Minor version number from
-the AssemblyVersion attribute. It then generates a version.txt file using the Major.Minor
+The scripts will look for the presence of a version.json or version.txt file.
+If one already exists, nothing happens. If the version file does not exist,
+the script looks in your project for the Properties\AssemblyInfo.cs file and attempts
+to read the Major.Minor version number from
+the AssemblyVersion attribute. It then generates a version.json file using the Major.Minor
 that was parsed so that your assembly will build with the same AssemblyVersion as before,
 which preserves backwards compatibility. Finally, it will remove the various version-related
 assembly attributes from AssemblyInfo.cs.
@@ -44,39 +45,57 @@ source code, as commonly found in your `Properties\AssemblyInfo.cs` file:
     [assembly: AssemblyInformationalVersion("1.0.0-dev")]
 
 This NuGet package creates these attributes at build time based on version information
-found in your `version.txt` file and your git repo's HEAD position.
+found in your `version.json` or `version.txt` file and your git repo's HEAD position.
 
-Note: After first installing the package, you need to commit the version.txt file so that
+Note: After first installing the package, you need to commit the version file so that
 it will be picked up during the build's version generation. If you build prior to committing,
 the version number produced will be 0.0.x.
 
-### version.txt file
+### version.json or version.txt file
 
-You must define a version.txt file in your project directory or some ancestor of it.
+You must define a version.json or version.txt file in your project directory or some ancestor of it.
 
-When the package is installed, a version.txt file is created in your project directory
+When the package is installed, a version.json file is created in your project directory
 (for NuGet 2.x clients). This ensures backwards compatibility where the installation of
 this package will not cause the assembly version of the project to change. If you would
 like the same version number to be applied to all projects in the repo, then you may move
 the file to the root directory of your git repo.
 
-Here is the content of a sample version.txt file you may start with (do not indent):
+Here is the content of a sample version.json file you may start with (do not indent):
+
+	{ "version": "1.0.0-beta" }
+
+Or the (deprecated) version.txt file you may start with (do not indent):
 
     1.0.0
     -beta
 
-### version.txt file format
+### version.json file format
 
-The format of the version.txt file is as follows:
-LINE 1: x.y.z
-LINE 2: -prerelease
+The content of the version.json file is a JSON serialized object with these properties:
+
+    {
+	    "version": "x.y.z-prerelease"
+	}
 
 The `x` and `y` variables are for your use to specify a version that is meaningful
 to your customers. Consider using [semantic versioning][semver] for guidance.
 The `z` variable should be 0.
 
-The second line is optional and allows you to indicate that you are building
-prerelease software. 
+The optional -prerelease tag allows you to indicate that you are building prerelease software. 
+
+### version.txt file format (obsolete)
+
+The content of the version.txt file is a semver-compliant version in this format:
+
+	x.y.z-prerelease
+
+The `x` and `y` variables are for your use to specify a version that is meaningful
+to your customers. Consider using [semantic versioning][semver] for guidance.
+The `z` variable should be 0.
+
+The optional -prerelease tag may appear on the second line. This tag allows you
+to indicate that you are building prerelease software. 
 
 ### Apply to VSIX versions
 
@@ -136,7 +155,7 @@ packages with a colliding version spec.
 
 ## Where and how versions are calculated and applied
 
-This package calculates the version based on a combination of the version.txt file,
+This package calculates the version based on a combination of the version file,
 the git 'height' of the version, and the git commit ID.
 
 ### Assembly version generation
@@ -148,10 +167,10 @@ During the build it adds source code such as this to your compilation:
     [assembly: System.Reflection.AssemblyInformationalVersion("1.0.24.15136-alpha+g9a7eb6c819")]
 
 The first and second integer components of the versions above come from the 
-version.txt file.
+version file.
 The third integer component of the version here is the height of your git history up to
 that point, such that it reliably increases with each release.
-The -alpha tag also comes from the version.txt file and indicates this is an
+The -alpha tag also comes from the version file and indicates this is an
 unstable version.
 The -g9a7eb6c819 tag is the concatenation of -g and the git commit ID that was built.
 

--- a/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
@@ -96,7 +96,7 @@ public class GitExtensionsTests : RepoTestBase
     [Fact]
     public void GetIdAsVersion_ReadsMajorMinorFromVersionTxtInSubdirectory()
     {
-        this.WriteVersionFile("4.8", relativeDirectory:@"foo\bar");
+        this.WriteVersionFile("4.8", relativeDirectory: @"foo\bar");
         var firstCommit = this.Repo.Commits.First();
 
         Version v1 = firstCommit.GetIdAsVersion(@"foo\bar");
@@ -150,10 +150,10 @@ public class GitExtensionsTests : RepoTestBase
     [Fact]
     public void GetIdAsVersion_Roundtrip_WithSubdirectoryVersionFiles()
     {
-        var rootVersionExpected = new Version(1, 0);
+        var rootVersionExpected = VersionOptions.FromVersion(new Version(1, 0));
         VersionFile.SetVersion(this.RepoPath, rootVersionExpected);
 
-        var subPathVersionExpected = new Version(1, 1);
+        var subPathVersionExpected = VersionOptions.FromVersion(new Version(1, 1));
         const string subPathRelative = "a";
         string subPath = Path.Combine(this.RepoPath, subPathRelative);
         Directory.CreateDirectory(subPath);
@@ -166,8 +166,8 @@ public class GitExtensionsTests : RepoTestBase
         Version subPathVersionActual = head.GetIdAsVersion(subPathRelative);
 
         // Verify that the versions calculated took the path into account.
-        Assert.Equal(rootVersionExpected.Minor, rootVersionActual?.Minor);
-        Assert.Equal(subPathVersionExpected.Minor, subPathVersionActual?.Minor);
+        Assert.Equal(rootVersionExpected.DefaultVersion.Version.Minor, rootVersionActual?.Minor);
+        Assert.Equal(subPathVersionExpected.DefaultVersion.Version.Minor, subPathVersionActual?.Minor);
 
         // Verify that we can find the commit given the version and path.
         Assert.Equal(head, this.Repo.GetCommitFromVersion(rootVersionActual));

--- a/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
@@ -193,6 +193,27 @@ public class GitExtensionsTests : RepoTestBase
         Assert.True(version.Revision < 0xfffe, $"{nameof(Version.Revision)} component exceeds maximum allowed by the compiler as an argument for AssemblyVersionAttribute and AssemblyFileVersionAttribute.");
     }
 
+    [Fact]
+    public void GetIdAsVersion_MigrationFromVersionTxtToJson()
+    {
+        var txtCommit = this.WriteVersionTxtFile("4.8");
+
+        // Delete the version.txt file so the system writes the version.json file.
+        File.Delete(Path.Combine(this.RepoPath, "version.txt"));
+        var jsonCommit = this.WriteVersionFile("4.8");
+        Assert.True(File.Exists(Path.Combine(this.RepoPath, "version.json")));
+
+        Version v1 = txtCommit.GetIdAsVersion();
+        Assert.Equal(4, v1.Major);
+        Assert.Equal(8, v1.Minor);
+        Assert.Equal(1, v1.Build);
+
+        Version v2 = jsonCommit.GetIdAsVersion();
+        Assert.Equal(4, v2.Major);
+        Assert.Equal(8, v2.Minor);
+        Assert.Equal(2, v2.Build);
+    }
+
     ////[Fact] // Manual, per machine test
     public void TestBiggerRepo()
     {

--- a/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
@@ -166,8 +166,8 @@ public class GitExtensionsTests : RepoTestBase
         Version subPathVersionActual = head.GetIdAsVersion(subPathRelative);
 
         // Verify that the versions calculated took the path into account.
-        Assert.Equal(rootVersionExpected.DefaultVersion.Version.Minor, rootVersionActual?.Minor);
-        Assert.Equal(subPathVersionExpected.DefaultVersion.Version.Minor, subPathVersionActual?.Minor);
+        Assert.Equal(rootVersionExpected.Version.Version.Minor, rootVersionActual?.Minor);
+        Assert.Equal(subPathVersionExpected.Version.Version.Minor, subPathVersionActual?.Minor);
 
         // Verify that we can find the commit given the version and path.
         Assert.Equal(head, this.Repo.GetCommitFromVersion(rootVersionActual));

--- a/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
+++ b/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
@@ -9,7 +9,7 @@
     using LibGit2Sharp;
     using Validation;
     using Xunit.Abstractions;
-
+    using System.Diagnostics;
     public abstract class RepoTestBase : IDisposable
     {
         public RepoTestBase(ITestOutputHelper logger)
@@ -75,11 +75,13 @@
                 relativeDirectory = string.Empty;
             }
 
-            VersionFile.SetVersion(Path.Combine(this.RepoPath, relativeDirectory), new System.Version(version), prerelease);
+            var versionData = VersionOptions.FromVersion(new System.Version(version), prerelease);
+            string versionFilePath = VersionFile.SetVersion(Path.Combine(this.RepoPath, relativeDirectory), versionData);
 
             if (this.Repo != null)
             {
-                var relativeFilePath = Path.Combine(relativeDirectory, VersionFile.FileName);
+                Assumes.True(versionFilePath.StartsWith(this.RepoPath, StringComparison.OrdinalIgnoreCase));
+                var relativeFilePath = versionFilePath.Substring(this.RepoPath.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                 this.Repo.Index.Add(relativeFilePath);
                 this.Repo.Commit($"Add/write {relativeFilePath} set to {version}", this.Signer);
             }

--- a/src/NerdBank.GitVersioning.Tests/SemanticVersionTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/SemanticVersionTests.cs
@@ -11,9 +11,10 @@ public class SemanticVersionTests
     [Fact]
     public void Ctor()
     {
-        var sv = new SemanticVersion(new Version(1, 2), "-pre");
+        var sv = new SemanticVersion(new Version(1, 2), "-pre", "+mybuild");
         Assert.Equal(new Version(1, 2), sv.Version);
-        Assert.Equal("-pre", sv.UnstableTag);
+        Assert.Equal("-pre", sv.Prerelease);
+        Assert.Equal("+mybuild", sv.BuildMetadata);
     }
 
     [Fact]
@@ -23,10 +24,11 @@ public class SemanticVersionTests
     }
 
     [Fact]
-    public void Ctor_NormalizesNullUnstableTag()
+    public void Ctor_NormalizesNullPreleaseAndBuildMetadata()
     {
-        var sv = new SemanticVersion(new Version(1, 2), null);
-        Assert.Equal(string.Empty, sv.UnstableTag);
+        var sv = new SemanticVersion(new Version(1, 2));
+        Assert.Equal(string.Empty, sv.Prerelease);
+        Assert.Equal(string.Empty, sv.BuildMetadata);
     }
 
     [Fact]
@@ -45,6 +47,11 @@ public class SemanticVersionTests
         Assert.NotEqual(sv12Pre, sv12Beta);
         Assert.Equal(sv12Pre, sv12Pre);
 
+        var sv12BuildInfo = new SemanticVersion(new Version(1, 2), buildMetadata: "+buildInfo");
+        var sv12OtherBuildInfo = new SemanticVersion(new Version(1, 2), buildMetadata: "+otherBuildInfo");
+        Assert.NotEqual(sv12BuildInfo, sv12OtherBuildInfo);
+        Assert.Equal(sv12BuildInfo, sv12BuildInfo);
+
         Assert.False(sv12a.Equals(null));
     }
 
@@ -57,5 +64,19 @@ public class SemanticVersionTests
 
         var sv13 = new SemanticVersion(new Version(1, 3), null);
         Assert.NotEqual(sv12a.GetHashCode(), sv13.GetHashCode());
+    }
+
+    [Fact]
+    public void ToStringTests()
+    {
+        var v = new SemanticVersion(new Version(1, 2), null);
+        Assert.Equal("1.2", v.ToString());
+        var vp = new SemanticVersion(new Version(1, 2), "-pre");
+        Assert.Equal("1.2-pre", vp.ToString());
+        var vb = new SemanticVersion(new Version(1, 2), buildMetadata: "+buildInfo");
+        Assert.Equal("1.2+buildInfo", vb.ToString());
+        var vpb = new SemanticVersion(new Version(1, 2), "-pre", "+buildInfo");
+        Assert.Equal("1.2-pre+buildInfo", vpb.ToString());
+
     }
 }

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -89,8 +89,18 @@ public class VersionFileTests : RepoTestBase
 
         VersionOptions actualVersion = VersionFile.GetVersion(this.RepoPath);
 
-        Assert.Equal(new Version(expectedVersion), actualVersion.DefaultVersion.Version);
-        Assert.Equal(expectedPrerelease ?? string.Empty, actualVersion.DefaultVersion.Prerelease);
+        Assert.Equal(new Version(expectedVersion), actualVersion.Version.Version);
+        Assert.Equal(expectedPrerelease ?? string.Empty, actualVersion.Version.Prerelease);
+    }
+
+    [Fact]
+    public void GetVersion_CanReadSpecConformantFile()
+    {
+        File.WriteAllText(Path.Combine(this.RepoPath, VersionFile.JsonFileName), "{ version: \"1.2-pre\" }");
+        VersionOptions actualVersion = VersionFile.GetVersion(this.RepoPath);
+        Assert.NotNull(actualVersion);
+        Assert.Equal(new Version(1, 2), actualVersion.Version.Version);
+        Assert.Equal("-pre", actualVersion.Version.Prerelease);
     }
 
     [Fact]
@@ -138,12 +148,12 @@ public class VersionFileTests : RepoTestBase
 
     private void AssertPathHasVersion(Commit commit, string absolutePath, Version expected)
     {
-        var actual = VersionFile.GetVersion(absolutePath)?.DefaultVersion?.Version;
+        var actual = VersionFile.GetVersion(absolutePath)?.Version?.Version;
         Assert.Equal(expected, actual);
 
         // Pass in the repo-relative path to ensure the commit is used as the data source.
         string relativePath = absolutePath.Substring(this.RepoPath.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        actual = VersionFile.GetVersion(commit, relativePath)?.DefaultVersion?.Version;
+        actual = VersionFile.GetVersion(commit, relativePath)?.Version?.Version;
         Assert.Equal(expected, actual);
     }
 }

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -14,11 +14,13 @@ using Version = System.Version;
 public class VersionFileTests : RepoTestBase
 {
     private string versionTxtPath;
+    private string versionJsonPath;
 
     public VersionFileTests(ITestOutputHelper logger)
         : base(logger)
     {
-        this.versionTxtPath = Path.Combine(this.RepoPath, VersionFile.FileName);
+        this.versionTxtPath = Path.Combine(this.RepoPath, VersionFile.TxtFileName);
+        this.versionJsonPath = Path.Combine(this.RepoPath, VersionFile.JsonFileName);
     }
 
     [Fact]
@@ -80,19 +82,15 @@ public class VersionFileTests : RepoTestBase
     public void SetVersion_GetVersionFromFile(string expectedVersion, string expectedPrerelease)
     {
         string pathWritten = VersionFile.SetVersion(this.RepoPath, new Version(expectedVersion), expectedPrerelease);
-        Assert.Equal(Path.Combine(this.RepoPath, VersionFile.FileName), pathWritten);
+        Assert.Equal(Path.Combine(this.RepoPath, VersionFile.JsonFileName), pathWritten);
 
-        string[] actualFileContent = File.ReadAllLines(this.versionTxtPath);
-        this.Logger.WriteLine(string.Join(Environment.NewLine, actualFileContent));
+        string actualFileContent = File.ReadAllText(pathWritten);
+        this.Logger.WriteLine(actualFileContent);
 
-        Assert.Equal(2, actualFileContent.Length);
-        Assert.Equal(expectedVersion, actualFileContent[0]);
-        Assert.Equal(expectedPrerelease ?? string.Empty, actualFileContent[1]);
+        VersionOptions actualVersion = VersionFile.GetVersion(this.RepoPath);
 
-        SemanticVersion actualVersion = VersionFile.GetVersion(this.RepoPath);
-
-        Assert.Equal(new Version(expectedVersion), actualVersion.Version);
-        Assert.Equal(expectedPrerelease ?? string.Empty, actualVersion.UnstableTag);
+        Assert.Equal(new Version(expectedVersion), actualVersion.DefaultVersion.Version);
+        Assert.Equal(expectedPrerelease ?? string.Empty, actualVersion.DefaultVersion.UnstableTag);
     }
 
     [Fact]
@@ -102,8 +100,8 @@ public class VersionFileTests : RepoTestBase
 
         this.InitializeSourceControl();
         this.WriteVersionFile();
-        SemanticVersion fromCommit = VersionFile.GetVersion(this.Repo.Head.Commits.First());
-        SemanticVersion fromFile = VersionFile.GetVersion(this.RepoPath);
+        VersionOptions fromCommit = VersionFile.GetVersion(this.Repo.Head.Commits.First());
+        VersionOptions fromFile = VersionFile.GetVersion(this.RepoPath);
         Assert.NotNull(fromCommit);
         Assert.Equal(fromFile, fromCommit);
     }
@@ -140,12 +138,12 @@ public class VersionFileTests : RepoTestBase
 
     private void AssertPathHasVersion(Commit commit, string absolutePath, Version expected)
     {
-        var actual = VersionFile.GetVersion(absolutePath)?.Version;
+        var actual = VersionFile.GetVersion(absolutePath)?.DefaultVersion?.Version;
         Assert.Equal(expected, actual);
 
         // Pass in the repo-relative path to ensure the commit is used as the data source.
         string relativePath = absolutePath.Substring(this.RepoPath.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        actual = VersionFile.GetVersion(commit, relativePath)?.Version;
+        actual = VersionFile.GetVersion(commit, relativePath)?.DefaultVersion?.Version;
         Assert.Equal(expected, actual);
     }
 }

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -90,7 +90,7 @@ public class VersionFileTests : RepoTestBase
         VersionOptions actualVersion = VersionFile.GetVersion(this.RepoPath);
 
         Assert.Equal(new Version(expectedVersion), actualVersion.DefaultVersion.Version);
-        Assert.Equal(expectedPrerelease ?? string.Empty, actualVersion.DefaultVersion.UnstableTag);
+        Assert.Equal(expectedPrerelease ?? string.Empty, actualVersion.DefaultVersion.Prerelease);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -94,9 +94,39 @@ public class VersionFileTests : RepoTestBase
     }
 
     [Fact]
-    public void GetVersion_CanReadSpecConformantFile()
+    public void GetVersion_CanReadSpecConformantJsonFile()
     {
         File.WriteAllText(Path.Combine(this.RepoPath, VersionFile.JsonFileName), "{ version: \"1.2-pre\" }");
+        VersionOptions actualVersion = VersionFile.GetVersion(this.RepoPath);
+        Assert.NotNull(actualVersion);
+        Assert.Equal(new Version(1, 2), actualVersion.Version.Version);
+        Assert.Equal("-pre", actualVersion.Version.Prerelease);
+    }
+
+    [Fact]
+    public void GetVersion_CanReadSpecConformantTxtFile_SingleLine()
+    {
+        File.WriteAllText(Path.Combine(this.RepoPath, VersionFile.TxtFileName), "1.2-pre");
+        VersionOptions actualVersion = VersionFile.GetVersion(this.RepoPath);
+        Assert.NotNull(actualVersion);
+        Assert.Equal(new Version(1, 2), actualVersion.Version.Version);
+        Assert.Equal("-pre", actualVersion.Version.Prerelease);
+    }
+
+    [Fact]
+    public void GetVersion_CanReadSpecConformantTxtFile_MultiLine()
+    {
+        File.WriteAllText(Path.Combine(this.RepoPath, VersionFile.TxtFileName), "1.2\n-pre");
+        VersionOptions actualVersion = VersionFile.GetVersion(this.RepoPath);
+        Assert.NotNull(actualVersion);
+        Assert.Equal(new Version(1, 2), actualVersion.Version.Version);
+        Assert.Equal("-pre", actualVersion.Version.Prerelease);
+    }
+
+    [Fact]
+    public void GetVersion_CanReadSpecConformantTxtFile_MultiLineNoHyphen()
+    {
+        File.WriteAllText(Path.Combine(this.RepoPath, VersionFile.TxtFileName), "1.2\npre");
         VersionOptions actualVersion = VersionFile.GetVersion(this.RepoPath);
         Assert.NotNull(actualVersion);
         Assert.Equal(new Version(1, 2), actualVersion.Version.Version);

--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -119,7 +119,7 @@
             Requires.NotNull(commit, nameof(commit));
             Requires.Argument(repoRelativeProjectDirectory == null || !Path.IsPathRooted(repoRelativeProjectDirectory), nameof(repoRelativeProjectDirectory), "Path should be relative to repo root.");
 
-            var baseVersion = VersionFile.GetVersion(commit, repoRelativeProjectDirectory)?.Version ?? Version0;
+            var baseVersion = VersionFile.GetVersion(commit, repoRelativeProjectDirectory)?.DefaultVersion?.Version ?? Version0;
 
             // The compiler (due to WinPE header requirements) only allows 16-bit version components,
             // and forbids 0xffff as a value.
@@ -192,7 +192,7 @@
             Requires.NotNull(commit, nameof(commit));
             Requires.NotNull(expectedVersion, nameof(expectedVersion));
 
-            Version majorMinorFromFile = VersionFile.GetVersion(commit, repoRelativeProjectDirectory)?.Version ?? Version0;
+            Version majorMinorFromFile = VersionFile.GetVersion(commit, repoRelativeProjectDirectory)?.DefaultVersion?.Version ?? Version0;
             return majorMinorFromFile?.Major == expectedVersion.Major && majorMinorFromFile?.Minor == expectedVersion.Minor;
         }
 

--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -119,7 +119,7 @@
             Requires.NotNull(commit, nameof(commit));
             Requires.Argument(repoRelativeProjectDirectory == null || !Path.IsPathRooted(repoRelativeProjectDirectory), nameof(repoRelativeProjectDirectory), "Path should be relative to repo root.");
 
-            var baseVersion = VersionFile.GetVersion(commit, repoRelativeProjectDirectory)?.DefaultVersion?.Version ?? Version0;
+            var baseVersion = VersionFile.GetVersion(commit, repoRelativeProjectDirectory)?.Version?.Version ?? Version0;
 
             // The compiler (due to WinPE header requirements) only allows 16-bit version components,
             // and forbids 0xffff as a value.
@@ -192,7 +192,7 @@
             Requires.NotNull(commit, nameof(commit));
             Requires.NotNull(expectedVersion, nameof(expectedVersion));
 
-            Version majorMinorFromFile = VersionFile.GetVersion(commit, repoRelativeProjectDirectory)?.DefaultVersion?.Version ?? Version0;
+            Version majorMinorFromFile = VersionFile.GetVersion(commit, repoRelativeProjectDirectory)?.Version?.Version ?? Version0;
             return majorMinorFromFile?.Major == expectedVersion.Major && majorMinorFromFile?.Minor == expectedVersion.Minor;
         }
 

--- a/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
+++ b/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
@@ -61,6 +61,7 @@
     <Compile Include="GitExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SemanticVersion.cs" />
+    <Compile Include="SemanticVersionJsonConverter.cs" />
     <Compile Include="VersionFile.cs" />
     <Compile Include="VersionOptions.cs" />
   </ItemGroup>

--- a/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
+++ b/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
@@ -40,6 +40,10 @@
       <HintPath>..\..\packages\LibGit2Sharp.0.21.0.176\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -58,6 +62,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SemanticVersion.cs" />
     <Compile Include="VersionFile.cs" />
+    <Compile Include="VersionOptions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/NerdBank.GitVersioning/SemanticVersion.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersion.cs
@@ -15,7 +15,10 @@
         /// The regular expression with capture groups for semantic versioning.
         /// It considers PATCH to be optional.
         /// </summary>
-        private static readonly Regex FullSemVerPattern = new Regex(@"^(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?(?<prerelease>-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?<buildMetadata>\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$");
+        /// <remarks>
+        /// Parts of this regex inspired by https://github.com/sindresorhus/semver-regex/blob/master/index.js
+        /// </remarks>
+        private static readonly Regex FullSemVerPattern = new Regex(@"^v?(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*))?(?<prerelease>-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?<buildMetadata>\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// The regex pattern that a prerelease must match.

--- a/src/NerdBank.GitVersioning/SemanticVersion.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersion.cs
@@ -1,11 +1,13 @@
 ﻿namespace Nerdbank.GitVersioning
 {
     using System;
+    using System.Diagnostics;
     using Validation;
 
     /// <summary>
     /// Describes a version with an optional unstable tag.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SemanticVersion : IEquatable<SemanticVersion>
     {
         /// <summary>
@@ -16,6 +18,7 @@
         public SemanticVersion(Version version, string unstableTag = null)
         {
             Requires.NotNull(version, nameof(version));
+            VerifyValidPrereleaseVersion(unstableTag, nameof(unstableTag));
 
             this.Version = version;
             this.UnstableTag = unstableTag ?? string.Empty;
@@ -31,6 +34,11 @@
         /// </summary>
         /// <value>A string with a leading hyphen or the empty string.</value>
         public string UnstableTag { get; private set; }
+
+        /// <summary>
+        /// Gets the debugger display for this instance.
+        /// </summary>
+        private string DebuggerDisplay => this.ToString();
 
         /// <summary>
         /// Checks equality against another object.
@@ -52,6 +60,15 @@
         }
 
         /// <summary>
+        /// Prints this instance as a string.
+        /// </summary>
+        /// <returns>A string representation of this object.</returns>
+        public override string ToString()
+        {
+            return this.Version + this.UnstableTag;
+        }
+
+        /// <summary>
         /// Checks equality against another instance of this class.
         /// </summary>
         /// <param name="other">The other instance.</param>
@@ -65,6 +82,35 @@
 
             return this.Version == other.Version
                 && this.UnstableTag == other.UnstableTag;
+        }
+
+        /// <summary>
+        /// Verifies that the prerelease tag follows semver rules.
+        /// </summary>
+        /// <param name="prerelease">The prerelease tag to verify.</param>
+        /// <param name="parameterName">The name of the parameter to report as not conforming.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown if the <paramref name="prerelease"/> does not follow semver rules.
+        /// </exception>
+        private static void VerifyValidPrereleaseVersion(string prerelease, string parameterName)
+        {
+            if (string.IsNullOrEmpty(prerelease))
+            {
+                return;
+            }
+
+            if (prerelease[0] != '-')
+            {
+                throw new ArgumentOutOfRangeException(parameterName, "The prerelease string must begin with a hyphen.");
+            }
+
+            for (int i = 1; i < prerelease.Length; i++)
+            {
+                if (!char.IsLetterOrDigit(prerelease[i]))
+                {
+                    throw new ArgumentOutOfRangeException(parameterName, "The prerelease string must be alphanumeric.");
+                }
+            }
         }
     }
 }

--- a/src/NerdBank.GitVersioning/SemanticVersionJsonConverter.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersionJsonConverter.cs
@@ -1,0 +1,42 @@
+﻿namespace Nerdbank.GitVersioning
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
+    internal class SemanticVersionJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(SemanticVersion).IsAssignableFrom(objectType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (objectType.IsEquivalentTo(typeof(SemanticVersion)) && reader.Value is string)
+            {
+                SemanticVersion value;
+                if (SemanticVersion.TryParse((string)reader.Value, out value))
+                {
+                    return value;
+                }
+            }
+
+            throw new NotSupportedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var version = value as SemanticVersion;
+            if (version != null)
+            {
+                writer.WriteValue(version.ToString());
+                return;
+            }
+
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -240,9 +240,11 @@
                 }
             }
 
+            SemanticVersion semVer;
+            Verify.Operation(SemanticVersion.TryParse(versionLine + prereleaseVersion, out semVer), "Unrecognized version format.");
             return new VersionOptions
             {
-                Version = new SemanticVersion(new Version(versionLine), prereleaseVersion),
+                Version = semVer,
             };
         }
     }

--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -145,7 +145,7 @@
                 {
                     File.WriteAllLines(
                         versionTxtPath,
-                        new[] { version.DefaultVersion.Version.ToString(), version.DefaultVersion.UnstableTag });
+                        new[] { version.DefaultVersion.Version.ToString(), version.DefaultVersion.Prerelease });
                     return versionTxtPath;
                 }
                 else

--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -1,6 +1,10 @@
 ﻿namespace Nerdbank.GitVersioning
 {
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using Newtonsoft.Json.Serialization;
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using Validation;
 
@@ -12,7 +16,27 @@
         /// <summary>
         /// The filename of the version.txt file.
         /// </summary>
-        public const string FileName = "version.txt";
+        public const string TxtFileName = "version.txt";
+
+        /// <summary>
+        /// The filename of the version.json file.
+        /// </summary>
+        public const string JsonFileName = "version.json";
+
+        /// <summary>
+        /// A sequence of possible filenames for the version file in preferred order.
+        /// </summary>
+        public static readonly IReadOnlyList<string> PreferredFileNames = new[] { JsonFileName, TxtFileName };
+
+        /// <summary>
+        /// The JSON serializer settings to use.
+        /// </summary>
+        private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings()
+        {
+            Converters = new[] { new VersionConverter() },
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Formatting = Formatting.Indented,
+        };
 
         /// <summary>
         /// Reads the version.txt file and returns the <see cref="Version"/> and prerelease tag from it.
@@ -20,17 +44,18 @@
         /// <param name="commit">The commit to read the version file from.</param>
         /// <param name="repoRelativeProjectDirectory">The directory to consider when searching for the version.txt file.</param>
         /// <returns>The version information read from the file.</returns>
-        public static SemanticVersion GetVersion(LibGit2Sharp.Commit commit, string repoRelativeProjectDirectory = null)
+        public static VersionOptions GetVersion(LibGit2Sharp.Commit commit, string repoRelativeProjectDirectory = null)
         {
             if (commit == null)
             {
                 return null;
             }
 
-            using (var content = GetVersionFileReader(commit, repoRelativeProjectDirectory))
+            bool json;
+            using (var content = GetVersionFileReader(commit, repoRelativeProjectDirectory, out json))
             {
                 return content != null
-                    ? ReadVersionFile(content)
+                    ? ReadVersionFile(content, json)
                     : null;
             }
         }
@@ -40,19 +65,28 @@
         /// </summary>
         /// <param name="projectDirectory">The path to the directory which may (or its ancestors may) define the version.txt file.</param>
         /// <returns>The version information read from the file, or <c>null</c> if the file wasn't found.</returns>
-        public static SemanticVersion GetVersion(string projectDirectory)
+        public static VersionOptions GetVersion(string projectDirectory)
         {
             Requires.NotNullOrEmpty(projectDirectory, nameof(projectDirectory));
 
             string searchDirectory = projectDirectory;
             while (searchDirectory != null)
             {
-                string versionTxtPath = Path.Combine(searchDirectory, FileName);
+                string versionTxtPath = Path.Combine(searchDirectory, TxtFileName);
                 if (File.Exists(versionTxtPath))
                 {
                     using (var sr = new StreamReader(versionTxtPath))
                     {
-                        return ReadVersionFile(sr);
+                        return ReadVersionFile(sr, isJsonFile: false);
+                    }
+                }
+
+                string versionJsonPath = Path.Combine(searchDirectory, JsonFileName);
+                if (File.Exists(versionJsonPath))
+                {
+                    using (var sr = new StreamReader(versionJsonPath))
+                    {
+                        return ReadVersionFile(sr, isJsonFile: true);
                     }
                 }
 
@@ -95,20 +129,52 @@
         /// except where any of those directories have their own version.txt file.
         /// </param>
         /// <param name="version">The version information to write to the file.</param>
-        /// <param name="prerelease">The prerelease tag, starting with a hyphen per semver rules. May be the empty string or null.</param>
         /// <returns>The path to the file written.</returns>
-        public static string SetVersion(string projectDirectory, Version version, string prerelease = "")
+        public static string SetVersion(string projectDirectory, VersionOptions version)
         {
             Requires.NotNullOrEmpty(projectDirectory, nameof(projectDirectory));
             Requires.NotNull(version, nameof(version));
+            Requires.Argument(version.DefaultVersion != null, nameof(version), $"{nameof(VersionOptions.DefaultVersion)} must be set.");
 
             Directory.CreateDirectory(projectDirectory);
 
-            string versionTxtPath = Path.Combine(projectDirectory, FileName);
-            File.WriteAllLines(
-                versionTxtPath,
-                new[] { version.ToString(), prerelease });
-            return versionTxtPath;
+            string versionTxtPath = Path.Combine(projectDirectory, TxtFileName);
+            if (File.Exists(versionTxtPath))
+            {
+                if (version.IsDefaultVersionTheOnlyPropertySet)
+                {
+                    File.WriteAllLines(
+                        versionTxtPath,
+                        new[] { version.DefaultVersion.Version.ToString(), version.DefaultVersion.UnstableTag });
+                    return versionTxtPath;
+                }
+                else
+                {
+                    // The file must be upgraded to use the more descriptive JSON format.
+                    File.Delete(versionTxtPath);
+                }
+            }
+
+            string versionJsonPath = Path.Combine(projectDirectory, JsonFileName);
+            var jsonContent = JsonConvert.SerializeObject(version, JsonSettings);
+            File.WriteAllText(versionJsonPath, jsonContent);
+            return versionJsonPath;
+        }
+
+        /// <summary>
+        /// Writes the version.txt file to a directory within a repo with the specified version information.
+        /// </summary>
+        /// <param name="projectDirectory">
+        /// The path to the directory in which to write the version.txt file.
+        /// The file's impact will be all descendent projects and directories from this specified directory,
+        /// except where any of those directories have their own version.txt file.
+        /// </param>
+        /// <param name="version">The version information to write to the file.</param>
+        /// <param name="unstableTag">The optional unstable tag to include in the file.</param>
+        /// <returns>The path to the file written.</returns>
+        public static string SetVersion(string projectDirectory, Version version, string unstableTag = null)
+        {
+            return SetVersion(projectDirectory, VersionOptions.FromVersion(version, unstableTag));
         }
 
         /// <summary>
@@ -116,22 +182,33 @@
         /// </summary>
         /// <param name="commit">The commit to read the version file from.</param>
         /// <param name="repoRelativeProjectDirectory">The directory to consider when searching for the version.txt file.</param>
+        /// <param name="isJsonFile">Receives a value indicating whether the file found is a JSON file.</param>
         /// <returns>A text reader with the content of the version.txt file.</returns>
-        private static TextReader GetVersionFileReader(LibGit2Sharp.Commit commit, string repoRelativeProjectDirectory)
+        private static TextReader GetVersionFileReader(LibGit2Sharp.Commit commit, string repoRelativeProjectDirectory, out bool isJsonFile)
         {
             string searchDirectory = repoRelativeProjectDirectory ?? string.Empty;
             while (searchDirectory != null)
             {
-                string candidatePath = Path.Combine(searchDirectory, FileName);
+                string candidatePath = Path.Combine(searchDirectory, JsonFileName);
                 var versionTxtBlob = commit.Tree[candidatePath]?.Target as LibGit2Sharp.Blob;
                 if (versionTxtBlob != null)
                 {
+                    isJsonFile = true;
+                    return new StreamReader(versionTxtBlob.GetContentStream());
+                }
+
+                candidatePath = Path.Combine(searchDirectory, TxtFileName);
+                versionTxtBlob = commit.Tree[candidatePath]?.Target as LibGit2Sharp.Blob;
+                if (versionTxtBlob != null)
+                {
+                    isJsonFile = false;
                     return new StreamReader(versionTxtBlob.GetContentStream());
                 }
 
                 searchDirectory = searchDirectory.Length > 0 ? Path.GetDirectoryName(searchDirectory) : null;
             }
 
+            isJsonFile = false;
             return null;
         }
 
@@ -139,9 +216,16 @@
         /// Reads the version.txt file and returns the <see cref="Version"/> and prerelease tag from it.
         /// </summary>
         /// <param name="versionTextContent">The content of the version.txt file to read.</param>
+        /// <param name="isJsonFile"><c>true</c> if the file being read is a JSON file; <c>false</c> for the old-style text format.</param>
         /// <returns>The version information read from the file.</returns>
-        private static SemanticVersion ReadVersionFile(TextReader versionTextContent)
+        private static VersionOptions ReadVersionFile(TextReader versionTextContent, bool isJsonFile)
         {
+            if (isJsonFile)
+            {
+                string jsonContent = versionTextContent.ReadToEnd();
+                return JsonConvert.DeserializeObject<VersionOptions>(jsonContent, JsonSettings);
+            }
+
             string versionLine = versionTextContent.ReadLine();
             string prereleaseVersion = versionTextContent.ReadLine();
             if (!string.IsNullOrEmpty(prereleaseVersion))
@@ -151,36 +235,12 @@
                     // SemVer requires that prerelease suffixes begin with a hyphen, so add one if it's missing.
                     prereleaseVersion = "-" + prereleaseVersion;
                 }
-
-                VerifyValidPrereleaseVersion(prereleaseVersion);
             }
 
-            return new SemanticVersion(new Version(versionLine), prereleaseVersion);
-        }
-
-        /// <summary>
-        /// Verifies that the prerelease tag follows semver rules.
-        /// </summary>
-        /// <param name="prerelease">The prerelease tag to verify.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// Thrown if the <paramref name="prerelease"/> does not follow semver rules.
-        /// </exception>
-        private static void VerifyValidPrereleaseVersion(string prerelease)
-        {
-            Requires.NotNullOrEmpty(prerelease, nameof(prerelease));
-
-            if (prerelease[0] != '-')
+            return new VersionOptions
             {
-                throw new ArgumentOutOfRangeException("The prerelease string must begin with a hyphen.");
-            }
-
-            for (int i = 1; i < prerelease.Length; i++)
-            {
-                if (!char.IsLetterOrDigit(prerelease[i]))
-                {
-                    throw new ArgumentOutOfRangeException("The prerelease string must be alphanumeric.");
-                }
-            }
+                DefaultVersion = new SemanticVersion(new Version(versionLine), prereleaseVersion),
+            };
         }
     }
 }

--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -33,7 +33,10 @@
         /// </summary>
         private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings()
         {
-            Converters = new[] { new VersionConverter() },
+            Converters = new JsonConverter[] {
+                new VersionConverter(),
+                new SemanticVersionJsonConverter(),
+            },
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             Formatting = Formatting.Indented,
         };
@@ -134,7 +137,7 @@
         {
             Requires.NotNullOrEmpty(projectDirectory, nameof(projectDirectory));
             Requires.NotNull(version, nameof(version));
-            Requires.Argument(version.DefaultVersion != null, nameof(version), $"{nameof(VersionOptions.DefaultVersion)} must be set.");
+            Requires.Argument(version.Version != null, nameof(version), $"{nameof(VersionOptions.Version)} must be set.");
 
             Directory.CreateDirectory(projectDirectory);
 
@@ -145,7 +148,7 @@
                 {
                     File.WriteAllLines(
                         versionTxtPath,
-                        new[] { version.DefaultVersion.Version.ToString(), version.DefaultVersion.Prerelease });
+                        new[] { version.Version.Version.ToString(), version.Version.Prerelease });
                     return versionTxtPath;
                 }
                 else
@@ -239,7 +242,7 @@
 
             return new VersionOptions
             {
-                DefaultVersion = new SemanticVersion(new Version(versionLine), prereleaseVersion),
+                Version = new SemanticVersion(new Version(versionLine), prereleaseVersion),
             };
         }
     }

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -13,16 +13,16 @@
         /// <summary>
         /// Gets the default version to use.
         /// </summary>
-        public SemanticVersion DefaultVersion { get; set; }
+        public SemanticVersion Version { get; set; }
 
         /// <summary>
         /// Gets the debugger display for this instance.
         /// </summary>
-        private string DebuggerDisplay => this.DefaultVersion.ToString();
+        private string DebuggerDisplay => this.Version?.ToString();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VersionOptions"/> class
-        /// with <see cref="DefaultVersion"/> initialized with the specified parameters.
+        /// with <see cref="Version"/> initialized with the specified parameters.
         /// </summary>
         /// <param name="version">The version number.</param>
         /// <param name="unstableTag">The prerelease tag, if any.</param>
@@ -31,7 +31,7 @@
         {
             return new VersionOptions
             {
-                DefaultVersion = new SemanticVersion(version, unstableTag),
+                Version = new SemanticVersion(version, unstableTag),
             };
         }
 
@@ -51,7 +51,7 @@
         /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
-            return this.DefaultVersion?.GetHashCode() ?? 0;
+            return this.Version?.GetHashCode() ?? 0;
         }
 
         /// <summary>
@@ -66,16 +66,16 @@
                 return false;
             }
 
-            return EqualityComparer<SemanticVersion>.Default.Equals(this.DefaultVersion, other.DefaultVersion);
+            return EqualityComparer<SemanticVersion>.Default.Equals(this.Version, other.Version);
         }
 
         /// <summary>
-        /// Gets a value indicating whether <see cref="DefaultVersion"/> is
+        /// Gets a value indicating whether <see cref="Version"/> is
         /// set and the only property on this class that is set.
         /// </summary>
         internal bool IsDefaultVersionTheOnlyPropertySet
         {
-            get { return this.DefaultVersion != null; }
+            get { return this.Version != null; }
         }
     }
 }

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -1,0 +1,81 @@
+﻿namespace Nerdbank.GitVersioning
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Describes the various versions and options required for the build.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class VersionOptions : IEquatable<VersionOptions>
+    {
+        /// <summary>
+        /// Gets the default version to use.
+        /// </summary>
+        public SemanticVersion DefaultVersion { get; set; }
+
+        /// <summary>
+        /// Gets the debugger display for this instance.
+        /// </summary>
+        private string DebuggerDisplay => this.DefaultVersion.ToString();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VersionOptions"/> class
+        /// with <see cref="DefaultVersion"/> initialized with the specified parameters.
+        /// </summary>
+        /// <param name="version">The version number.</param>
+        /// <param name="unstableTag">The prerelease tag, if any.</param>
+        /// <returns>The new instance of <see cref="VersionOptions"/>.</returns>
+        public static VersionOptions FromVersion(Version version, string unstableTag = null)
+        {
+            return new VersionOptions
+            {
+                DefaultVersion = new SemanticVersion(version, unstableTag),
+            };
+        }
+
+        /// <summary>
+        /// Checks equality against another object.
+        /// </summary>
+        /// <param name="obj">The other instance.</param>
+        /// <returns><c>true</c> if the instances have equal values; <c>false</c> otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as VersionOptions);
+        }
+
+        /// <summary>
+        /// Gets a hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        public override int GetHashCode()
+        {
+            return this.DefaultVersion?.GetHashCode() ?? 0;
+        }
+
+        /// <summary>
+        /// Checks equality against another instance of this class.
+        /// </summary>
+        /// <param name="other">The other instance.</param>
+        /// <returns><c>true</c> if the instances have equal values; <c>false</c> otherwise.</returns>
+        public bool Equals(VersionOptions other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return EqualityComparer<SemanticVersion>.Default.Equals(this.DefaultVersion, other.DefaultVersion);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether <see cref="DefaultVersion"/> is
+        /// set and the only property on this class that is set.
+        /// </summary>
+        internal bool IsDefaultVersionTheOnlyPropertySet
+        {
+            get { return this.DefaultVersion != null; }
+        }
+    }
+}

--- a/src/NerdBank.GitVersioning/packages.config
+++ b/src/NerdBank.GitVersioning/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="LibGit2Sharp" version="0.21.0.176" targetFramework="net452" />
   <package id="Nerdbank.GitVersioning" version="1.1.2-rc" targetFramework="net452" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Validation" version="2.0.6.15003" targetFramework="net452" />
 </packages>

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -1,0 +1,8 @@
+﻿{
+  "title": "Nerdbank.GitVersioning version.json schema",
+  "type": "object",
+  "required": [ "version" ],
+  "properties": {
+    "version": { "type": "string" }
+  }
+}

--- a/src/Nerdbank.GitVersioning.NuGet/Nerdbank.GitVersioning.NuGet.nuproj
+++ b/src/Nerdbank.GitVersioning.NuGet/Nerdbank.GitVersioning.NuGet.nuproj
@@ -52,7 +52,7 @@
     <Content Include="build\NerdBank.GitVersioning.targets" />
     <Content Include="tools\Get-Version.ps1" />
     <Content Include="tools\Get-CommitId.ps1" />
-    <Content Include="tools\Create-VersionTxt.ps1" />
+    <Content Include="tools\Create-VersionFile.ps1" />
     <Content Include="tools\Install.ps1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
@@ -12,8 +12,6 @@
       GenerateAssemblyInfo;
       $(CoreCompileDependsOn)
     </CoreCompileDependsOn>
-
-    <GitVersioningTxtFile Condition=" '$(GitVersioningTxtFile)' == '' and '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), version.txt))' != '' ">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), version.txt))\version.txt</GitVersioningTxtFile>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="MSBuild.Community.Tasks.dll" TaskName="AssemblyInfo"/>
@@ -21,10 +19,7 @@
   <UsingTask AssemblyFile="$(NerdbankGitVersioningTasksPath)Nerdbank.GitVersioning.Tasks.dll" TaskName="CompareFiles"/>
 
   <Target Name="GetBuildVersion" Returns="$(BuildVersion)">
-    <Error Text="Unable to find version.txt file." Condition=" '$(GitVersioningTxtFile)' == '' " />
-    <GetBuildVersion Condition=" '$(BuildVersion)' == '' "
-                     VersionFile="$(GitVersioningTxtFile)"
-                     GitRepoPath="$(MSBuildProjectDirectory)">
+    <GetBuildVersion>
       <Output TaskParameter="Version" PropertyName="BuildVersion" />
       <Output TaskParameter="SimpleVersion" PropertyName="BuildVersionSimple" />
       <Output TaskParameter="PrereleaseVersion" PropertyName="PrereleaseVersion" Condition=" '$(PrereleaseVersion)' == '' " />

--- a/src/Nerdbank.GitVersioning.NuGet/tools/Create-VersionFile.ps1
+++ b/src/Nerdbank.GitVersioning.NuGet/tools/Create-VersionFile.ps1
@@ -1,15 +1,15 @@
 <#
 .SYNOPSIS
-Generates a version.txt file if one does not exist.
+Generates a version.json file if one does not exist.
 .DESCRIPTION
-When creating version.txt, AssemblyInfo.cs is loaded and the Major.Minor from the AssemblyVersion attribute is
+When creating version.json, AssemblyInfo.cs is loaded and the Major.Minor from the AssemblyVersion attribute is
 used to seed the version number. Then, those Assembly attributes are removed from AssemblyInfo.cs. This cmdlet
 returns the path to the generated file, or null if the file was not created (it already existed, or the cmdlet
 was being executed with -WhatIf).
 .PARAMETER ProjectDirectory
 The directory of the project which is adding versioning logic with Nerdbank.GitVersioning.
 .PARAMETER OutputDirectory
-The directory where version.txt should be generated. Defaults to the project directory if not specified.
+The directory where version.json should be generated. Defaults to the project directory if not specified.
 This should either be the project directory, or in a parent directory of the project inside the repo.
 #>
 [CmdletBinding(SupportsShouldProcess)]
@@ -27,8 +27,9 @@ if (!$OutputDirectory)
 }
 
 $versionTxtPath = Join-Path $OutputDirectory "version.txt"
+$versionJsonPath = Join-Path $OutputDirectory "version.json"
 
-if (-not (Test-Path $versionTxtPath))
+if (-not ((Test-Path $versionTxtPath) -or (Test-Path $versionJsonPath)))
 {
     # The version file doesn't exist, which means this package is being installed for the first time.
     # 1) Load up the AssemblyInfo.cs file and grab the existing version declarations.
@@ -58,21 +59,21 @@ if (-not (Test-Path $versionTxtPath))
 
         if ($version)
         {
-            if ($PSCmdlet.ShouldProcess($versionTxtPath, "Writing version.txt file"))
+            if ($PSCmdlet.ShouldProcess($versionJsonPath, "Writing version.json file"))
             {
-                $version | Set-Content $versionTxtPath
-                $versionTxtPath
+                "{ `"version`": `"$version`" }" | Set-Content $versionJsonPath
+                $versionJsonPath
             }
         }
         else
         {
-            # This is not a warning because the user is probably already consuming version.txt from a parent directory as part of
+            # This is not a warning because the user is probably already consuming version.json from a parent directory as part of
             # a solution- or repo-level versioning scheme.
-            Write-Verbose "Could not find an AssemblyVersion attribute in file '$assemblyInfo'. Skipping version.txt generation."
+            Write-Verbose "Could not find an AssemblyVersion attribute in file '$assemblyInfo'. Skipping version.json generation."
         }
     }
     else
     {
-        Write-Warning "Could not find an AssemblyInfo.cs file at '$assemblyInfo'. Skipping version.txt generation."
+        Write-Warning "Could not find an AssemblyInfo.cs file at '$assemblyInfo'. Skipping version.json generation."
     }
 }

--- a/src/Nerdbank.GitVersioning.NuGet/tools/Install.ps1
+++ b/src/Nerdbank.GitVersioning.NuGet/tools/Install.ps1
@@ -1,11 +1,11 @@
 param($installPath, $toolsPath, $package, $project)
 
 $projectDirectory = Split-Path $project.FileName
-$generatedFile = .(Join-Path $toolsPath Create-VersionTxt.ps1) -ProjectDirectory $projectDirectory
+$generatedFile = .(Join-Path $toolsPath Create-VersionFile.ps1) -ProjectDirectory $projectDirectory
 
 if ($generatedFile)
 {
-    # Add version.txt to the project so it shows up in VS.
+    # Add version.json to the project so it shows up in VS.
     $result = $project.ProjectItems.AddFromFile($generatedFile)
 
     # By default, items get added with ItemType=Content, which could cause version.txt to be included in the build's output.

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -84,7 +84,7 @@
                         VersionFile.GetVersion(commit) ??
                         VersionFile.GetVersion(Environment.CurrentDirectory);
 
-                    this.PrereleaseVersion = v.DefaultVersion.Prerelease;
+                    this.PrereleaseVersion = v.Version.Prerelease;
 
                     var repoRoot = git?.Info?.WorkingDirectory;
                     var relativeRepoProjectDirectory = !string.IsNullOrWhiteSpace(repoRoot)
@@ -92,7 +92,7 @@
                         : null;
 
                     // Override the typedVersion with the special build number and revision components, when available.
-                    typedVersion = commit?.GetIdAsVersion(relativeRepoProjectDirectory) ?? v.DefaultVersion.Version;
+                    typedVersion = commit?.GetIdAsVersion(relativeRepoProjectDirectory) ?? v.Version.Version;
                 }
 
                 typedVersion = typedVersion ?? new Version();

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -84,7 +84,7 @@
                         VersionFile.GetVersion(commit) ??
                         VersionFile.GetVersion(Environment.CurrentDirectory);
 
-                    this.PrereleaseVersion = v.DefaultVersion.UnstableTag;
+                    this.PrereleaseVersion = v.DefaultVersion.Prerelease;
 
                     var repoRoot = git?.Info?.WorkingDirectory;
                     var relativeRepoProjectDirectory = !string.IsNullOrWhiteSpace(repoRoot)

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -69,17 +69,6 @@
         [Output]
         public int BuildNumber { get; private set; }
 
-        /// <summary>
-        /// The file that contains the version base (Major.Minor.Build) to use.
-        /// </summary>
-        [Required]
-        public string VersionFile { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path to the git repo root or some directory beneath it.
-        /// </summary>
-        public string GitRepoPath { get; set; }
-
         public override bool Execute()
         {
             try
@@ -91,19 +80,19 @@
                     this.GitCommitId = commit?.Id.Sha ?? string.Empty;
                     this.GitHeight = commit?.GetHeight() ?? 0;
 
-                    SemanticVersion v =
-                        GitVersioning.VersionFile.GetVersion(commit) ??
-                        GitVersioning.VersionFile.GetVersion(this.GitRepoPath);
+                    VersionOptions v =
+                        VersionFile.GetVersion(commit) ??
+                        VersionFile.GetVersion(Environment.CurrentDirectory);
 
-                    this.PrereleaseVersion = v.UnstableTag;
+                    this.PrereleaseVersion = v.DefaultVersion.UnstableTag;
 
                     var repoRoot = git?.Info?.WorkingDirectory;
-                    var relativeRepoProjectDirectory = !string.IsNullOrWhiteSpace(repoRoot) && GitRepoPath.StartsWith(repoRoot, StringComparison.OrdinalIgnoreCase)
-                        ? GitRepoPath.Substring(repoRoot.Length)
+                    var relativeRepoProjectDirectory = !string.IsNullOrWhiteSpace(repoRoot)
+                        ? Environment.CurrentDirectory.Substring(repoRoot.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
                         : null;
 
                     // Override the typedVersion with the special build number and revision components, when available.
-                    typedVersion = commit?.GetIdAsVersion(relativeRepoProjectDirectory) ?? v.Version;
+                    typedVersion = commit?.GetIdAsVersion(relativeRepoProjectDirectory) ?? v.DefaultVersion.Version;
                 }
 
                 typedVersion = typedVersion ?? new Version();
@@ -126,12 +115,7 @@
 
         private LibGit2Sharp.Repository OpenGitRepo()
         {
-            if (string.IsNullOrEmpty(this.GitRepoPath))
-            {
-                return null;
-            }
-
-            string repoRoot = this.GitRepoPath;
+            string repoRoot = Environment.CurrentDirectory;
             while (!Directory.Exists(Path.Combine(repoRoot, ".git")))
             {
                 repoRoot = Path.GetDirectoryName(repoRoot);


### PR DESCRIPTION
Add support for a version.json file, such that we can add more interesting properties to it later and keep the file format human-manageable. 

Fix #19
Fix #20