### PR TITLE
Support automatically building as if PublicRelease=true

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -257,7 +257,7 @@ public class BuildIntegrationTests : RepoTestBase
         var versionOptions = new VersionOptions
         {
             Version = SemanticVersion.Parse("1.0"),
-            PublicReleaseRefSpec = "^refs/heads/release$",
+            PublicReleaseRefSpec = new string[] { "^refs/heads/release$" },
         };
         this.WriteVersionFile(versionOptions);
         this.InitializeSourceControl();
@@ -299,7 +299,7 @@ public class BuildIntegrationTests : RepoTestBase
         var versionOptions = new VersionOptions
         {
             Version = SemanticVersion.Parse("1.0"),
-            PublicReleaseRefSpec = "^refs/heads/release$",
+            PublicReleaseRefSpec = new string[] { "^refs/heads/release$" },
         };
         this.WriteVersionFile(versionOptions);
         this.InitializeSourceControl();
@@ -323,7 +323,7 @@ public class BuildIntegrationTests : RepoTestBase
         var versionOptions = new VersionOptions
         {
             Version = SemanticVersion.Parse("1.0"),
-            PublicReleaseRefSpec = "^refs/heads/release$",
+            PublicReleaseRefSpec = new string[] { "^refs/heads/release$" },
         };
         this.WriteVersionFile(versionOptions);
         this.InitializeSourceControl();

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -84,8 +84,9 @@
     <Compile Include="VersionOptionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\Nerdbank.GitVersioning.NuGet\build\NerdBank.GitVersioning.targets">
-      <Link>NerdBank.GitVersioning.targets</Link>
+    <EmbeddedResource Include="..\Nerdbank.GitVersioning.NuGet\build\*.targets">
+      <Visible>false</Visible>
+      <Link>Targets\%(FileName)%(Extension)</Link>
     </EmbeddedResource>
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -38,11 +38,11 @@
         public int BuildNumberOffset { get; set; }
 
         /// <summary>
-        /// Gets or sets a regular expression that describes branch or tag names that should
+        /// Gets or sets an array of regular expressions that describes branch or tag names that should
         /// be built with PublicRelease=true as the default value on build servers.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string PublicReleaseRefSpec { get; set; }
+        public string[] PublicReleaseRefSpec { get; set; }
 
         /// <summary>
         /// Gets the debugger display for this instance.

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -38,6 +38,13 @@
         public int BuildNumberOffset { get; set; }
 
         /// <summary>
+        /// Gets or sets a regular expression that describes branch or tag names that should
+        /// be built with PublicRelease=true as the default value on build servers.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string PublicReleaseRefSpec { get; set; }
+
+        /// <summary>
         /// Gets the debugger display for this instance.
         /// </summary>
         private string DebuggerDisplay => this.Version?.ToString();

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -17,6 +17,11 @@
       "type": "integer",
       "description": "A number to add to the git height when calculating the build number.",
       "default": 0
+    },
+    "publicReleaseRefSpec": {
+      "type": "string",
+      "description": "A regular expression that may match a ref (branch or tag) that should be built with PublicRelease=true as the default value. The ref matched against is in its canonical form (e.g. refs/heads/master)",
+      "format": "regex"
     }
   }
 }

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -19,9 +19,13 @@
       "default": 0
     },
     "publicReleaseRefSpec": {
-      "type": "string",
-      "description": "A regular expression that may match a ref (branch or tag) that should be built with PublicRelease=true as the default value. The ref matched against is in its canonical form (e.g. refs/heads/master)",
-      "format": "regex"
+      "type": "array",
+      "description": "An array of regular expressions that may match a ref (branch or tag) that should be built with PublicRelease=true as the default value. The ref matched against is in its canonical form (e.g. refs/heads/master)",
+      "items": {
+        "type": "string",
+        "format": "regex"
+      },
+      "uniqueItems": true
     }
   }
 }

--- a/src/Nerdbank.GitVersioning.NuGet/Nerdbank.GitVersioning.NuGet.nuproj
+++ b/src/Nerdbank.GitVersioning.NuGet/Nerdbank.GitVersioning.NuGet.nuproj
@@ -52,7 +52,9 @@
     <Content Include="..\NerdBank.GitVersioning\version.schema.json">
       <Link>tools\version.schema.json</Link>
     </Content>
+    <Content Include="build\VisualStudioTeamServices.targets" />
     <Content Include="build\dotnet\Nerdbank.GitVersioning.targets" />
+    <Content Include="build\AppVeyor.targets" />
     <Content Include="build\NerdBank.GitVersioning.targets" />
     <Content Include="build\portable-net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS\Nerdbank.GitVersioning.targets" />
     <Content Include="tools\Get-Version.ps1" />

--- a/src/Nerdbank.GitVersioning.NuGet/build/AppVeyor.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/AppVeyor.targets
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <!--
+         The AppVeyor-specific properties referenced here are documented here:
+         http://www.appveyor.com/docs/environment-variables 
+    -->
+    <_NBGV_BuildServerSoftware>AppVeyor</_NBGV_BuildServerSoftware>
+    <_NBGV_IsPullRequest Condition=" '$(APPVEYOR_PULL_REQUEST_NUMBER)' != '' ">true</_NBGV_IsPullRequest>
+    <_NBGV_BuildingTag Condition=" '$(APPVEYOR_REPO_TAG)' == 'true' ">refs/tags/$(APPVEYOR_REPO_TAG_NAME)</_NBGV_BuildingTag>
+
+    <!-- AppVeyor's branch variable is the target branch of a PR, which is *NOT* to be misinterpreted 
+         as building the target branch itself. So only set the branch built property if it's not a PR. -->
+    <_NBGV_BuildingBranch Condition=" '$(_NBGV_IsPullRequest)' != 'true' and '$(APPVEYOR_REPO_BRANCH)' != '' ">refs/heads/$(APPVEYOR_REPO_BRANCH)</_NBGV_BuildingBranch>
+  </PropertyGroup>
+</Project>

--- a/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
@@ -18,8 +18,16 @@
   <UsingTask AssemblyFile="$(NerdbankGitVersioningTasksPath)Nerdbank.GitVersioning.Tasks.dll" TaskName="GetBuildVersion"/>
   <UsingTask AssemblyFile="$(NerdbankGitVersioningTasksPath)Nerdbank.GitVersioning.Tasks.dll" TaskName="CompareFiles"/>
 
+  <Import Project="VisualStudioTeamServices.targets"  Condition=" '$(SYSTEM_TEAMPROJECTID)' != '' "/>
+  <Import Project="AppVeyor.targets"                  Condition=" '$(APPVEYOR)' == 'True' "/>
+  <PropertyGroup>
+    <!-- Consider building a tag to be more precise than the branch we're building. -->
+    <_NBGV_BuildingRef>$(_NBGV_BuildingTag)</_NBGV_BuildingRef>
+    <_NBGV_BuildingRef Condition=" '$(_NBGV_BuildingRef)' == '' ">$(_NBGV_BuildingBranch)</_NBGV_BuildingRef>
+  </PropertyGroup>
+
   <Target Name="GetBuildVersion" Returns="$(BuildVersion)">
-    <GetBuildVersion>
+    <GetBuildVersion BuildingRef="$(_NBGV_BuildingRef)">
       <Output TaskParameter="Version" PropertyName="BuildVersion" />
       <Output TaskParameter="SimpleVersion" PropertyName="BuildVersionSimple" />
       <Output TaskParameter="PrereleaseVersion" PropertyName="PrereleaseVersion" Condition=" '$(PrereleaseVersion)' == '' " />
@@ -28,8 +36,11 @@
       <Output TaskParameter="GitCommitId" PropertyName="GitCommitId" />
       <Output TaskParameter="GitVersionHeight" PropertyName="GitVersionHeight" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildVersionNumberComponent" />
+      <Output TaskParameter="PublicReleaseDefault" PropertyName="PublicReleaseDefault" />
     </GetBuildVersion>
     <PropertyGroup>
+      <PublicRelease Condition=" '$(PublicRelease)' == '' ">$(PublicReleaseDefault)</PublicRelease>
+
       <BuildNumber>$(BuildVersionNumberComponent)</BuildNumber>
       <BuildNumberFirstComponent>$([System.Text.RegularExpressions.Regex]::Match($(BuildNumber), '(\d+)').Groups[1].Value)</BuildNumberFirstComponent>
       <BuildNumberSecondComponent>$([System.Text.RegularExpressions.Regex]::Match($(BuildNumber), '(\d+)\.(\d+)').Groups[2].Value)</BuildNumberSecondComponent>
@@ -84,7 +95,7 @@
   </Target>
 
   <!-- Support for pattern found in users of Tvl.NuGet.BuildTasks. -->
-  <Target Name="SupplyNuGetManifestVersion" 
+  <Target Name="SupplyNuGetManifestVersion"
           DependsOnTargets="GetBuildVersion"
           BeforeTargets="EnsureNuGetManifestMetadata">
     <ItemGroup>

--- a/src/Nerdbank.GitVersioning.NuGet/build/VisualStudioTeamServices.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/VisualStudioTeamServices.targets
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <!--
+         The VSTS-specific properties referenced here are documented here:
+         https://msdn.microsoft.com/en-us/Library/vs/alm/Build/scripts/variables
+    -->
+    <_NBGV_BuildServerSoftware>VisualStudioTeamServices</_NBGV_BuildServerSoftware>
+    <_NBGV_BuildingBranch>$(BUILD_SOURCEBRANCH)</_NBGV_BuildingBranch>
+    <_NBGV_BuildingRef>$(_NBGV_BuildingBranch)</_NBGV_BuildingRef>
+
+    <!-- VSTS doesn't define variables for tags and PRs -->
+    <!--<_NBGV_BuildingTag Condition=" '$()' == 'true' ">$()</_NBGV_BuildingTag>-->
+    <!--<_NBGV_IsPullRequest Condition=" '$()' != '' "></_NBGV_IsPullRequest>-->
+  </PropertyGroup>
+</Project>

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -114,9 +114,10 @@
                         VersionFile.GetVersion(git, Environment.CurrentDirectory) ??
                         VersionFile.GetVersion(Environment.CurrentDirectory);
 
-                    if (!string.IsNullOrEmpty(this.BuildingRef) && !string.IsNullOrEmpty(versionOptions?.PublicReleaseRefSpec))
+                    if (!string.IsNullOrEmpty(this.BuildingRef) && versionOptions?.PublicReleaseRefSpec?.Length > 0)
                     {
-                        this.PublicReleaseDefault = Regex.IsMatch(this.BuildingRef, versionOptions.PublicReleaseRefSpec);
+                        this.PublicReleaseDefault = versionOptions.PublicReleaseRefSpec.Any(
+                            expr => Regex.IsMatch(this.BuildingRef, expr));
                     }
 
                     this.PrereleaseVersion = versionOptions?.Version.Prerelease ?? string.Empty;

--- a/version.json
+++ b/version.json
@@ -1,1 +1,5 @@
-{ "version": "1.1" }
+{
+  "$schema": "src\\NerdBank.GitVersioning\\version.schema.json",
+  "version": "1.1",
+  "publicReleaseRefSpec": "^refs/heads/master$" // we release out of master
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,7 @@
 {
   "$schema": "src\\NerdBank.GitVersioning\\version.schema.json",
   "version": "1.1",
-  "publicReleaseRefSpec": "^refs/heads/master$" // we release out of master
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$" // we release out of master
+  ]
 }


### PR DESCRIPTION
The version.json file can now specify regex patterns that if the ref being built matches will cause PublicRelease to default to true instead of false.

This comes with specialized support for a couple of build server platforms (VSTS and AppVeyor). But it works with pure git as well, both locally on dev boxes and on these and other build servers.

Fix #38