### PR TITLE
Explicitly set the build platform, suppress loading of PS profile.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -8,10 +8,14 @@ The project configuration to build.
 Param(
     [Parameter()]
     [ValidateSet('Debug', 'Release')]
-    [string]$Configuration
+    [string]$Configuration,
+
+    [Parameter()]
+    [ValidateSet('minimal', 'normal', 'detailed', 'diagnostic')]
+    [string]$MsBuildVerbosity = 'minimal'
 )
 
-$msbuildCommandLine = "msbuild `"$PSScriptRoot\src\Nerdbank.GitVersioning.sln`" /m /verbosity:minimal /nologo"
+$msbuildCommandLine = "msbuild `"$PSScriptRoot\src\Nerdbank.GitVersioning.sln`" /m /verbosity:$MsBuildVerbosity /nologo /p:Platform=`"Any CPU`""
 
 if (Test-Path "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll") {
     $msbuildCommandLine += " /logger:`"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll`""

--- a/init.cmd
+++ b/init.cmd
@@ -1,1 +1,1 @@
-powershell.exe -ExecutionPolicy bypass -Command "& '%~dpn0.ps1'" %*
+powershell.exe -ExecutionPolicy bypass -NoProfile -Command "& '%~dpn0.ps1'" %*

--- a/init.ps1
+++ b/init.ps1
@@ -6,6 +6,9 @@ Restores all NuGet, NPM and Typings packages necessary to build this repository.
 Param(
 )
 
+$oldPlatform=$env:Platform
+$env:Platform='AnyCPU' # Some people wander in here from a platform-specific build window.
+
 Push-Location $PSScriptRoot
 try {
     $toolsPath = "$PSScriptRoot\tools"
@@ -38,5 +41,6 @@ catch {
     exit $lastexitcode
 }
 finally {
+    $env:Platform=$oldPlatform
     Pop-Location
 }


### PR DESCRIPTION
Also add a -MsBuildVerbosity param to build.ps1.

Some people default to using a platform-specific msbuild window, but our
project only supports 'AnyCPU'.

-NoProfile will help PS to load faster, and also prevent problems when
people have weird stuff in their $profile.