### PR TITLE
Allow user control of build number integer

### DIFF
--- a/doc/versionJson.md
+++ b/doc/versionJson.md
@@ -24,9 +24,10 @@ The content of the version.json file is a JSON serialized object with these prop
   "version": "x.y-prerelease", // required
   "assemblyVersion": "x.y", // optional. Use when x.y for AssemblyVersionAttribute differs from the default version property.
   "buildNumberOffset": "zOffset", // optional. Use when you need to add/subtract a fixed value from the computed build number.
+  "semVer1NumericIdentifierPadding": 4, // optional. Use when your -prerelease includes numeric identifiers and need semver1 support.
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
-    "^refs/tags/v\\d\\.\\d" // we also release tags starting with vN.N
+    "^refs/tags/v\\d+\\.\\d+" // we also release tags starting with vN.N
   ],
   "cloudBuild": {
     "setVersionVariables": true,
@@ -43,6 +44,11 @@ The content of the version.json file is a JSON serialized object with these prop
 
 The `x` and `y` variables are for your use to specify a version that is meaningful
 to your customers. Consider using [semantic versioning][semver] for guidance.
+You may optionally supply a third integer in the version (i.e. x.y.z),
+in which case the git version height is specified as the fourth integer,
+which only appears in certain version representations.
+Alternatively, you can include the git version height in the -prerelease tag using
+syntax such as: `1.2.3-beta.{height}`
 
 The optional -prerelease tag allows you to indicate that you are building prerelease software.
 

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -104,6 +104,7 @@ public class BuildIntegrationTests : RepoTestBase
         VersionOptions workingCopyVersion = new VersionOptions
         {
             Version = SemanticVersion.Parse("7.8.9-beta.3"),
+            SemVer1NumericIdentifierPadding = 1,
         };
         this.WriteVersionFile(workingCopyVersion);
         this.InitializeSourceControl();
@@ -860,7 +861,7 @@ public class BuildIntegrationTests : RepoTestBase
         string pkgVersionSuffix = buildResult.PublicRelease
             ? string.Empty
             : $"-g{commitIdShort}";
-        Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}{versionOptions.Version.Prerelease}{pkgVersionSuffix}", buildResult.NuGetPackageVersion);
+        Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}{GetSemVer1PrereleaseTag(versionOptions)}{pkgVersionSuffix}", buildResult.NuGetPackageVersion);
 
         var buildNumberOptions = versionOptions.CloudBuild?.BuildNumber ?? new VersionOptions.CloudBuildNumberOptions();
         if (buildNumberOptions.Enabled)
@@ -890,6 +891,11 @@ public class BuildIntegrationTests : RepoTestBase
         {
             Assert.Equal(string.Empty, buildResult.CloudBuildNumber);
         }
+    }
+
+    private static string GetSemVer1PrereleaseTag(VersionOptions versionOptions)
+    {
+        return versionOptions.Version.Prerelease?.Replace('.', '-');
     }
 
     private async Task<BuildResults> BuildAsync(string target = Targets.GetBuildVersion, LoggerVerbosity logVerbosity = LoggerVerbosity.Detailed, bool assertSuccessfulBuild = true)

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -99,6 +99,19 @@ public class BuildIntegrationTests : RepoTestBase
     }
 
     [Fact]
+    public async Task GetBuildVersion_WithThreeVersionIntegers()
+    {
+        VersionOptions workingCopyVersion = new VersionOptions
+        {
+            Version = SemanticVersion.Parse("7.8.9-beta.3"),
+        };
+        this.WriteVersionFile(workingCopyVersion);
+        this.InitializeSourceControl();
+        var buildResult = await this.BuildAsync();
+        this.AssertStandardProperties(workingCopyVersion, buildResult);
+    }
+
+    [Fact]
     public async Task GetBuildVersion_Without_Git_HighPrecisionAssemblyVersion()
     {
         this.WriteVersionFile(new VersionOptions
@@ -836,7 +849,6 @@ public class BuildIntegrationTests : RepoTestBase
         Assert.Equal($"{version}", buildResult.BuildVersion);
         Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}", buildResult.BuildVersion3Components);
         Assert.Equal(idAsVersion.Build.ToString(), buildResult.BuildVersionNumberComponent);
-        Assert.Equal(versionOptions.Version.Version.Build != -1 ? versionOptions.Version.Version.Build.ToString() : string.Empty, buildResult.BuildNumberFromVersionJson);
         Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}", buildResult.BuildVersionSimple);
         Assert.Equal(this.Repo.Head.Commits.First().Id.Sha, buildResult.GitCommitId);
         Assert.Equal(commitIdShort, buildResult.GitCommitIdShort);
@@ -996,7 +1008,6 @@ public class BuildIntegrationTests : RepoTestBase
         public string PrereleaseVersion => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("PrereleaseVersion");
         public string MajorMinorVersion => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("MajorMinorVersion");
         public string BuildVersionNumberComponent => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("BuildVersionNumberComponent");
-        public string BuildNumberFromVersionJson => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("BuildNumberFromVersionJson");
         public string GitCommitIdShort => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitCommitIdShort");
         public string GitVersionHeight => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitVersionHeight");
         public string SemVerBuildSuffix => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("SemVerBuildSuffix");

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -381,6 +381,21 @@ public class BuildIntegrationTests : RepoTestBase
         this.AssertStandardProperties(versionOptions, buildResult);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(21)]
+    public async Task GetBuildVersion_BuildNumberSpecifiedInVersionJson(int buildNumber)
+    {
+        var versionOptions = new VersionOptions
+        {
+            Version = SemanticVersion.Parse("14.0." + buildNumber),
+        };
+        this.WriteVersionFile(versionOptions);
+        this.InitializeSourceControl();
+        var buildResult = await this.BuildAsync();
+        this.AssertStandardProperties(versionOptions, buildResult);
+    }
+
     [Fact]
     public async Task PublicRelease_RegEx_Unsatisfied()
     {
@@ -821,6 +836,7 @@ public class BuildIntegrationTests : RepoTestBase
         Assert.Equal($"{version}", buildResult.BuildVersion);
         Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}", buildResult.BuildVersion3Components);
         Assert.Equal(idAsVersion.Build.ToString(), buildResult.BuildVersionNumberComponent);
+        Assert.Equal(versionOptions.Version.Version.Build != -1 ? versionOptions.Version.Version.Build.ToString() : string.Empty, buildResult.BuildNumberFromVersionJson);
         Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}", buildResult.BuildVersionSimple);
         Assert.Equal(this.Repo.Head.Commits.First().Id.Sha, buildResult.GitCommitId);
         Assert.Equal(commitIdShort, buildResult.GitCommitIdShort);
@@ -980,6 +996,7 @@ public class BuildIntegrationTests : RepoTestBase
         public string PrereleaseVersion => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("PrereleaseVersion");
         public string MajorMinorVersion => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("MajorMinorVersion");
         public string BuildVersionNumberComponent => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("BuildVersionNumberComponent");
+        public string BuildNumberFromVersionJson => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("BuildNumberFromVersionJson");
         public string GitCommitIdShort => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitCommitIdShort");
         public string GitVersionHeight => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitVersionHeight");
         public string SemVerBuildSuffix => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("SemVerBuildSuffix");

--- a/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
@@ -172,7 +172,7 @@ public class GitExtensionsTests : RepoTestBase
     }
 
     [Fact]
-    public void GetIdAsVersion_VersionFileNeverCheckedIn()
+    public void GetIdAsVersion_VersionFileNeverCheckedIn_3Ints()
     {
         this.AddCommits();
         var expectedVersion = new Version(1, 1, 0);
@@ -182,6 +182,23 @@ public class GitExtensionsTests : RepoTestBase
         Assert.Equal(expectedVersion.Major, actualVersion.Major);
         Assert.Equal(expectedVersion.Minor, actualVersion.Minor);
         Assert.Equal(expectedVersion.Build, actualVersion.Build);
+
+        // Height is expressed in the 4th integer since 3 were specified in version.json.
+        // height is 0 since the change hasn't been committed.
+        Assert.Equal(0, actualVersion.Revision);
+    }
+
+    [Fact]
+    public void GetIdAsVersion_VersionFileNeverCheckedIn_2Ints()
+    {
+        this.AddCommits();
+        var expectedVersion = new Version(1, 1);
+        var unstagedVersionData = VersionOptions.FromVersion(expectedVersion);
+        string versionFilePath = VersionFile.SetVersion(this.RepoPath, unstagedVersionData);
+        Version actualVersion = this.Repo.GetIdAsVersion();
+        Assert.Equal(expectedVersion.Major, actualVersion.Major);
+        Assert.Equal(expectedVersion.Minor, actualVersion.Minor);
+        Assert.Equal(0, actualVersion.Build); // height is 0 since the change hasn't been committed.
         Assert.Equal(this.Repo.Head.Commits.First().GetTruncatedCommitIdAsUInt16(), actualVersion.Revision);
     }
 

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -9,6 +9,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Keys\*.snk" />
     <EmbeddedResource Include="Keys\*.pfx" />
+    <EmbeddedResource Include="..\NerdBank.GitVersioning\version.schema.json" Link="version.schema.json" />
     <EmbeddedResource Include="test.prj" />
     <EmbeddedResource Include="repos\submodules.7z" />
   </ItemGroup>
@@ -18,6 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="7z.NET" Version="1.0.3" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="2.0.11" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Build" Version="14.3" Condition=" '$(TargetFramework)' == 'net45' " />
     <PackageReference Include="Xunit.Combinatorial" Version="1.1.12" />

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -28,4 +28,88 @@ public class VersionOracleTests : RepoTestBase
             Assert.Equal("3ea7f010c3", oracleB.GitCommitIdShort);
         }
     }
+
+    [Fact]
+    public void MajorMinorPrereleaseBuildMetadata()
+    {
+        VersionOptions workingCopyVersion = new VersionOptions
+        {
+            Version = SemanticVersion.Parse("7.8-beta.3+metadata.4"),
+        };
+        this.WriteVersionFile(workingCopyVersion);
+        this.InitializeSourceControl();
+        var oracle = VersionOracle.Create(this.RepoPath);
+        Assert.Equal("7.8", oracle.MajorMinorVersion.ToString());
+        Assert.Equal(oracle.VersionHeight, oracle.BuildNumber);
+
+        Assert.Equal("-beta.3", oracle.PrereleaseVersion);
+        ////Assert.Equal("+metadata.4", oracle.BuildMetadataFragment);
+
+        Assert.Equal(1, oracle.VersionHeight);
+        Assert.Equal(0, oracle.VersionHeightOffset);
+    }
+
+    [Fact]
+    public void MajorMinorBuildPrereleaseBuildMetadata()
+    {
+        VersionOptions workingCopyVersion = new VersionOptions
+        {
+            Version = SemanticVersion.Parse("7.8.9-beta.3+metadata.4"),
+        };
+        this.WriteVersionFile(workingCopyVersion);
+        this.InitializeSourceControl();
+        var oracle = VersionOracle.Create(this.RepoPath);
+        Assert.Equal("7.8", oracle.MajorMinorVersion.ToString());
+        Assert.Equal(9, oracle.BuildNumber);
+        Assert.Equal(oracle.VersionHeight + oracle.VersionHeightOffset, oracle.Version.Revision);
+
+        Assert.Equal("-beta.3", oracle.PrereleaseVersion);
+        ////Assert.Equal("+metadata.4", oracle.BuildMetadataFragment);
+
+        Assert.Equal(1, oracle.VersionHeight);
+        Assert.Equal(0, oracle.VersionHeightOffset);
+    }
+
+    [Fact]
+    public void HeightInPrerelease()
+    {
+        VersionOptions workingCopyVersion = new VersionOptions
+        {
+            Version = SemanticVersion.Parse("7.8.9-beta.{height}.foo"),
+            BuildNumberOffset = 2,
+        };
+        this.WriteVersionFile(workingCopyVersion);
+        this.InitializeSourceControl();
+        var oracle = VersionOracle.Create(this.RepoPath);
+        Assert.Equal("7.8", oracle.MajorMinorVersion.ToString());
+        Assert.Equal(9, oracle.BuildNumber);
+        Assert.Equal(oracle.VersionHeight + oracle.VersionHeightOffset, oracle.Version.Revision);
+
+        Assert.Equal("-beta." + (oracle.VersionHeight + oracle.VersionHeightOffset) + ".foo", oracle.PrereleaseVersion);
+
+        Assert.Equal(1, oracle.VersionHeight);
+        Assert.Equal(2, oracle.VersionHeightOffset);
+    }
+
+    [Fact(Skip = "Build metadata not yet retained from version.json")]
+    public void HeightInBuildMetadata()
+    {
+        VersionOptions workingCopyVersion = new VersionOptions
+        {
+            Version = SemanticVersion.Parse("7.8.9-beta+another.{height}.foo"),
+            BuildNumberOffset = 2,
+        };
+        this.WriteVersionFile(workingCopyVersion);
+        this.InitializeSourceControl();
+        var oracle = VersionOracle.Create(this.RepoPath);
+        Assert.Equal("7.8", oracle.MajorMinorVersion.ToString());
+        Assert.Equal(9, oracle.BuildNumber);
+        Assert.Equal(oracle.VersionHeight + oracle.VersionHeightOffset, oracle.Version.Revision);
+
+        Assert.Equal("-beta", oracle.PrereleaseVersion);
+        Assert.Equal("+another." + (oracle.VersionHeight + oracle.VersionHeightOffset) + ".foo", oracle.BuildMetadataFragment);
+
+        Assert.Equal(1, oracle.VersionHeight);
+        Assert.Equal(2, oracle.VersionHeightOffset);
+    }
 }

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -112,4 +112,41 @@ public class VersionOracleTests : RepoTestBase
         Assert.Equal(1, oracle.VersionHeight);
         Assert.Equal(2, oracle.VersionHeightOffset);
     }
+
+    [Theory]
+    [InlineData("7.8.9-foo.25", "7.8.9-foo-0025")]
+    [InlineData("7.8.9-foo.25s", "7.8.9-foo-25s")]
+    [InlineData("7.8.9-foo.s25", "7.8.9-foo-s25")]
+    [InlineData("7.8.9-foo.25.bar-24.13-11", "7.8.9-foo-0025-bar-24-13-11")]
+    [InlineData("7.8.9-25.bar.baz-25", "7.8.9-0025-bar-baz-25")]
+    [InlineData("7.8.9-foo.5.bar.1.43.baz", "7.8.9-foo-0005-bar-0001-0043-baz")]
+    public void SemVer1PrereleaseConversion(string semVer2, string semVer1)
+    {
+        VersionOptions workingCopyVersion = new VersionOptions
+        {
+            Version = SemanticVersion.Parse(semVer2),
+            BuildNumberOffset = 2,
+        };
+        this.WriteVersionFile(workingCopyVersion);
+        this.InitializeSourceControl();
+        var oracle = VersionOracle.Create(this.RepoPath);
+        oracle.PublicRelease = true;
+        Assert.Equal(semVer1, oracle.SemVer1);
+    }
+
+    [Fact]
+    public void SemVer1PrereleaseConversionPadding()
+    {
+        VersionOptions workingCopyVersion = new VersionOptions
+        {
+            Version = SemanticVersion.Parse("7.8.9-foo.25"),
+            BuildNumberOffset = 2,
+            SemVer1NumericIdentifierPadding = 3,
+        };
+        this.WriteVersionFile(workingCopyVersion);
+        this.InitializeSourceControl();
+        var oracle = VersionOracle.Create(this.RepoPath);
+        oracle.PublicRelease = true;
+        Assert.Equal("7.8.9-foo-025", oracle.SemVer1);
+    }
 }

--- a/src/NerdBank.GitVersioning.Tests/VersionSchemaTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionSchemaTests.cs
@@ -1,0 +1,73 @@
+﻿using System.IO;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
+using Xunit;
+using Xunit.Abstractions;
+
+public class VersionSchemaTests
+{
+    private readonly ITestOutputHelper Logger;
+
+    private readonly JSchema schema;
+
+    private JObject json;
+
+    public VersionSchemaTests(ITestOutputHelper logger)
+    {
+        this.Logger = logger;
+        using (var schemaStream = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStream($"{ThisAssembly.RootNamespace}.version.schema.json")))
+        {
+            this.schema = JSchema.Load(new JsonTextReader(schemaStream));
+        }
+    }
+
+    [Fact]
+    public void VersionField_BasicScenarios()
+    {
+        json = JObject.Parse(@"{ ""version"": ""2.3"" }");
+        Assert.True(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""2.3-beta"" }");
+        Assert.True(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""2.3-beta-final"" }");
+        Assert.True(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""2.3-beta.2"" }");
+        Assert.True(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""2.3-beta.0"" }");
+        Assert.True(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""2.3-beta.01"" }");
+        Assert.True(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""1.2.3"" }");
+        Assert.True(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""1.2.3.4"" }");
+        Assert.True(json.IsValid(this.schema));
+
+        json = JObject.Parse(@"{ ""version"": ""02.3"" }");
+        Assert.False(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""2.03"" }");
+        Assert.False(json.IsValid(this.schema));
+    }
+
+    [Fact]
+    public void VersionField_HeightMacroPlacement()
+    {
+        // Valid uses
+        json = JObject.Parse(@"{ ""version"": ""2.3.0-{height}"" }");
+        Assert.True(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""2.3.0-{height}.beta"" }");
+        Assert.True(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""2.3.0-beta.{height}"" }");
+        Assert.True(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""2.3.0-beta+{height}"" }");
+        Assert.True(json.IsValid(this.schema));
+
+        // Invalid uses
+        json = JObject.Parse(@"{ ""version"": ""2.3.{height}-beta"" }");
+        Assert.False(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""2.3.0-beta-{height}"" }");
+        Assert.False(json.IsValid(this.schema));
+        json = JObject.Parse(@"{ ""version"": ""2.3.0-beta+height-{height}"" }");
+        Assert.False(json.IsValid(this.schema));
+    }
+}

--- a/src/NerdBank.GitVersioning/SemanticVersion.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersion.cs
@@ -23,12 +23,27 @@
         /// <summary>
         /// The regex pattern that a prerelease must match.
         /// </summary>
-        private static readonly Regex PrereleasePattern = new Regex(@"^-(?:[0-9A-Za-z-]+)(?:\.[0-9A-Za-z-]+)*$");
+        /// <remarks>
+        /// Keep in sync with the regex for the version field found in the version.schema.json file.
+        /// </remarks>
+        private static readonly Regex PrereleasePattern = new Regex("-(?:[\\da-z\\-]+|\\{height\\})(?:\\.(?:[\\da-z\\-]+|\\{height\\}))*", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// The regex pattern that build metadata must match.
         /// </summary>
-        private static readonly Regex BuildMetadataPattern = new Regex(@"^\+(?:[0-9A-Za-z-]+)(?:\.[0-9A-Za-z-]+)*$");
+        /// <remarks>
+        /// Keep in sync with the regex for the version field found in the version.schema.json file.
+        /// </remarks>
+        private static readonly Regex BuildMetadataPattern = new Regex("\\+(?:[\\da-z\\-]+|\\{height\\})(?:\\.(?:[\\da-z\\-]+|\\{height\\}))*", RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// The regular expression with capture groups for semantic versioning,
+        /// allowing for macros such as {height}.
+        /// </summary>
+        /// <remarks>
+        /// Keep in sync with the regex for the version field found in the version.schema.json file.
+        /// </remarks>
+        private static readonly Regex FullSemVerWithMacrosPattern = new Regex("^v?(?<major>0|[1-9][0-9]*)\\.(?<minor>0|[1-9][0-9]*)(?:\\.(?<patch>0|[1-9][0-9]*)(?:\\.(?<revision>0|[1-9][0-9]*))?)?(?<prerelease>" + PrereleasePattern + ")?(?<buildMetadata>" + BuildMetadataPattern + ")?$", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SemanticVersion"/> class.
@@ -90,7 +105,7 @@
         {
             Requires.NotNullOrEmpty(semanticVersion, nameof(semanticVersion));
 
-            Match m = FullSemVerPattern.Match(semanticVersion);
+            Match m = FullSemVerWithMacrosPattern.Match(semanticVersion);
             if (m.Success)
             {
                 var major = int.Parse(m.Groups["major"].Value);

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -60,6 +60,12 @@
         public int BuildNumberOffset { get; set; }
 
         /// <summary>
+        /// Gets or sets the minimum number of digits to use for numeric identifiers in SemVer 1.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? SemVer1NumericIdentifierPadding { get; set; }
+
+        /// <summary>
         /// Gets or sets an array of regular expressions that describes branch or tag names that should
         /// be built with PublicRelease=true as the default value on build servers.
         /// </summary>

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -160,6 +160,12 @@
         public int BuildNumber => Math.Max(0, this.Version.Build);
 
         /// <summary>
+        /// Gets the build number as it was specified in the version.json file.
+        /// </summary>
+        /// <value>The version specified, or -1 if none was specified.</value>
+        public int BuildNumberFromVersionOptions => this.VersionOptions?.Version?.Version?.Build ?? -1;
+
+        /// <summary>
         /// Gets or sets the major.minor version string.
         /// </summary>
         /// <value>

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -16,6 +16,11 @@
     public class VersionOracle
     {
         /// <summary>
+        /// A regex that matches on numeric identifiers for prerelease or build metadata.
+        /// </summary>
+        private static readonly Regex NumericIdentifierRegex = new Regex(@"(?<![\w-])(\d+)(?![\w-])");
+
+        /// <summary>
         /// The cloud build suppport, if any.
         /// </summary>
         private readonly ICloudBuild cloudBuild;
@@ -249,7 +254,7 @@
         /// when <see cref="PublicRelease"/> is <c>false</c>.
         /// </summary>
         public string SemVer1 =>
-            $"{this.Version.ToStringSafe(3)}{this.PrereleaseVersion}{this.SemVer1BuildMetadata}";
+            $"{this.Version.ToStringSafe(3)}{this.PrereleaseVersionSemVer1}{this.SemVer1BuildMetadata}";
 
         /// <summary>
         /// Gets a SemVer 2.0 compliant string that represents this version, including a +gCOMMITID suffix
@@ -258,11 +263,18 @@
         public string SemVer2 =>
             $"{this.Version.ToStringSafe(3)}{this.PrereleaseVersion}{this.SemVer2BuildMetadata}";
 
+        /// <summary>
+        /// Gets the minimum number of digits to use for numeric identifiers in SemVer 1.
+        /// </summary>
+        public int SemVer1NumericIdentifierPadding => this.VersionOptions?.SemVer1NumericIdentifierPadding ?? 4;
+
         private string SemVer1BuildMetadata =>
             this.PublicRelease ? string.Empty : $"-g{this.GitCommitIdShort}";
 
         private string SemVer2BuildMetadata =>
             FormatBuildMetadata(this.PublicRelease ? this.BuildMetadata : this.BuildMetadataWithCommitId);
+
+        private string PrereleaseVersionSemVer1 => MakePrereleaseSemVer1Compliant(this.PrereleaseVersion, SemVer1NumericIdentifierPadding);
 
         private VersionOptions.CloudBuildNumberOptions CloudBuildNumberOptions { get; }
 
@@ -343,5 +355,31 @@
         /// <param name="prereleaseOrBuildMetadata">The prerelease or build metadata.</param>
         /// <returns>The specified string, with macros substituted for actual values.</returns>
         private string ReplaceMacros(string prereleaseOrBuildMetadata) => prereleaseOrBuildMetadata?.Replace("{height}", this.VersionHeightWithOffset.ToString(CultureInfo.InvariantCulture));
+
+        /// <summary>
+        /// Converts a semver 2 compliant "-beta.5" prerelease tag to a semver 1 compatible one.
+        /// </summary>
+        /// <param name="prerelease">The semver 2 prerelease tag, including its leading hyphen.</param>
+        /// <param name="paddingSize">The minimum number of digits to use for any numeric identifier.</param>
+        /// <returns>A semver 1 compliant prerelease tag. For example "-beta-0005".</returns>
+        private static string MakePrereleaseSemVer1Compliant(string prerelease, int paddingSize)
+        {
+            if (string.IsNullOrEmpty(prerelease))
+            {
+                return prerelease;
+            }
+
+            string paddingFormatter = "{0:" + new string('0', paddingSize) + "}";
+
+            string semver1 = prerelease;
+
+            // Identify numeric identifiers and pad them.
+            Assumes.True(prerelease.StartsWith("-"));
+            semver1 = "-" + NumericIdentifierRegex.Replace(semver1.Substring(1), m => string.Format(CultureInfo.InvariantCulture, paddingFormatter, int.Parse(m.Groups[1].Value)));
+
+            semver1 = semver1.Replace('.', '-');
+
+            return semver1;
+        }
     }
 }

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -32,6 +32,13 @@
       "description": "A number to add to the git height when calculating the build number.",
       "default": 0
     },
+    "semVer1NumericIdentifierPadding": {
+      "type": "integer",
+      "description": "The minimum number of digits to use for numeric identifiers in SemVer 1.",
+      "default": 4,
+      "minimum": 1,
+      "maximum": 6
+    },
     "publicReleaseRefSpec": {
       "type": "array",
       "description": "An array of regular expressions that may match a ref (branch or tag) that should be built with PublicRelease=true as the default value. The ref matched against is in its canonical form (e.g. refs/heads/master)",

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -6,8 +6,8 @@
   "properties": {
     "version": {
       "type": "string",
-      "description": "The default x.y-pre version to use as the basis for version calculations.",
-      "pattern": "^v?(?<major>0|[1-9][0-9]*)\\.(?<minor>0|[1-9][0-9]*)(?:\\.(?<patch>0|[1-9][0-9]*))?(?<prerelease>-[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?(?<buildMetadata>\\+[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?$"
+      "description": "The major.minor-pre version to use as the basis for version calculations. If {height} is not used in this value and the value has fewer than the full major.minor.build.revision specified, \".{height}\" will be appended by the build.",
+      "pattern": "^v?(?<major>0|[1-9][0-9]*)\\.(?<minor>0|[1-9][0-9]*)(?:\\.(?<patch>0|[1-9][0-9]*)(?:\\.(?<revision>0|[1-9][0-9]*))?)?(?<prerelease>-(?:[\\da-z\\-]+|\\{height\\})(?:\\.(?:[\\da-z\\-]+|\\{height\\}))*)?(?<buildMetadata>\\+(?:[\\da-z\\-]+|\\{height\\})(?:\\.(?:[\\da-z\\-]+|\\{height\\}))*)?$"
     },
     "assemblyVersion": {
       "description": "The x.y version to use particularly for the AssemblyVersionAttribute instead of the default. This is useful when maintaining assembly binding compatibility on the desktop .NET Framework is important even though AssemblyFileVersion may change.",

--- a/src/Nerdbank.GitVersioning.NuGet/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/Nerdbank.GitVersioning.targets
@@ -69,6 +69,7 @@
       <Output TaskParameter="GitVersionHeight" PropertyName="GitVersionHeight" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildNumber" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildVersionNumberComponent" />
+      <Output TaskParameter="BuildNumberFromVersionJson" PropertyName="BuildNumberFromVersionJson" />
       <Output TaskParameter="PublicRelease" PropertyName="PublicRelease" />
       <Output TaskParameter="CloudBuildNumber" PropertyName="CloudBuildNumber" Condition=" '$(CloudBuildNumber)' == '' "/>
       <Output TaskParameter="BuildMetadataFragment" PropertyName="SemVerBuildSuffix" />

--- a/src/Nerdbank.GitVersioning.NuGet/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/Nerdbank.GitVersioning.targets
@@ -69,7 +69,6 @@
       <Output TaskParameter="GitVersionHeight" PropertyName="GitVersionHeight" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildNumber" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildVersionNumberComponent" />
-      <Output TaskParameter="BuildNumberFromVersionJson" PropertyName="BuildNumberFromVersionJson" />
       <Output TaskParameter="PublicRelease" PropertyName="PublicRelease" />
       <Output TaskParameter="CloudBuildNumber" PropertyName="CloudBuildNumber" Condition=" '$(CloudBuildNumber)' == '' "/>
       <Output TaskParameter="BuildMetadataFragment" PropertyName="SemVerBuildSuffix" />

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -141,12 +141,6 @@
         public int BuildNumber { get; private set; }
 
         /// <summary>
-        /// Gets the build number as specified in the version.json file.
-        /// </summary>
-        [Output]
-        public string BuildNumberFromVersionJson { get; private set; }
-
-        /// <summary>
         /// Gets the BuildNumber to set the cloud build to (if applicable).
         /// </summary>
         [Output]
@@ -181,7 +175,6 @@
                 this.SimpleVersion = oracle.SimpleVersion.ToString();
                 this.MajorMinorVersion = oracle.MajorMinorVersion.ToString();
                 this.BuildNumber = oracle.BuildNumber;
-                this.BuildNumberFromVersionJson = oracle.BuildNumberFromVersionOptions != -1 ? oracle.BuildNumberFromVersionOptions.ToString(CultureInfo.InvariantCulture) : string.Empty;
                 this.PrereleaseVersion = oracle.PrereleaseVersion;
                 this.GitCommitId = oracle.GitCommitId;
                 this.GitCommitIdShort = oracle.GitCommitIdShort;

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using Microsoft.Build.Framework;
@@ -140,6 +141,12 @@
         public int BuildNumber { get; private set; }
 
         /// <summary>
+        /// Gets the build number as specified in the version.json file.
+        /// </summary>
+        [Output]
+        public string BuildNumberFromVersionJson { get; private set; }
+
+        /// <summary>
         /// Gets the BuildNumber to set the cloud build to (if applicable).
         /// </summary>
         [Output]
@@ -174,6 +181,7 @@
                 this.SimpleVersion = oracle.SimpleVersion.ToString();
                 this.MajorMinorVersion = oracle.MajorMinorVersion.ToString();
                 this.BuildNumber = oracle.BuildNumber;
+                this.BuildNumberFromVersionJson = oracle.BuildNumberFromVersionOptions != -1 ? oracle.BuildNumberFromVersionOptions.ToString(CultureInfo.InvariantCulture) : string.Empty;
                 this.PrereleaseVersion = oracle.PrereleaseVersion;
                 this.GitCommitId = oracle.GitCommitId;
                 this.GitCommitIdShort = oracle.GitCommitIdShort;

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "src\\NerdBank.GitVersioning\\version.schema.json",
-  "version": "1.6",
+  "version": "2.0-beta",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
This allows folks who want to do particularly custom things with their versioning stamps to have a bit more data from the version.json file with which to work.

Fixes #115 