### PR TITLE
Allow "major" as a value for assemblyVersion.precision

### DIFF
--- a/src/NerdBank.GitVersioning/AssemblyVersionOptionsConverter.cs
+++ b/src/NerdBank.GitVersioning/AssemblyVersionOptionsConverter.cs
@@ -45,7 +45,7 @@
             var data = value as VersionOptions.AssemblyVersionOptions;
             if (data != null)
             {
-                if (data.Precision == default(VersionOptions.VersionPrecision))
+                if (data.Precision == VersionOptions.VersionPrecision.Minor)
                 {
                     serializer.Serialize(writer, data.Version);
                     return;

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -162,7 +162,7 @@
             /// </summary>
             /// <param name="version">The assembly version (with major.minor components).</param>
             /// <param name="precision">The additional version precision to add toward matching the AssemblyFileVersion.</param>
-            public AssemblyVersionOptions(Version version, VersionPrecision precision = default(VersionPrecision))
+            public AssemblyVersionOptions(Version version, VersionPrecision precision = VersionPrecision.Minor)
             {
                 this.Version = version;
                 this.Precision = precision;
@@ -368,6 +368,11 @@
         /// </summary>
         public enum VersionPrecision
         {
+            /// <summary>
+            /// The first integer is the last number set. The rest will be zeros.
+            /// </summary>
+            Major,
+
             /// <summary>
             /// The second integer is the last number set. The rest will be zeros.
             /// </summary>

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -6,6 +6,7 @@
     using System.Reflection;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
+    using System.ComponentModel;
 
     /// <summary>
     /// Describes the various versions and options required for the build.
@@ -178,7 +179,8 @@
             /// Gets or sets the additional version precision to add toward matching the AssemblyFileVersion.
             /// </summary>
             [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-            public VersionPrecision Precision { get; set; }
+            [DefaultValue(VersionPrecision.Minor)]
+            public VersionPrecision Precision { get; set; } = VersionPrecision.Minor;
 
             /// <inheritdoc />
             public override bool Equals(object obj) => this.Equals(obj as AssemblyVersionOptions);

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -281,7 +281,7 @@
             var assemblyVersion = versionOptions?.AssemblyVersion?.Version ?? new System.Version(version.Major, version.Minor);
             assemblyVersion = new System.Version(
                 assemblyVersion.Major,
-                assemblyVersion.Minor,
+                versionOptions?.AssemblyVersion?.Precision >= VersionOptions.VersionPrecision.Minor ? version.Minor : 0,
                 versionOptions?.AssemblyVersion?.Precision >= VersionOptions.VersionPrecision.Build ? version.Build : 0,
                 versionOptions?.AssemblyVersion?.Precision >= VersionOptions.VersionPrecision.Revision ? version.Revision : 0);
             return assemblyVersion.EnsureNonNegativeComponents(4);

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -20,7 +20,7 @@
             "precision": {
               "type": "string",
               "description": "Identifies the last component to be explicitly set in the version.",
-              "enum": [ "minor", "build", "revision" ],
+              "enum": [ "major", "minor", "build", "revision" ],
               "default": "minor"
             }
           }


### PR DESCRIPTION
Addresses #96. In addition to the items listed there, I also had to replace two instances of `default(VersionPrecision)` with `VersionPrecision.Minor`. 