### PR TITLE
Add support for AssemblyTitle/AssemblyProduct/etc. to AssemblyInfo task

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -359,19 +359,32 @@ public class BuildIntegrationTests : RepoTestBase
 
         var assemblyFileVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
         var assemblyInformationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        var assemblyTitle = assembly.GetCustomAttribute<AssemblyTitleAttribute>();
+        var assemblyProduct = assembly.GetCustomAttribute<AssemblyProductAttribute>();
+        var assemblyCompany = assembly.GetCustomAttribute<AssemblyCompanyAttribute>();
+        var assemblyCopyright = assembly.GetCustomAttribute<AssemblyCopyrightAttribute>();
         var thisAssemblyClass = assembly.GetType("ThisAssembly") ?? assembly.GetType("TestNamespace.ThisAssembly");
         Assert.NotNull(thisAssemblyClass);
 
         Assert.Equal(new Version(result.AssemblyVersion), assembly.GetName().Version);
         Assert.Equal(result.AssemblyFileVersion, assemblyFileVersion.Version);
         Assert.Equal(result.AssemblyInformationalVersion, assemblyInformationalVersion.InformationalVersion);
+        Assert.Equal(result.AssemblyTitle, assemblyTitle.Title);
+        Assert.Equal(result.AssemblyProduct, assemblyProduct.Product);
+        Assert.Equal(result.AssemblyCompany, assemblyCompany.Company);
+        Assert.Equal(result.AssemblyCopyright, assemblyCopyright.Copyright);
 
         const BindingFlags fieldFlags = BindingFlags.Static | BindingFlags.NonPublic;
         Assert.Equal(result.AssemblyVersion, thisAssemblyClass.GetField("AssemblyVersion", fieldFlags).GetValue(null));
         Assert.Equal(result.AssemblyFileVersion, thisAssemblyClass.GetField("AssemblyFileVersion", fieldFlags).GetValue(null));
         Assert.Equal(result.AssemblyInformationalVersion, thisAssemblyClass.GetField("AssemblyInformationalVersion", fieldFlags).GetValue(null));
-        Assert.Equal(result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("AssemblyName"), thisAssemblyClass.GetField("AssemblyName", fieldFlags).GetValue(null));
-        Assert.Equal(result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("RootNamespace"), thisAssemblyClass.GetField("RootNamespace", fieldFlags).GetValue(null));
+        Assert.Equal(result.AssemblyName, thisAssemblyClass.GetField("AssemblyName", fieldFlags).GetValue(null));
+        Assert.Equal(result.RootNamespace, thisAssemblyClass.GetField("RootNamespace", fieldFlags).GetValue(null));
+        Assert.Equal(result.AssemblyTitle, thisAssemblyClass.GetField("AssemblyTitle", fieldFlags).GetValue(null));
+        Assert.Equal(result.AssemblyProduct, thisAssemblyClass.GetField("AssemblyProduct", fieldFlags).GetValue(null));
+        Assert.Equal(result.AssemblyCompany, thisAssemblyClass.GetField("AssemblyCompany", fieldFlags).GetValue(null));
+        Assert.Equal(result.AssemblyCopyright, thisAssemblyClass.GetField("AssemblyCopyright", fieldFlags).GetValue(null));
+        Assert.Equal(result.AssemblyConfiguration, thisAssemblyClass.GetField("AssemblyConfiguration", fieldFlags).GetValue(null));
 
         // Verify that it doesn't have key fields
         Assert.Null(thisAssemblyClass.GetField("PublicKey", fieldFlags));
@@ -493,6 +506,11 @@ public class BuildIntegrationTests : RepoTestBase
 
         pre.AddProperty("RootNamespace", "TestNamespace");
         pre.AddProperty("AssemblyName", "TestAssembly");
+        pre.AddProperty("AssemblyTitle", "TestAssembly");
+        pre.AddProperty("AssemblyProduct", "TestProduct");
+        pre.AddProperty("AssemblyCompany", "TestCompany");
+        pre.AddProperty("AssemblyCopyright", "TestCopyright");
+        pre.AddProperty("AssemblyConfiguration", "TestConfiguration");
         pre.AddProperty("TargetFrameworkVersion", "v4.5");
         pre.AddProperty("OutputType", "Library");
         pre.AddProperty("OutputPath", @"bin\");
@@ -547,6 +565,13 @@ public class BuildIntegrationTests : RepoTestBase
         public string AssemblyFileVersion => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("AssemblyFileVersion");
         public string AssemblyVersion => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("AssemblyVersion");
         public string NuGetPackageVersion => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("NuGetPackageVersion");
+        public string AssemblyName => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("AssemblyName");
+        public string AssemblyTitle => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("AssemblyTitle");
+        public string AssemblyProduct => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("AssemblyProduct");
+        public string AssemblyCompany => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("AssemblyCompany");
+        public string AssemblyCopyright => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("AssemblyCopyright");
+        public string AssemblyConfiguration => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("Configuration");
+        public string RootNamespace => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("RootNamespace");
 
         public override string ToString()
         {

--- a/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
@@ -84,7 +84,12 @@
                   AssemblyInformationalVersion="$(AssemblyInformationalVersion)"
                   AssemblyName="$(AssemblyName)"
                   RootNamespace="$(RootNamespace)"
-                  AssemblyOriginatorKeyFile="$(AssemblyOriginatorKeyFile)" />
+                  AssemblyOriginatorKeyFile="$(AssemblyOriginatorKeyFile)"
+                  AssemblyTitle="$(AssemblyTitle)"
+                  AssemblyProduct="$(AssemblyProduct)"
+                  AssemblyCopyright="$(AssemblyCopyright)"
+                  AssemblyCompany="$(AssemblyCompany)"
+                  AssemblyConfiguration="$(Configuration)"/>
     <!-- Avoid applying the newly generated AssemblyInfo.cs file to the build 
          unless it has changed in order to allow for incremental building. -->
     <CompareFiles OriginalItems="$(VersionSourceFile)" NewItems="$(NewVersionSourceFile)">

--- a/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
@@ -14,7 +14,7 @@
     </CoreCompileDependsOn>
   </PropertyGroup>
 
-  <UsingTask AssemblyFile="$(NerdbankGitVersioningTasksPath)Nerdbank.GitVersioning.Tasks.dll" TaskName="AssemblyInfo"/>
+  <UsingTask AssemblyFile="$(NerdbankGitVersioningTasksPath)Nerdbank.GitVersioning.Tasks.dll" TaskName="AssemblyVersionInfo"/>
   <UsingTask AssemblyFile="$(NerdbankGitVersioningTasksPath)Nerdbank.GitVersioning.Tasks.dll" TaskName="GetBuildVersion"/>
   <UsingTask AssemblyFile="$(NerdbankGitVersioningTasksPath)Nerdbank.GitVersioning.Tasks.dll" TaskName="CompareFiles"/>
 
@@ -78,7 +78,7 @@
       <UltimateResourceFallbackLocation Condition=" '$(DevDivProjectSubType)' != 'portable' ">UltimateResourceFallbackLocation.MainAssembly</UltimateResourceFallbackLocation>
     </PropertyGroup>
     <MakeDir Directories="$(IntermediatePath)"/>
-    <AssemblyInfo OutputFile="$(NewVersionSourceFile)" CodeLanguage="$(Language)"
+    <AssemblyVersionInfo OutputFile="$(NewVersionSourceFile)" CodeLanguage="$(Language)"
                   AssemblyVersion="$(AssemblyVersion)"
                   AssemblyFileVersion="$(AssemblyFileVersion)"
                   AssemblyInformationalVersion="$(AssemblyInformationalVersion)"

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyInfo.cs
@@ -13,7 +13,7 @@
     using Microsoft.Build.Utilities;
     using PInvoke;
 
-    public class AssemblyInfo : Task
+    public class AssemblyVersionInfo : Task
     {
         private static readonly CodeGeneratorOptions codeGeneratorOptions = new CodeGeneratorOptions
         {

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyInfo.cs
@@ -43,6 +43,16 @@
 
         public string AssemblyKeyContainerName { get; set; }
 
+        public string AssemblyTitle { get; set; }
+
+        public string AssemblyProduct { get; set; }
+
+        public string AssemblyCopyright { get; set; }
+
+        public string AssemblyCompany { get; set; }
+
+        public string AssemblyConfiguration { get; set; }
+
         public override bool Execute()
         {
             using (var codeDomProvider = CodeDomProvider.CreateProvider(this.CodeLanguage))
@@ -89,6 +99,11 @@
                 { "AssemblyName", this.AssemblyName },
                 { "PublicKey", publicKey },
                 { "PublicKeyToken", publicKeyToken },
+                { "AssemblyTitle", this.AssemblyTitle },
+                { "AssemblyProduct", this.AssemblyProduct },
+                { "AssemblyCopyright", this.AssemblyCopyright },
+                { "AssemblyCompany", this.AssemblyCompany },
+                { "AssemblyConfiguration", this.AssemblyConfiguration }
             }).ToArray());
 
             // These properties should be defined even if they are empty.
@@ -136,6 +151,14 @@
             yield return DeclareAttribute(typeof(AssemblyVersionAttribute), this.AssemblyVersion);
             yield return DeclareAttribute(typeof(AssemblyFileVersionAttribute), this.AssemblyFileVersion);
             yield return DeclareAttribute(typeof(AssemblyInformationalVersionAttribute), this.AssemblyInformationalVersion);
+            if (!string.IsNullOrEmpty(this.AssemblyTitle))
+                yield return DeclareAttribute(typeof(AssemblyTitleAttribute), this.AssemblyTitle);
+            if (!string.IsNullOrEmpty(this.AssemblyProduct))
+                yield return DeclareAttribute(typeof(AssemblyProductAttribute), this.AssemblyProduct);
+            if (!string.IsNullOrEmpty(this.AssemblyCompany))
+                yield return DeclareAttribute(typeof(AssemblyCompanyAttribute), this.AssemblyCompany);
+            if (!string.IsNullOrEmpty(this.AssemblyCopyright))
+                yield return DeclareAttribute(typeof(AssemblyCopyrightAttribute), this.AssemblyCopyright);
         }
 
         private static IEnumerable<CodeMemberField> CreateFields(IReadOnlyDictionary<string, string> namesAndValues)


### PR DESCRIPTION
In previous versions the AssemblyInfo task was taken from https://github.com/loresoft/msbuildtasks and I kinda misused it to also set ```AssemblyTitle```, ```AssemblyProduct```, ```AssemblyCompany``` and ```AssemblyCopyright``` attributes. I was also using the ```ThisAssembly.AssemblyConfiguration``` constant, which I'm missing now in the latest release (1.2.8).

This PR adds all those fields and should hopefully not break anything.