### PR TITLE
Partial performance improvement for #114

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using LibGit2Sharp;
 using Nerdbank.GitVersioning;
@@ -14,6 +15,14 @@ public class VersionOracleTests : RepoTestBase
     }
 
     private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, 10);
+
+    [Fact]
+    public void NotRepo()
+    {
+        // Seems safe to assume the system directory is not a repository.
+        var oracle = VersionOracle.Create(Environment.SystemDirectory);
+        Assert.Equal(0, oracle.VersionHeight);
+    }
 
     [Fact(Skip = "Unstable test. See issue #125")]
     public void Submodule_RecognizedWithCorrectVersion()

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -432,7 +432,8 @@
                 return !EqualityComparer<VersionOptions>.Default.Equals(workingVersion, committedVersion);
             }
 
-            return false; // a missing working version is allowed and not a change.
+            // A missing working version is a change only if it was previously commited.
+            return committedVersion != null;
         }
     }
 }


### PR DESCRIPTION
I was starting to work towards #94 but hit some performance issues and found open issue #114. I took a couple hours to understand the code then took a shot at minimizing the number of git calls (I think I've reduced the 5 or 6 calls to 1 or 2).

I didn't delete as much code from `GitExtensions.cs` as I'd like to since there were a lot of unit tests using the code. If this PR looks good, I can also reduce the code in `GitExtensions.cs` (and `GitExtensionsTests.cs`) to clean up the bit of duplication between `VersionOracle.cs` and `GitExtensions.cs` remaining.

Note, there are a couple code clean up commits in the PR. The performance improvement commit is in the middle. I tried to be pretty detailed in the commit message on that commit.