### PR TITLE
Implements CloudBuild support for Teamcity

### DIFF
--- a/doc/cloudbuild.md
+++ b/doc/cloudbuild.md
@@ -21,7 +21,7 @@ you can activate features for some cloud build systems, as follows
 Cloud builds tend to associate some calendar date or monotonically increasing
 build number to each build. These build numbers are not very informative, if at all.
 Instead, Nerdbank.GitVersioning can automatically set your cloud build's
-build number to equal the semver version calculated during your build. 
+build number to equal the semver version calculated during your build.
 
 Enable this feature by setting the `cloudBuild.buildNumber.enabled` field
 in your `version.json` file to `true`, as shown below:
@@ -76,10 +76,12 @@ in your `version.json` file to `true`, as shown below:
 }
 ```
 
-### Teamcity Specifics
-Teamcity does not expose the build branch by default as an environment variable. This can be exposed by
+## CI Server specific configurations
+
+### TeamCity
+TeamCity does not expose the build branch by default as an environment variable. This can be exposed by
 adding an environment variable with the value of `%teamcity.build.vcs.branch.<vcsid>%` where `<vcsid>` is
-the root id described on the teamcity VCS roots page. Details on this variable can be found on the teamcity
-docs [Here.](https://confluence.jetbrains.com/display/TCD8/Predefined+Build+Parameters)
+the root id described on the TeamCity VCS roots page. Details on this variable can be found on the
+[TeamCity docs](https://confluence.jetbrains.com/display/TCD8/Predefined+Build+Parameters).
 
 [Issue37]: https://github.com/AArnott/Nerdbank.GitVersioning/issues/37

--- a/doc/cloudbuild.md
+++ b/doc/cloudbuild.md
@@ -76,4 +76,10 @@ in your `version.json` file to `true`, as shown below:
 }
 ```
 
+### Teamcity Specifics
+Teamcity does not expose the build branch by default as an environment variable. This can be exposed by
+adding an environment variable with the value of `%teamcity.build.vcs.branch.<vcsid>%` where `<vcsid>` is
+the root id described on the teamcity VCS roots page. Details on this variable can be found on the teamcity
+docs [Here.](https://confluence.jetbrains.com/display/TCD8/Predefined+Build+Parameters)
+
 [Issue37]: https://github.com/AArnott/Nerdbank.GitVersioning/issues/37

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -436,6 +436,8 @@ public class BuildIntegrationTests : RepoTestBase
             new object[] { CloudBuild.AppVeyor.SetItem("APPVEYOR_REPO_BRANCH", branchName) },
             new object[] { CloudBuild.VSTS.SetItem("BUILD_SOURCEBRANCH", $"refs/heads/{branchName}") },
             new object[] { CloudBuild.VSTS.SetItem("BUILD_SOURCEBRANCH", branchName) }, // VSTS building a github repo
+            new object[] { CloudBuild.Teamcity.SetItem("BUILD_GIT_BRANCH", $"refs/heads/{branchName}") },
+            new object[] { CloudBuild.Teamcity.SetItem("BUILD_GIT_BRANCH", branchName) },
         };
     }
 
@@ -1028,11 +1030,16 @@ public class BuildIntegrationTests : RepoTestBase
             .Add("APPVEYOR_PULL_REQUEST_NUMBER", string.Empty)
             // VSTS
             .Add("SYSTEM_TEAMPROJECTID", string.Empty)
-            .Add("BUILD_SOURCEBRANCH", string.Empty);
+            .Add("BUILD_SOURCEBRANCH", string.Empty)
+            // Teamcity
+            .Add("BUILD_VCS_NUMBER", string.Empty)
+            .Add("BUILD_GIT_BRANCH", string.Empty);
         public static readonly ImmutableDictionary<string, string> VSTS = SuppressEnvironment
             .SetItem("SYSTEM_TEAMPROJECTID", "1");
         public static readonly ImmutableDictionary<string, string> AppVeyor = SuppressEnvironment
             .SetItem("APPVEYOR", "True");
+        public static readonly ImmutableDictionary<string, string> Teamcity = SuppressEnvironment
+            .SetItem("BUILD_VCS_NUMBER", "1");
     }
 
     private static class Targets

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -437,7 +437,6 @@ public class BuildIntegrationTests : RepoTestBase
             new object[] { CloudBuild.VSTS.SetItem("BUILD_SOURCEBRANCH", $"refs/heads/{branchName}") },
             new object[] { CloudBuild.VSTS.SetItem("BUILD_SOURCEBRANCH", branchName) }, // VSTS building a github repo
             new object[] { CloudBuild.Teamcity.SetItem("BUILD_GIT_BRANCH", $"refs/heads/{branchName}") },
-            new object[] { CloudBuild.Teamcity.SetItem("BUILD_GIT_BRANCH", branchName) },
         };
     }
 

--- a/src/NerdBank.GitVersioning/CloudBuildServices/TeamCity.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/TeamCity.cs
@@ -24,8 +24,8 @@
 
         public IReadOnlyDictionary<string, string> SetCloudBuildVariable(string name, string value, TextWriter stdout, TextWriter stderr)
         {
-            (stdout ?? Console.Out).WriteLine($"##teamcity[setParameter name='GitVersion.{name}' value='{value}']");
-            (stdout ?? Console.Out).WriteLine($"##teamcity[setParameter name='system.GitVersion.{name}' value='{value}']");
+            (stdout ?? Console.Out).WriteLine($"##teamcity[setParameter name='{name}' value='{value}']");
+            (stdout ?? Console.Out).WriteLine($"##teamcity[setParameter name='system.{name}' value='{value}']");
 
             return new Dictionary<string, string>();
         }

--- a/src/NerdBank.GitVersioning/CloudBuildServices/TeamCity.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/TeamCity.cs
@@ -4,6 +4,13 @@
     using System.Collections.Generic;
     using System.IO;
 
+    /// <summary>
+    /// TeamCity CI build support.
+    /// </summary>
+    /// <remarks>
+    /// The TeamCIty-specific properties referenced here are documented here:
+    /// https://confluence.jetbrains.com/display/TCD8/Predefined+Build+Parameters
+    /// </remarks>
     internal class TeamCity : ICloudBuild
     {
         public string BuildingBranch => CloudBuild.ShouldStartWith(Environment.GetEnvironmentVariable("BUILD_GIT_BRANCH"), "refs/heads/");

--- a/src/NerdBank.GitVersioning/CloudBuildServices/TeamCity.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/TeamCity.cs
@@ -6,7 +6,7 @@
 
     internal class TeamCity : ICloudBuild
     {
-        public string BuildingBranch => null;
+        public string BuildingBranch => CloudBuild.ShouldStartWith(Environment.GetEnvironmentVariable("BUILD_GIT_BRANCH"), "refs/heads/");
 
         public string BuildingTag => null;
 
@@ -18,11 +18,15 @@
 
         public IReadOnlyDictionary<string, string>  SetCloudBuildNumber(string buildNumber, TextWriter stdout, TextWriter stderr)
         {
+            (stdout ?? Console.Out).WriteLine($"##teamcity[buildNumber '{buildNumber}']");
             return new Dictionary<string, string>();
         }
 
         public IReadOnlyDictionary<string, string> SetCloudBuildVariable(string name, string value, TextWriter stdout, TextWriter stderr)
         {
+            (stdout ?? Console.Out).WriteLine($"##teamcity[setParameter name='GitVersion.{name}' value='{value}']");
+            (stdout ?? Console.Out).WriteLine($"##teamcity[setParameter name='system.GitVersion.{name}' value='{value}']");
+
             return new Dictionary<string, string>();
         }
     }


### PR DESCRIPTION
Hi there,

We're using this project to version with teamcity and noticed that the cloud build support wasn't implemented.

I took @onovotny's advice and made the implementation very similar to GitVersion. I tried adding tests for the integration, hopefully i've done all that needs to be done.

When setting up with teamcity you have to manually expose the branch name through a environment variable, I called this `BUILD_GIT_BRANCH` however the name can easily be changed. I'll update the cloud build docs to include this.

#37