### PR TITLE
Support applying git versioning policy to cloud-based "build number"

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -670,9 +670,8 @@ public class BuildIntegrationTests : RepoTestBase
         string commitIdShort = this.Repo.Head.Commits.First().Id.Sha.Substring(0, 10);
         Version version = this.Repo.GetIdAsVersion(relativeProjectDirectory);
         Version assemblyVersion = GetExpectedAssemblyVersion(versionOptions, version);
-        var additionalBuildMetadata = from item in this.testProject.Items
-                                      where string.Equals(item.ItemType, "BuildMetadata", StringComparison.OrdinalIgnoreCase)
-                                      select item.Include;
+        var additionalBuildMetadata = from item in buildResult.BuildResult.ProjectStateAfterBuild.GetItems("BuildMetadata")
+                                      select item.EvaluatedInclude;
         var expectedBuildMetadata = $"+g{commitIdShort}";
         if (additionalBuildMetadata.Any())
         {

--- a/src/NerdBank.GitVersioning.Tests/SemanticVersionTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/SemanticVersionTests.cs
@@ -45,14 +45,57 @@ public class SemanticVersionTests
     public void TryParse()
     {
         SemanticVersion result;
-        Assert.True(SemanticVersion.TryParse("1.2-pre+build", out result));
+        Assert.True(SemanticVersion.TryParse("1.2-pre.5.8-foo+build-metadata.id1.2", out result));
         Assert.Equal(1, result.Version.Major);
         Assert.Equal(2, result.Version.Minor);
+        Assert.Equal("-pre.5.8-foo", result.Prerelease);
+        Assert.Equal("+build-metadata.id1.2", result.BuildMetadata);
+
+    }
+
+    [Fact]
+    public void PrereleaseIdentifiers_InvalidCases()
+    {
+        SemanticVersion result;
+        Assert.False(SemanticVersion.TryParse("1.2-$", out result));
+        Assert.False(SemanticVersion.TryParse("1.2-", out result));
+        Assert.False(SemanticVersion.TryParse("1.2-a.", out result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void BuildMetadata_InvalidCases()
+    {
+        SemanticVersion result;
+        Assert.False(SemanticVersion.TryParse("1.2+$", out result));
+        Assert.False(SemanticVersion.TryParse("1.2+", out result));
+        Assert.False(SemanticVersion.TryParse("1.2+a.", out result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryParse_WithPatch()
+    {
+        SemanticVersion result;
+        Assert.True(SemanticVersion.TryParse("1.2.3-pre+build", out result));
+        Assert.Equal(1, result.Version.Major);
+        Assert.Equal(2, result.Version.Minor);
+        Assert.Equal(3, result.Version.Build);
         Assert.Equal("-pre", result.Prerelease);
         Assert.Equal("+build", result.BuildMetadata);
+    }
 
-        Assert.False(SemanticVersion.TryParse("1.2-$", out result));
-        Assert.Null(result);
+    [Fact]
+    public void TryParse_WithRevision()
+    {
+        SemanticVersion result;
+        Assert.True(SemanticVersion.TryParse("1.2.3.4-pre+build", out result));
+        Assert.Equal(1, result.Version.Major);
+        Assert.Equal(2, result.Version.Minor);
+        Assert.Equal(3, result.Version.Build);
+        Assert.Equal(4, result.Version.Revision);
+        Assert.Equal("-pre", result.Prerelease);
+        Assert.Equal("+build", result.BuildMetadata);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -134,6 +134,22 @@ public class VersionFileTests : RepoTestBase
         Assert.Equal(expectedJson, normalizedFileContent);
     }
 
+    [Theory]
+    [InlineData(@"{""cloudBuild"":{""setVersionVariables"":true}}", @"{}")]
+    public void JsonMinification(string full, string minimal)
+    {
+        var settings = VersionOptions.JsonSettings;
+        settings.Formatting = Formatting.None;
+
+        // Assert that the two representations are equivalent.
+        var fullVersion = JsonConvert.DeserializeObject<VersionOptions>(full, settings);
+        var minimalVersion = JsonConvert.DeserializeObject<VersionOptions>(minimal, settings);
+        Assert.Equal(fullVersion, minimalVersion);
+
+        string fullVersionSerialized = JsonConvert.SerializeObject(fullVersion, settings);
+        Assert.Equal(minimal, fullVersionSerialized);
+    }
+
     [Fact]
     public void GetVersion_CanReadSpecConformantJsonFile()
     {

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -135,6 +135,10 @@ public class VersionFileTests : RepoTestBase
     }
 
     [Theory]
+    [InlineData(@"{""cloudBuild"":{""buildNumber"":{""enabled"":false,""includeCommitId"":{""when"":""nonPublicReleaseOnly"",""where"":""buildMetadata""}}}}", @"{}")]
+    [InlineData(@"{""cloudBuild"":{""buildNumber"":{""enabled"":true,""includeCommitId"":{""when"":""nonPublicReleaseOnly"",""where"":""buildMetadata""}}}}", @"{""cloudBuild"":{""buildNumber"":{""enabled"":true}}}")]
+    [InlineData(@"{""cloudBuild"":{""buildNumber"":{""enabled"":true,""includeCommitId"":{""when"":""always"",""where"":""buildMetadata""}}}}", @"{""cloudBuild"":{""buildNumber"":{""enabled"":true,""includeCommitId"":{""when"":""always""}}}}")]
+    [InlineData(@"{""cloudBuild"":{""buildNumber"":{""enabled"":true,""includeCommitId"":{""when"":""nonPublicReleaseOnly"",""where"":""fourthVersionComponent""}}}}", @"{""cloudBuild"":{""buildNumber"":{""enabled"":true,""includeCommitId"":{""where"":""fourthVersionComponent""}}}}")]
     [InlineData(@"{""cloudBuild"":{""setVersionVariables"":true}}", @"{}")]
     public void JsonMinification(string full, string minimal)
     {

--- a/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
@@ -103,5 +103,66 @@ public class VersionOptionsTests
             SetVersionVariables = !cbo1a.SetVersionVariables,
         };
         Assert.NotEqual(cbo2a, cbo1a);
+
+        var cbo3a = new VersionOptions.CloudBuildOptions
+        {
+            BuildNumber = new VersionOptions.CloudBuildNumberOptions { },
+        };
+        Assert.Equal(cbo3a, cbo1a); // Equal because we haven't changed defaults.
+
+        var cbo4a = new VersionOptions.CloudBuildOptions
+        {
+            BuildNumber = new VersionOptions.CloudBuildNumberOptions
+            {
+                Enabled = !(new VersionOptions.CloudBuildNumberOptions().Enabled),
+            },
+        };
+        Assert.NotEqual(cbo4a, cbo1a);
+    }
+
+    [Fact]
+    public void CloudBuildNumberOptions_Equality()
+    {
+        var bno1a = new VersionOptions.CloudBuildNumberOptions { };
+        var bno1b = new VersionOptions.CloudBuildNumberOptions { };
+        Assert.Equal(bno1a, bno1b);
+
+        var bno2a = new VersionOptions.CloudBuildNumberOptions
+        {
+            Enabled = !bno1a.Enabled,
+        };
+        Assert.NotEqual(bno1a, bno2a);
+
+        var bno3a = new VersionOptions.CloudBuildNumberOptions
+        {
+            IncludeCommitId = new VersionOptions.CloudBuildNumberCommitIdOptions { },
+        };
+        Assert.Equal(bno1a, bno3a); // we haven't changed any defaults, even if it's non-null.
+
+        var bno4a = new VersionOptions.CloudBuildNumberOptions
+        {
+            IncludeCommitId = new VersionOptions.CloudBuildNumberCommitIdOptions { When = VersionOptions.CloudBuildNumberCommitWhen.Never },
+        };
+        Assert.NotEqual(bno1a, bno4a);
+    }
+
+    [Fact]
+    public void CloudBuildNumberCommitIdOptions_Equality()
+    {
+        var cio1a = new VersionOptions.CloudBuildNumberCommitIdOptions { };
+        var cio1b = new VersionOptions.CloudBuildNumberCommitIdOptions { };
+        Assert.Equal(cio1a, cio1b);
+
+        var cio2a = new VersionOptions.CloudBuildNumberCommitIdOptions
+        {
+            When = (VersionOptions.CloudBuildNumberCommitWhen)((int)cio1a.When + 1),
+        };
+        Assert.NotEqual(cio1a, cio2a);
+
+        var cio3a = new VersionOptions.CloudBuildNumberCommitIdOptions
+        {
+            Where = (VersionOptions.CloudBuildNumberCommitWhere)((int)cio1a.Where + 1),
+        };
+        Assert.NotEqual(cio1a, cio3a);
     }
 }

--- a/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
@@ -90,4 +90,18 @@ public class VersionOptionsTests
         };
         Assert.NotEqual(avo4, avo5);
     }
+
+    [Fact]
+    public void CloudBuildOptions_Equality()
+    {
+        var cbo1a = new VersionOptions.CloudBuildOptions { };
+        var cbo1b = new VersionOptions.CloudBuildOptions { };
+        Assert.Equal(cbo1a, cbo1b);
+
+        var cbo2a = new VersionOptions.CloudBuildOptions
+        {
+            SetVersionVariables = !cbo1a.SetVersionVariables,
+        };
+        Assert.NotEqual(cbo2a, cbo1a);
+    }
 }

--- a/src/NerdBank.GitVersioning.Tests/project.json
+++ b/src/NerdBank.GitVersioning.Tests/project.json
@@ -4,8 +4,10 @@
     "Microsoft.CodeAnalysis.CSharp": "1.1.1",
     "Nerdbank.GitVersioning": "1.4.6",
     "Newtonsoft.Json": "7.0.1",
+    "System.Collections.Immutable": "1.1.37",
     "Validation": "2.0.6.15003",
     "xunit": "2.1.0",
+    "Xunit.Combinatorial": "1.1.12",
     "xunit.runner.visualstudio": "2.1.0"
   },
   "frameworks": {

--- a/src/NerdBank.GitVersioning/SemanticVersion.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersion.cs
@@ -13,12 +13,12 @@
     {
         /// <summary>
         /// The regular expression with capture groups for semantic versioning.
-        /// It considers PATCH to be optional.
+        /// It considers PATCH to be optional and permits the 4th Revision component.
         /// </summary>
         /// <remarks>
         /// Parts of this regex inspired by https://github.com/sindresorhus/semver-regex/blob/master/index.js
         /// </remarks>
-        private static readonly Regex FullSemVerPattern = new Regex(@"^v?(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*))?(?<prerelease>-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?<buildMetadata>\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$", RegexOptions.IgnoreCase);
+        private static readonly Regex FullSemVerPattern = new Regex(@"^v?(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*)(?:\.(?<revision>0|[1-9][0-9]*))?)?(?<prerelease>-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?<buildMetadata>\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// The regex pattern that a prerelease must match.
@@ -96,7 +96,10 @@
                 var major = int.Parse(m.Groups["major"].Value);
                 var minor = int.Parse(m.Groups["minor"].Value);
                 var patch = m.Groups["patch"].Value;
-                var systemVersion = patch.Length > 0 ? new Version(major, minor, int.Parse(patch)) : new Version(major, minor);
+                var revision = m.Groups["revision"].Value;
+                var systemVersion = patch.Length > 0
+                    ? revision.Length > 0 ? new Version(major, minor, int.Parse(patch), int.Parse(revision)) : new Version(major, minor, int.Parse(patch))
+                    : new Version(major, minor);
                 var prerelease = m.Groups["prerelease"].Value;
                 var buildMetadata = m.Groups["buildMetadata"].Value;
                 version = new SemanticVersion(systemVersion, prerelease, buildMetadata);

--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -29,21 +29,6 @@
         public static readonly IReadOnlyList<string> PreferredFileNames = new[] { JsonFileName, TxtFileName };
 
         /// <summary>
-        /// The JSON serializer settings to use.
-        /// </summary>
-        private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings()
-        {
-            Converters = new JsonConverter[] {
-                new VersionConverter(),
-                new SemanticVersionJsonConverter(),
-                new AssemblyVersionOptionsConverter(),
-                new StringEnumConverter() { CamelCaseText = true },
-            },
-            ContractResolver = new VersionOptionsContractResolver(),
-            Formatting = Formatting.Indented,
-        };
-
-        /// <summary>
         /// Reads the version.txt file and returns the <see cref="Version"/> and prerelease tag from it.
         /// </summary>
         /// <param name="commit">The commit to read the version file from.</param>
@@ -191,7 +176,7 @@
             }
 
             string versionJsonPath = Path.Combine(projectDirectory, JsonFileName);
-            var jsonContent = JsonConvert.SerializeObject(version, JsonSettings);
+            var jsonContent = JsonConvert.SerializeObject(version, VersionOptions.JsonSettings);
             File.WriteAllText(versionJsonPath, jsonContent);
             return versionJsonPath;
         }
@@ -260,7 +245,7 @@
                 string jsonContent = versionTextContent.ReadToEnd();
                 try
                 {
-                    return JsonConvert.DeserializeObject<VersionOptions>(jsonContent, JsonSettings);
+                    return JsonConvert.DeserializeObject<VersionOptions>(jsonContent, VersionOptions.JsonSettings);
                 }
                 catch (JsonSerializationException)
                 {

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -225,6 +225,11 @@
             /// </summary>
             public bool SetVersionVariables { get; set; } = true;
 
+            /// <summary>
+            /// Override the build number preset by the cloud build with one enriched with version information.
+            /// </summary>
+            public CloudBuildNumberOptions BuildNumber { get; set; }
+
             internal bool ShouldSerializeSetVersionVariables() => this.SetVersionVariables != DefaultInstance.SetVersionVariables;
 
             /// <inheritdoc />
@@ -234,13 +239,122 @@
             public bool Equals(CloudBuildOptions other)
             {
                 return other != null
-                    && this.SetVersionVariables == other.SetVersionVariables;
+                    && this.SetVersionVariables == other.SetVersionVariables
+                    && EqualityComparer<CloudBuildNumberOptions>.Default.Equals(this.BuildNumber ?? CloudBuildNumberOptions.DefaultInstance, other.BuildNumber ?? CloudBuildNumberOptions.DefaultInstance);
             }
 
             /// <inheritdoc />
             public override int GetHashCode()
             {
-                return this.SetVersionVariables ? 1 : 0;
+                return this.SetVersionVariables ? 1 : 0
+                    + this.BuildNumber?.GetHashCode() ?? 0;
+            }
+
+            /// <summary>
+            /// Gets a value indicating whether this instance is equivalent to the default instance.
+            /// </summary>
+            internal bool IsDefault => this.Equals(DefaultInstance);
+        }
+
+        /// <summary>
+        /// Override the build number preset by the cloud build with one enriched with version information.
+        /// </summary>
+        public class CloudBuildNumberOptions : IEquatable<CloudBuildNumberOptions>
+        {
+            /// <summary>
+            /// The default (uninitialized) instance.
+            /// </summary>
+            internal static readonly CloudBuildNumberOptions DefaultInstance = new CloudBuildNumberOptions();
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CloudBuildNumberOptions"/> class.
+            /// </summary>
+            public CloudBuildNumberOptions()
+            {
+            }
+
+            /// <summary>
+            /// Gets or sets a value indicating whether to override the build number preset by the cloud build.
+            /// </summary>
+            public bool Enabled { get; set; }
+
+            /// <summary>
+            /// Getse or sets when and where to include information about the git commit being built.
+            /// </summary>
+            public CloudBuildNumberCommitIdOptions IncludeCommitId { get; set; }
+
+            internal bool ShouldSerializeIncludeCommitId() => !(this.IncludeCommitId?.IsDefault ?? true);
+
+            /// <inheritdoc />
+            public override bool Equals(object obj) => this.Equals(obj as CloudBuildNumberOptions);
+
+            /// <inheritdoc />
+            public bool Equals(CloudBuildNumberOptions other)
+            {
+                return other != null
+                    && this.Enabled == other.Enabled
+                    && EqualityComparer<CloudBuildNumberCommitIdOptions>.Default.Equals(this.IncludeCommitId ?? CloudBuildNumberCommitIdOptions.DefaultInstance, other.IncludeCommitId ?? CloudBuildNumberCommitIdOptions.DefaultInstance);
+            }
+
+            /// <inheritdoc />
+            public override int GetHashCode()
+            {
+                return this.Enabled ? 1 : 0
+                    + this.IncludeCommitId?.GetHashCode() ?? 0;
+            }
+
+            /// <summary>
+            /// Gets a value indicating whether this instance is equivalent to the default instance.
+            /// </summary>
+            internal bool IsDefault => this.Equals(DefaultInstance);
+        }
+
+        /// <summary>
+        /// Describes when and where to include information about the git commit being built.
+        /// </summary>
+        public class CloudBuildNumberCommitIdOptions : IEquatable<CloudBuildNumberCommitIdOptions>
+        {
+            /// <summary>
+            /// The default (uninitialized) instance.
+            /// </summary>
+            internal static readonly CloudBuildNumberCommitIdOptions DefaultInstance = new CloudBuildNumberCommitIdOptions();
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CloudBuildNumberCommitIdOptions"/> class.
+            /// </summary>
+            public CloudBuildNumberCommitIdOptions()
+            {
+            }
+
+            /// <summary>
+            /// Gets or sets the conditions when the commit ID is included in the build number.
+            /// </summary>
+            public CloudBuildNumberCommitWhen When { get; set; } = CloudBuildNumberCommitWhen.NonPublicReleaseOnly;
+
+            /// <summary>
+            /// Gets or sets the position to include the commit ID information.
+            /// </summary>
+            public CloudBuildNumberCommitWhere Where { get; set; } = CloudBuildNumberCommitWhere.BuildMetadata;
+
+            internal bool ShouldSerializeWhen() => this.When != DefaultInstance.When;
+
+            internal bool ShouldSerializeWhere() => this.Where != DefaultInstance.Where;
+
+            /// <inheritdoc />
+            public override bool Equals(object obj) => this.Equals(obj as CloudBuildNumberCommitIdOptions);
+
+            /// <inheritdoc />
+            public bool Equals(CloudBuildNumberCommitIdOptions other)
+            {
+                return other != null
+                    && this.When == other.When
+                    && this.Where == other.Where;
+            }
+
+            /// <inheritdoc />
+            public override int GetHashCode()
+            {
+                return (int)this.Where + (int)this.When * 0x10;
             }
 
             /// <summary>
@@ -268,6 +382,43 @@
             /// All four integers will be set.
             /// </summary>
             Revision,
+        }
+
+        /// <summary>
+        /// The conditions a commit ID is included in a cloud build number.
+        /// </summary>
+        public enum CloudBuildNumberCommitWhen
+        {
+            /// <summary>
+            /// Always include the commit information in the cloud Build Number.
+            /// </summary>
+            Always,
+
+            /// <summary>
+            /// Only include the commit information when building a non-PublicRelease.
+            /// </summary>
+            NonPublicReleaseOnly,
+
+            /// <summary>
+            /// Never include the commit information.
+            /// </summary>
+            Never,
+        }
+
+        /// <summary>
+        /// The position a commit ID can appear in a cloud build number.
+        /// </summary>
+        public enum CloudBuildNumberCommitWhere
+        {
+            /// <summary>
+            /// The commit ID appears in build metadata (e.g. +ga1b2c3).
+            /// </summary>
+            BuildMetadata,
+
+            /// <summary>
+            /// The commit ID appears as the 4th integer in the version (e.g. 1.2.3.23523).
+            /// </summary>
+            FourthVersionComponent,
         }
     }
 }

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -14,6 +14,21 @@
     public class VersionOptions : IEquatable<VersionOptions>
     {
         /// <summary>
+        /// The JSON serializer settings to use.
+        /// </summary>
+        public static JsonSerializerSettings JsonSettings => new JsonSerializerSettings
+        {
+            Converters = new JsonConverter[] {
+                new VersionConverter(),
+                new SemanticVersionJsonConverter(),
+                new AssemblyVersionOptionsConverter(),
+                new StringEnumConverter() { CamelCaseText = true },
+            },
+            ContractResolver = new VersionOptionsContractResolver(),
+            Formatting = Formatting.Indented,
+        };
+
+        /// <summary>
         /// Gets or sets the default version to use.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/src/NerdBank.GitVersioning/VersionOptionsContractResolver.cs
+++ b/src/NerdBank.GitVersioning/VersionOptionsContractResolver.cs
@@ -20,6 +20,16 @@
                 property.ShouldSerialize = instance => ((VersionOptions)instance).ShouldSerializeAssemblyVersion();
             }
 
+            if (property.DeclaringType == typeof(VersionOptions) && member.Name == nameof(VersionOptions.CloudBuild))
+            {
+                property.ShouldSerialize = instance => ((VersionOptions)instance).ShouldSerializeCloudBuild();
+            }
+
+            if (property.DeclaringType == typeof(VersionOptions.CloudBuildOptions) && member.Name == nameof(VersionOptions.CloudBuildOptions.SetVersionVariables))
+            {
+                property.ShouldSerialize = instance => ((VersionOptions.CloudBuildOptions)instance).ShouldSerializeSetVersionVariables();
+            }
+
             return property;
         }
     }

--- a/src/NerdBank.GitVersioning/VersionOptionsContractResolver.cs
+++ b/src/NerdBank.GitVersioning/VersionOptionsContractResolver.cs
@@ -30,6 +30,21 @@
                 property.ShouldSerialize = instance => ((VersionOptions.CloudBuildOptions)instance).ShouldSerializeSetVersionVariables();
             }
 
+            if (property.DeclaringType == typeof(VersionOptions.CloudBuildNumberOptions) && member.Name == nameof(VersionOptions.CloudBuildNumberOptions.IncludeCommitId))
+            {
+                property.ShouldSerialize = instance => ((VersionOptions.CloudBuildNumberOptions)instance).ShouldSerializeIncludeCommitId();
+            }
+
+            if (property.DeclaringType == typeof(VersionOptions.CloudBuildNumberCommitIdOptions) && member.Name == nameof(VersionOptions.CloudBuildNumberCommitIdOptions.When))
+            {
+                property.ShouldSerialize = instance => ((VersionOptions.CloudBuildNumberCommitIdOptions)instance).ShouldSerializeWhen();
+            }
+
+            if (property.DeclaringType == typeof(VersionOptions.CloudBuildNumberCommitIdOptions) && member.Name == nameof(VersionOptions.CloudBuildNumberCommitIdOptions.Where))
+            {
+                property.ShouldSerialize = instance => ((VersionOptions.CloudBuildNumberCommitIdOptions)instance).ShouldSerializeWhere();
+            }
+
             return property;
         }
     }

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -49,6 +49,35 @@
           "type": "boolean",
           "default": true,
           "description": "Elevate certain calculated version build properties to cloud build variables."
+        },
+        "buildNumber": {
+          "type": "object",
+          "description": "Override the build number preset by the cloud build with one enriched with version information.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether to override the build number preset by the cloud build.",
+              "default": false
+            },
+            "includeCommitId": {
+              "type": "object",
+              "description": "Describes when and where to include information about the git commit being built.",
+              "properties": {
+                "when": {
+                  "type": "string",
+                  "default": "nonPublicReleaseOnly",
+                  "description": "The conditions when the commit ID is included in the build number.",
+                  "enum": [ "always", "nonPublicReleaseOnly", "never" ]
+                },
+                "where": {
+                  "type": "string",
+                  "default": "buildMetadata",
+                  "description": "The position to include the commit ID information.",
+                  "enum": [ "buildMetadata", "fourthVersionComponent" ]
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -1,4 +1,5 @@
 ﻿{
+  "$schema": "http://json-schema.org/draft-04/schema",
   "title": "Nerdbank.GitVersioning version.json schema",
   "type": "object",
   "required": [ "version" ],
@@ -39,6 +40,17 @@
         "format": "regex"
       },
       "uniqueItems": true
+    },
+    "cloudBuild": {
+      "type": "object",
+      "description": "Options that are applicable specifically to cloud builds (e.g. VSTS, AppVeyor, TeamCity)",
+      "properties": {
+        "setVersionVariables": {
+          "type": "boolean",
+          "default": true,
+          "description": "Elevate certain calculated version build properties to cloud build variables."
+        }
+      }
     }
   },
   "definitions": {

--- a/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
@@ -50,6 +50,7 @@
       <Output TaskParameter="PublicRelease" PropertyName="PublicRelease" />
       <Output TaskParameter="CloudBuildNumber" PropertyName="CloudBuildNumber" />
       <Output TaskParameter="SetCloudBuildVersionVars" PropertyName="SetCloudBuildVersionVars" />
+      <Output TaskParameter="BuildMetadataFragment" PropertyName="SemVerBuildSuffix" />
     </GetBuildVersion>
     <PropertyGroup>
       <BuildNumber>$(BuildVersionNumberComponent)</BuildNumber>
@@ -62,7 +63,6 @@
       <GitCommitId Condition=" '$(GitCommitId)' == '' ">$(BUILD_VCS_NUMBER)</GitCommitId>
 
       <GitCommitIdShort Condition=" '$(GitCommitId)' != '' ">$(GitCommitId.Substring(0,10))</GitCommitIdShort>
-      <SemVerBuildSuffix Condition=" '$(GitCommitIdShort)' != '' ">+g$(GitCommitIdShort)</SemVerBuildSuffix>
 
       <BuildVersion3Components>$(MajorMinorVersion).$(BuildNumberFirstComponent)</BuildVersion3Components>
       <AssemblyInformationalVersion>$(MajorMinorVersion).$(BuildNumberFirstAndSecondComponentsIfApplicable)$(PrereleaseVersion)$(SemVerBuildSuffix)</AssemblyInformationalVersion>

--- a/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
@@ -35,7 +35,9 @@
   </PropertyGroup>
 
   <Target Name="GetBuildVersion" Returns="$(BuildVersion)">
-    <GetBuildVersion BuildingRef="$(_NBGV_BuildingRef)">
+    <GetBuildVersion
+      BuildingRef="$(_NBGV_BuildingRef)"
+      DefaultPublicRelease="$(PublicRelease)">
       <Output TaskParameter="Version" PropertyName="BuildVersion" />
       <Output TaskParameter="SimpleVersion" PropertyName="BuildVersionSimple" />
       <Output TaskParameter="PrereleaseVersion" PropertyName="PrereleaseVersion" Condition=" '$(PrereleaseVersion)' == '' " />
@@ -44,11 +46,9 @@
       <Output TaskParameter="GitCommitId" PropertyName="GitCommitId" />
       <Output TaskParameter="GitVersionHeight" PropertyName="GitVersionHeight" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildVersionNumberComponent" />
-      <Output TaskParameter="PublicReleaseDefault" PropertyName="PublicReleaseDefault" />
+      <Output TaskParameter="PublicRelease" PropertyName="PublicRelease" />
     </GetBuildVersion>
     <PropertyGroup>
-      <PublicRelease Condition=" '$(PublicRelease)' == '' ">$(PublicReleaseDefault)</PublicRelease>
-
       <BuildNumber>$(BuildVersionNumberComponent)</BuildNumber>
       <BuildNumberFirstComponent>$([System.Text.RegularExpressions.Regex]::Match($(BuildNumber), '(\d+)').Groups[1].Value)</BuildNumberFirstComponent>
       <BuildNumberSecondComponent>$([System.Text.RegularExpressions.Regex]::Match($(BuildNumber), '(\d+)\.(\d+)').Groups[2].Value)</BuildNumberSecondComponent>

--- a/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
@@ -47,6 +47,7 @@
       <Output TaskParameter="GitVersionHeight" PropertyName="GitVersionHeight" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildVersionNumberComponent" />
       <Output TaskParameter="PublicRelease" PropertyName="PublicRelease" />
+      <Output TaskParameter="CloudBuildNumber" PropertyName="CloudBuildNumber" />
       <Output TaskParameter="SetCloudBuildVersionVars" PropertyName="SetCloudBuildVersionVars" />
     </GetBuildVersion>
     <PropertyGroup>

--- a/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
@@ -70,6 +70,14 @@
            The 'g' prefix allows tooling to recognize that a git commit ID follows. -->
       <NuGetPackageVersion Condition=" '$(PublicRelease)' != 'true' ">$(NuGetPackageVersion)-g$(GitCommitIdShort)</NuGetPackageVersion>
     </PropertyGroup>
+    <ItemGroup>
+      <CloudBuildVersionVars Include="GitAssemblyInformationalVersion">
+        <Value>$(AssemblyInformationalVersion)</Value>
+      </CloudBuildVersionVars>
+      <CloudBuildVersionVars Include="GitBuildVersion">
+        <Value>$(BuildVersion)</Value>
+      </CloudBuildVersionVars>
+    </ItemGroup>
 
     <Warning Condition=" '$(AssemblyInformationalVersion)' == '' " Text="Unable to determine the git HEAD commit ID to use for informational version number." />
     <Message Condition=" '$(AssemblyInformationalVersion)' != '' " Text="Building version $(BuildVersion) from commit $(GitCommitId)"/>

--- a/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
@@ -47,6 +47,7 @@
       <Output TaskParameter="GitVersionHeight" PropertyName="GitVersionHeight" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildVersionNumberComponent" />
       <Output TaskParameter="PublicRelease" PropertyName="PublicRelease" />
+      <Output TaskParameter="SetCloudBuildVersionVars" PropertyName="SetCloudBuildVersionVars" />
     </GetBuildVersion>
     <PropertyGroup>
       <BuildNumber>$(BuildVersionNumberComponent)</BuildNumber>
@@ -70,7 +71,7 @@
            The 'g' prefix allows tooling to recognize that a git commit ID follows. -->
       <NuGetPackageVersion Condition=" '$(PublicRelease)' != 'true' ">$(NuGetPackageVersion)-g$(GitCommitIdShort)</NuGetPackageVersion>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Condition=" '$(SetCloudBuildVersionVars)' == 'true' ">
       <CloudBuildVersionVars Include="GitAssemblyInformationalVersion">
         <Value>$(AssemblyInformationalVersion)</Value>
       </CloudBuildVersionVars>

--- a/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/NerdBank.GitVersioning.targets
@@ -37,6 +37,7 @@
   <Target Name="GetBuildVersion" Returns="$(BuildVersion)">
     <GetBuildVersion
       BuildingRef="$(_NBGV_BuildingRef)"
+      BuildMetadata="@(BuildMetadata)"
       DefaultPublicRelease="$(PublicRelease)">
       <Output TaskParameter="Version" PropertyName="BuildVersion" />
       <Output TaskParameter="SimpleVersion" PropertyName="BuildVersionSimple" />

--- a/src/Nerdbank.GitVersioning.NuGet/build/VisualStudioTeamServices.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/VisualStudioTeamServices.targets
@@ -26,4 +26,15 @@
     <Message Text="##vso[task.setvariable variable=%(CloudBuildVersionVars.Identity);]%(CloudBuildVersionVars.Value)
 " />
   </Target>
+
+  <Target Name="SetCloudBuildNumberWithVersion"
+          DependsOnTargets="GetBuildVersion"
+          AfterTargets="GetBuildVersion"
+          Condition=" '$(CloudBuildNumber)' != '' ">
+    <!-- IMPORTANT: The newline character at the end of this message is important when MSBuild logging
+                    verbosity is set to diagnostic, so that the " (TaskId: 25)" suffix is not appended
+                    at the end of the line that VSO will interpret as a variable set command. -->
+    <Message Text="##vso[build.updatebuildnumber]$(CloudBuildNumber)
+" />
+  </Target>
 </Project>

--- a/src/Nerdbank.GitVersioning.NuGet/build/VisualStudioTeamServices.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/VisualStudioTeamServices.targets
@@ -16,22 +16,14 @@
 
   <!-- When we're building in VSTS, set VSTS variables so that build drops
        can be in paths named after the versions are calculated during the build. -->
-  <Target Name="SetVsoVersionVars"
+  <Target Name="SetCloudBuildVersionVars"
           DependsOnTargets="GetBuildVersion"
-          AfterTargets="GetBuildVersion">
-    <ItemGroup>
-      <VSOVariable Include="GitAssemblyInformationalVersion">
-        <Value>$(AssemblyInformationalVersion)</Value>
-      </VSOVariable>
-      <VSOVariable Include="GitBuildVersion">
-        <Value>$(BuildVersion)</Value>
-      </VSOVariable>
-    </ItemGroup>
-
+          AfterTargets="GetBuildVersion"
+          Condition=" '@(CloudBuildVersionVars)' != '' ">
     <!-- IMPORTANT: The newline character at the end of this message is important when MSBuild logging
                     verbosity is set to diagnostic, so that the " (TaskId: 25)" suffix is not appended
                     at the end of the line that VSO will interpret as a variable set command. -->
-    <Message Text="##vso[task.setvariable variable=%(VSOVariable.Identity);]%(VSOVariable.Value)
+    <Message Text="##vso[task.setvariable variable=%(CloudBuildVersionVars.Identity);]%(CloudBuildVersionVars.Value)
 " />
   </Target>
 </Project>

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -27,11 +27,18 @@
         public string BuildingRef { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the project suggests the default
-        /// value for the PublicRelease MSBuild property be true.
+        /// Gets or sets the value of the PublicRelease property in MSBuild at the
+        /// start of this Task.
+        /// </summary>
+        /// <value>Expected to be "true", "false", or empty.</value>
+        public string DefaultPublicRelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the project is building
+        /// in PublicRelease mode.
         /// </summary>
         [Output]
-        public bool PublicReleaseDefault { get; private set; }
+        public bool PublicRelease { get; private set; }
 
         /// <summary>
         /// Gets the version string to use in the compiled assemblies.
@@ -114,10 +121,14 @@
                         VersionFile.GetVersion(git, Environment.CurrentDirectory) ??
                         VersionFile.GetVersion(Environment.CurrentDirectory);
 
-                    if (!string.IsNullOrEmpty(this.BuildingRef) && versionOptions?.PublicReleaseRefSpec?.Length > 0)
+                    this.PublicRelease = string.Equals(this.DefaultPublicRelease, "true", StringComparison.OrdinalIgnoreCase);
+                    if (string.IsNullOrEmpty(this.DefaultPublicRelease))
                     {
-                        this.PublicReleaseDefault = versionOptions.PublicReleaseRefSpec.Any(
-                            expr => Regex.IsMatch(this.BuildingRef, expr));
+                        if (!string.IsNullOrEmpty(this.BuildingRef) && versionOptions?.PublicReleaseRefSpec?.Length > 0)
+                        {
+                            this.PublicRelease = versionOptions.PublicReleaseRefSpec.Any(
+                                expr => Regex.IsMatch(this.BuildingRef, expr));
+                        }
                     }
 
                     this.PrereleaseVersion = versionOptions?.Version.Prerelease ?? string.Empty;

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -96,6 +96,12 @@
         [Output]
         public int BuildNumber { get; private set; }
 
+        /// <summary>
+        /// Gets a value indicating whether to set cloud build version variables.
+        /// </summary>
+        [Output]
+        public bool SetCloudBuildVersionVars { get; private set; }
+
         public override bool Execute()
         {
             try
@@ -148,6 +154,9 @@
                 this.AssemblyVersion = assemblyVersion.ToStringSafe(4);
                 this.BuildNumber = Math.Max(0, typedVersion.Build);
                 this.Version = typedVersion.ToString();
+
+                this.SetCloudBuildVersionVars = versionOptions?.CloudBuild?.SetVersionVariables
+                    ?? (new VersionOptions.CloudBuildOptions()).SetVersionVariables;
             }
             catch (ArgumentOutOfRangeException ex)
             {

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -96,6 +96,12 @@
         public int GitVersionHeight { get; private set; }
 
         /// <summary>
+        /// Gets the +buildMetadata fragment for the semantic version.
+        /// </summary>
+        [Output]
+        public string BuildMetadataFragment { get; private set; }
+
+        /// <summary>
         /// Gets the build number (git height) for this version.
         /// </summary>
         [Output]
@@ -169,6 +175,14 @@
                 this.SetCloudBuildVersionVars = versionOptions?.CloudBuild?.SetVersionVariables
                     ?? (new VersionOptions.CloudBuildOptions()).SetVersionVariables;
 
+                var buildMetadata = this.BuildMetadata?.ToList() ?? new List<string>();
+                if (!string.IsNullOrEmpty(this.GitCommitId))
+                {
+                    buildMetadata.Insert(0, $"g{this.GitCommitId.Substring(0, 10)}");
+                }
+
+                this.BuildMetadataFragment = FormatBuildMetadata(buildMetadata);
+
                 var buildNumber = versionOptions?.CloudBuild?.BuildNumber ?? new VersionOptions.CloudBuildNumberOptions();
                 if (buildNumber.Enabled)
                 {
@@ -178,13 +192,7 @@
                     bool commitIdInRevision = includeCommitInfo && commitIdOptions.Where == VersionOptions.CloudBuildNumberCommitWhere.FourthVersionComponent;
                     bool commitIdInBuildMetadata = includeCommitInfo && commitIdOptions.Where == VersionOptions.CloudBuildNumberCommitWhere.BuildMetadata;
                     Version buildNumberVersion = commitIdInRevision ? typedVersion : typedVersionWithoutRevision;
-                    var buildMetadata = this.BuildMetadata?.ToList() ?? new List<string>();
-                    if (commitIdInBuildMetadata && !string.IsNullOrEmpty(this.GitCommitId))
-                    {
-                        buildMetadata.Insert(0, $"g{this.GitCommitId.Substring(0, 10)}");
-                    }
-
-                    string buildNumberMetadata = FormatBuildMetadata(buildMetadata);
+                    string buildNumberMetadata = FormatBuildMetadata(commitIdInBuildMetadata ? (IEnumerable<string>)buildMetadata : this.BuildMetadata);
                     this.CloudBuildNumber = buildNumberVersion + this.PrereleaseVersion + buildNumberMetadata;
                 }
             }

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -27,6 +27,11 @@
         public string BuildingRef { get; set; }
 
         /// <summary>
+        /// Gets or sets identifiers to append as build metadata.
+        /// </summary>
+        public string[] BuildMetadata { get; set; }
+
+        /// <summary>
         /// Gets or sets the value of the PublicRelease property in MSBuild at the
         /// start of this Task.
         /// </summary>
@@ -173,7 +178,7 @@
                     bool commitIdInRevision = includeCommitInfo && commitIdOptions.Where == VersionOptions.CloudBuildNumberCommitWhere.FourthVersionComponent;
                     bool commitIdInBuildMetadata = includeCommitInfo && commitIdOptions.Where == VersionOptions.CloudBuildNumberCommitWhere.BuildMetadata;
                     Version buildNumberVersion = commitIdInRevision ? typedVersion : typedVersionWithoutRevision;
-                    var buildMetadata = new List<string>();
+                    var buildMetadata = this.BuildMetadata?.ToList() ?? new List<string>();
                     if (commitIdInBuildMetadata && !string.IsNullOrEmpty(this.GitCommitId))
                     {
                         buildMetadata.Insert(0, $"g{this.GitCommitId.Substring(0, 10)}");


### PR DESCRIPTION
Toward fix for #37 (it actually fixes it entirely, but only for VSTS)

## Design Question

An interesting design question though (CC: @onovotny): should the settings to "opt-in" and control policy around the build number be stored in version.json, which is an SCC-controlled file? Or should it be all based on MSBuild properties which can be conveniently set by the cloud build definition? I tried both approaches and settled on the SCC-controlleed version.json file.

### Arguments in favor of settings in version.json:

1. Some git repos have multiple projects with distinct version.json files. Storing the opt-in setting in version.json allows *one* to actually set the build number while the others don't.
1. It's convenient to change a json file, and it applies to all build definitions automatically, even across cloud build services.
1. Can easily represent several and complex options.

### Arguments in favor of settings in MSBuild properties:

1. Build number policies can be adjusted without fiddling with git commits by adjusting the build definition's set of initial global properties and environment variables.
1. An MSBuild property can specify which one MSBuild project in the repo should execute the cloud build server commands.
1. Different build definitions of the same repo can apply different policies on their build numbering.