### PR TITLE
Update the LKG we stamp our own NPM package with

### DIFF
--- a/src/nerdbank-gitversioning.npm/gulpfile.js
+++ b/src/nerdbank-gitversioning.npm/gulpfile.js
@@ -20,7 +20,7 @@ gulp.task('tsc', function() {
 
     var replacements = {
         'version': {
-            'lkg': '1.4.41'
+            'lkg': '1.5.18-rc'
         }
     };
     return merge([


### PR DESCRIPTION
This fixes #75 because it includes the fix so that semVer1 as returned by Get-Version.ps1 no longer adds the -gCOMMITID suffix on release branches.