### PR TITLE
The GetBuildVersion task crashed in case a project was not in a subdirectory

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -37,6 +37,7 @@ public class BuildIntegrationTests : RepoTestBase
     private ProjectCollection projectCollection;
     private string projectDirectory;
     private ProjectRootElement testProject;
+    private ProjectRootElement testProjectInRoot;
     private Dictionary<string, string> globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         // Set global properties to neutralize environment variables
@@ -57,7 +58,8 @@ public class BuildIntegrationTests : RepoTestBase
         this.projectDirectory = Path.Combine(this.RepoPath, "projdir");
         Directory.CreateDirectory(this.projectDirectory);
         this.LoadTargetsIntoProjectCollection();
-        this.testProject = this.CreateProjectRootElement();
+        this.testProject = this.CreateProjectRootElement(this.projectDirectory, "test.proj");
+        this.testProjectInRoot = this.CreateProjectRootElement(this.RepoPath, "root.proj");
         this.globalProperties.Add("NerdbankGitVersioningTasksPath", Environment.CurrentDirectory + "\\");
 
         // Sterilize the test of any environment variables.
@@ -76,7 +78,7 @@ public class BuildIntegrationTests : RepoTestBase
     {
         this.WriteVersionFile();
         this.InitializeSourceControl();
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         Assert.Equal(
             buildResult.BuildVersion,
             buildResult.BuildResult.ResultsByTarget[Targets.GetBuildVersion].Items.Single().ItemSpec);
@@ -86,7 +88,7 @@ public class BuildIntegrationTests : RepoTestBase
     public async Task GetBuildVersion_Without_Git()
     {
         this.WriteVersionFile("3.4");
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         Assert.Equal("3.4", buildResult.BuildVersion);
         Assert.Equal("3.4.0", buildResult.AssemblyInformationalVersion);
     }
@@ -98,7 +100,7 @@ public class BuildIntegrationTests : RepoTestBase
         var repo = new Repository(this.RepoPath); // do not assign Repo property to avoid commits being generated later
         this.WriteVersionFile("3.4");
         Assumes.False(repo.Head.Commits.Any()); // verification that the test is doing what it claims
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         Assert.Equal("3.4.0.0", buildResult.BuildVersion);
         Assert.Equal("3.4.0", buildResult.AssemblyInformationalVersion);
     }
@@ -111,7 +113,7 @@ public class BuildIntegrationTests : RepoTestBase
         repo.Commit("empty", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
         this.WriteVersionFile("3.4");
         Assumes.True(repo.Index[VersionFile.JsonFileName] == null);
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         Assert.Equal("3.4.0." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
         Assert.Equal("3.4.0+g" + repo.Head.Commits.First().Id.Sha.Substring(0, 10), buildResult.AssemblyInformationalVersion);
     }
@@ -126,7 +128,7 @@ public class BuildIntegrationTests : RepoTestBase
         this.InitializeSourceControl();
         var workingCopyVersion = VersionOptions.FromVersion(new Version("6.0"));
         VersionFile.SetVersion(this.RepoPath, workingCopyVersion);
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         this.AssertStandardProperties(workingCopyVersion, buildResult);
     }
 
@@ -136,7 +138,7 @@ public class BuildIntegrationTests : RepoTestBase
         Repository.Init(this.RepoPath);
         var repo = new Repository(this.RepoPath); // do not assign Repo property to avoid commits being generated later
         repo.Commit("empty", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         Assert.Equal("0.0.1." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
         Assert.Equal("0.0.1+g" + repo.Head.Commits.First().Id.Sha.Substring(0, 10), buildResult.AssemblyInformationalVersion);
     }
@@ -151,7 +153,7 @@ public class BuildIntegrationTests : RepoTestBase
         this.WriteVersionFile(majorMinorVersion, prerelease, subdirectory);
         this.InitializeSourceControl();
         this.AddCommits(this.random.Next(15));
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         this.AssertStandardProperties(VersionOptions.FromVersion(new Version(majorMinorVersion)), buildResult, subdirectory);
     }
 
@@ -170,8 +172,24 @@ public class BuildIntegrationTests : RepoTestBase
         this.WriteVersionFile(subdirVersionSpec, subdirectory);
         this.InitializeSourceControl();
         this.AddCommits(this.random.Next(15));
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         this.AssertStandardProperties(subdirVersionSpec, buildResult, subdirectory);
+    }
+
+    [Fact]
+    public async Task GetBuildVersion_In_Git_With_Version_File_In_Root_And_Project_In_Root_Works()
+    {
+        var rootVersionSpec = new VersionOptions
+        {
+            Version = SemanticVersion.Parse("14.1"),
+            AssemblyVersion = new VersionOptions.AssemblyVersionOptions(new Version(14, 0)),
+        };
+
+        this.WriteVersionFile(rootVersionSpec);
+        this.InitializeSourceControl();
+        this.AddCommits(this.random.Next(15));
+        var buildResult = await this.BuildAsync(this.testProjectInRoot);
+        this.AssertStandardProperties(rootVersionSpec, buildResult);
     }
 
     [Fact]
@@ -183,7 +201,7 @@ public class BuildIntegrationTests : RepoTestBase
         this.WriteVersionFile(majorMinorVersion, prerelease);
         this.InitializeSourceControl();
         this.AddCommits(this.random.Next(15));
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         this.AssertStandardProperties(VersionOptions.FromVersion(new Version(majorMinorVersion)), buildResult);
     }
 
@@ -197,7 +215,7 @@ public class BuildIntegrationTests : RepoTestBase
         this.InitializeSourceControl();
         this.AddCommits(this.random.Next(15));
         this.globalProperties["PublicRelease"] = "true";
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         this.AssertStandardProperties(VersionOptions.FromVersion(new Version(majorMinorVersion)), buildResult);
 
         Version version = this.Repo.Head.Commits.First().GetIdAsVersion();
@@ -213,7 +231,7 @@ public class BuildIntegrationTests : RepoTestBase
         this.WriteVersionFile(majorMinorVersion, prerelease);
         this.InitializeSourceControl();
         this.AddCommits(this.random.Next(15));
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         this.AssertStandardProperties(VersionOptions.FromVersion(new Version(majorMinorVersion), prerelease), buildResult);
     }
 
@@ -227,7 +245,7 @@ public class BuildIntegrationTests : RepoTestBase
         this.InitializeSourceControl();
         this.AddCommits(this.random.Next(15));
         this.globalProperties["PublicRelease"] = "true";
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         this.AssertStandardProperties(VersionOptions.FromVersion(new Version(majorMinorVersion), prerelease), buildResult);
     }
 
@@ -242,7 +260,7 @@ public class BuildIntegrationTests : RepoTestBase
             AssemblyVersion = new VersionOptions.AssemblyVersionOptions(new Version(14, 0)),
         };
         this.WriteVersionFile(versionOptions);
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         this.AssertStandardProperties(versionOptions, buildResult);
     }
 
@@ -262,7 +280,7 @@ public class BuildIntegrationTests : RepoTestBase
         };
         this.WriteVersionFile(versionOptions);
         this.InitializeSourceControl();
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         this.AssertStandardProperties(versionOptions, buildResult);
     }
 
@@ -281,7 +299,7 @@ public class BuildIntegrationTests : RepoTestBase
         };
         this.WriteVersionFile(versionOptions);
         this.InitializeSourceControl();
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         this.AssertStandardProperties(versionOptions, buildResult);
     }
 
@@ -296,7 +314,7 @@ public class BuildIntegrationTests : RepoTestBase
             BuildNumberOffset = 5,
         };
         this.WriteVersionFile(versionOptions);
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         this.AssertStandardProperties(versionOptions, buildResult);
     }
 
@@ -312,7 +330,7 @@ public class BuildIntegrationTests : RepoTestBase
         this.InitializeSourceControl();
 
         // Just build "master", which doesn't conform to the regex.
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         Assert.False(buildResult.PublicRelease);
         AssertStandardProperties(versionOptions, buildResult);
     }
@@ -346,7 +364,7 @@ public class BuildIntegrationTests : RepoTestBase
             this.globalProperties[property.Key] = property.Value;
         }
 
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         Assert.True(buildResult.PublicRelease);
         AssertStandardProperties(versionOptions, buildResult);
     }
@@ -387,7 +405,7 @@ public class BuildIntegrationTests : RepoTestBase
         this.WriteVersionFile(versionOptions);
         this.InitializeSourceControl();
 
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         AssertStandardProperties(versionOptions, buildResult);
         string conditionallyExpectedMessage = expectedMessage
             .Replace("{NAME}", "GitBuildVersion")
@@ -397,7 +415,7 @@ public class BuildIntegrationTests : RepoTestBase
 
         versionOptions.CloudBuild.SetVersionVariables = false;
         this.WriteVersionFile(versionOptions);
-        buildResult = await this.BuildAsync();
+        buildResult = await this.BuildAsync(this.testProject);
         AssertStandardProperties(versionOptions, buildResult);
         conditionallyExpectedMessage = expectedMessage
             .Replace("{NAME}", "GitBuildVersion")
@@ -448,7 +466,7 @@ public class BuildIntegrationTests : RepoTestBase
             this.globalProperties[property.Key] = property.Value;
         }
 
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         AssertStandardProperties(versionOptions, buildResult);
         expectedBuildNumberMessage = expectedBuildNumberMessage.Replace("{CLOUDBUILDNUMBER}", buildResult.CloudBuildNumber);
         Assert.Contains(expectedBuildNumberMessage, buildResult.LoggedEvents.Select(e => e.Message.TrimEnd()));
@@ -470,7 +488,7 @@ public class BuildIntegrationTests : RepoTestBase
             this.testProject.AddItem("BuildMetadata", $"A{i}");
         }
 
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         AssertStandardProperties(versionOptions, buildResult);
     }
 
@@ -488,7 +506,7 @@ public class BuildIntegrationTests : RepoTestBase
         // Check out a branch that conforms.
         var releaseBranch = this.Repo.CreateBranch("release");
         this.Repo.Checkout(releaseBranch);
-        var buildResult = await this.BuildAsync();
+        var buildResult = await this.BuildAsync(this.testProject);
         Assert.True(buildResult.PublicRelease);
         AssertStandardProperties(versionOptions, buildResult);
     }
@@ -504,7 +522,7 @@ public class BuildIntegrationTests : RepoTestBase
             this.MakeItAVBProject();
         }
 
-        var result = await this.BuildAsync("Build", logVerbosity: LoggerVerbosity.Minimal);
+        var result = await this.BuildAsync(this.testProject, "Build", logVerbosity: LoggerVerbosity.Minimal);
         string assemblyPath = result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("TargetPath");
         string versionFileContent = File.ReadAllText(Path.Combine(this.projectDirectory, result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("VersionSourceFile")));
         this.Logger.WriteLine(versionFileContent);
@@ -558,7 +576,7 @@ public class BuildIntegrationTests : RepoTestBase
         this.testProject.AddProperty("DelaySign", delaySigned.ToString());
 
         this.WriteVersionFile();
-        var result = await this.BuildAsync(Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
+        var result = await this.BuildAsync(this.testProject, Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
         string versionCsContent = File.ReadAllText(Path.Combine(this.projectDirectory, result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("VersionSourceFile")));
         this.Logger.WriteLine(versionCsContent);
 
@@ -590,9 +608,9 @@ public class BuildIntegrationTests : RepoTestBase
     public async Task AssemblyInfo_IncrementalBuild()
     {
         this.WriteVersionFile(prerelease: "-beta");
-        await this.BuildAsync("Build", logVerbosity: LoggerVerbosity.Minimal);
+        await this.BuildAsync(this.testProject, "Build", logVerbosity: LoggerVerbosity.Minimal);
         this.WriteVersionFile(prerelease: "-rc"); // two characters SHORTER, to test file truncation.
-        await this.BuildAsync("Build", logVerbosity: LoggerVerbosity.Minimal);
+        await this.BuildAsync(this.testProject, "Build", logVerbosity: LoggerVerbosity.Minimal);
     }
 
     /// <summary>
@@ -607,7 +625,7 @@ public class BuildIntegrationTests : RepoTestBase
         propertyGroup.AddProperty("Language", "NoCodeDOMProviderForThisLanguage");
 
         this.WriteVersionFile();
-        var result = await this.BuildAsync(Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal, assertSuccessfulBuild: false);
+        var result = await this.BuildAsync(this.testProject, Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal, assertSuccessfulBuild: false);
         Assert.Equal(BuildResultCode.Failure, result.BuildResult.OverallResult);
         string versionCsFilePath = Path.Combine(this.projectDirectory, result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("VersionSourceFile"));
         Assert.False(File.Exists(versionCsFilePath));
@@ -627,7 +645,7 @@ public class BuildIntegrationTests : RepoTestBase
         propertyGroup.AddProperty(Targets.GenerateAssemblyVersionInfo, "false");
 
         this.WriteVersionFile();
-        var result = await this.BuildAsync(Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
+        var result = await this.BuildAsync(this.testProject, Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
         string versionCsFilePath = Path.Combine(this.projectDirectory, result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("VersionSourceFile"));
         Assert.False(File.Exists(versionCsFilePath));
         Assert.Empty(result.LoggedEvents.OfType<BuildErrorEventArgs>());
@@ -647,7 +665,7 @@ public class BuildIntegrationTests : RepoTestBase
         propertyGroup.AddProperty("TargetExt", ".notdll");
 
         this.WriteVersionFile();
-        var result = await this.BuildAsync(Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
+        var result = await this.BuildAsync(this.testProject, Targets.GenerateAssemblyVersionInfo, logVerbosity: LoggerVerbosity.Minimal);
         string versionCsFilePath = Path.Combine(this.projectDirectory, result.BuildResult.ProjectStateAfterBuild.GetPropertyValue("VersionSourceFile"));
         Assert.False(File.Exists(versionCsFilePath));
         Assert.Empty(result.LoggedEvents.OfType<BuildErrorEventArgs>());
@@ -736,14 +754,14 @@ public class BuildIntegrationTests : RepoTestBase
         }
     }
 
-    private async Task<BuildResults> BuildAsync(string target = Targets.GetBuildVersion, LoggerVerbosity logVerbosity = LoggerVerbosity.Detailed, bool assertSuccessfulBuild = true)
+    private async Task<BuildResults> BuildAsync(ProjectRootElement project, string target = Targets.GetBuildVersion, LoggerVerbosity logVerbosity = LoggerVerbosity.Detailed, bool assertSuccessfulBuild = true)
     {
         var eventLogger = new MSBuildLogger { Verbosity = LoggerVerbosity.Minimal };
         var loggers = new ILogger[] { eventLogger };
         var buildResult = await this.buildManager.BuildAsync(
             this.Logger,
             this.projectCollection,
-            this.testProject,
+            project,
             target,
             this.globalProperties,
             logVerbosity,
@@ -775,10 +793,10 @@ public class BuildIntegrationTests : RepoTestBase
         }
     }
 
-    private ProjectRootElement CreateProjectRootElement()
+    private ProjectRootElement CreateProjectRootElement(string projectDirectory, string projectName)
     {
         var pre = ProjectRootElement.Create(this.projectCollection);
-        pre.FullPath = Path.Combine(this.projectDirectory, "test.proj");
+        pre.FullPath = Path.Combine(projectDirectory, projectName);
 
         pre.AddProperty("RootNamespace", "TestNamespace");
         pre.AddProperty("AssemblyName", "TestAssembly");

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -127,7 +127,7 @@
                 VersionOptions versionOptions;
                 using (var git = this.OpenGitRepo())
                 {
-                    var repoRoot = git?.Info?.WorkingDirectory;
+                    var repoRoot = git?.Info?.WorkingDirectory?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                     var relativeRepoProjectDirectory = !string.IsNullOrWhiteSpace(repoRoot)
                         ? Environment.CurrentDirectory.Substring(repoRoot.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
                         : null;


### PR DESCRIPTION
Encountered this issue in a project where the directory layout was like this:
`ROOT_DIR/.git/`
`ROOT_DIR/*.csproj`
`ROOT_DIR/version.json`

When building the project it crashed with the error message
`startindex cannot be larger than length of string`