### PR TITLE
Use xUnit 2.2 and set debug type to full to get Test Explorer to work

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,10 @@ before_build:
 build_script:
 - ps: >-
     .\build.ps1
+test:
+  assemblies:
+    only:
+    - NerdBank.GitVersioning.Tests.dll
 artifacts:
 - path: bin\**\*.nupkg
 - path: bin\js\*.tgz

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
+    <DebugType>full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Nerdbank.GitVersioning.NuGet\build\*.targets">
@@ -19,11 +20,14 @@
   <ItemGroup>
     <PackageReference Include="7z.NET" Version="1.0.3" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Build" Version="14.3" Condition=" '$(TargetFramework)' == 'net45' " />
+    <PackageReference Include="Microsoft.Build" Version="14.3" Condition=" '$(TargetFramework)' == 'net452' " />
     <PackageReference Include="Xunit.Combinatorial" Version="1.1.12" />
-    <PackageReference Include="xunit" Version="2.1.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.1.1" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="1.6.20-beta-gfea83a8c9e" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
DebugType needs to be full for .NET Desktop tests or they show up as `External`