### PR TITLE
Also set GitBuildVersionSimple cloud variable

### DIFF
--- a/doc/cloudbuild.md
+++ b/doc/cloudbuild.md
@@ -59,6 +59,7 @@ range.
 | --- | --- | --- |
 | GitAssemblyInformationalVersion | AssemblyInformationalVersion | 1.3.1+g15e1898f47
 | GitBuildVersion | BuildVersion | 1.3.1.57621
+| GitBuildVersionSimple | BuildVersionSimple | 1.3.1
 
 This means you can use these variables in subsequent steps in your cloud build
 such as publishing artifacts, so that your richer version information can be

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -433,14 +433,24 @@ public class BuildIntegrationTests : RepoTestBase
 
             var buildResult = await this.BuildAsync();
             AssertStandardProperties(versionOptions, buildResult);
+
+            // Assert GitBuildVersion was set
             string conditionallyExpectedMessage = UnitTestCloudBuildPrefix + expectedMessage
                 .Replace("{NAME}", "GitBuildVersion")
                 .Replace("{VALUE}", buildResult.BuildVersion);
             Assert.Contains(alwaysExpectedMessage, buildResult.LoggedEvents.Select(e => e.Message.TrimEnd()));
             Assert.Contains(conditionallyExpectedMessage, buildResult.LoggedEvents.Select(e => e.Message.TrimEnd()));
 
+            // Assert GitBuildVersionSimple was set
+            conditionallyExpectedMessage = UnitTestCloudBuildPrefix + expectedMessage
+                .Replace("{NAME}", "GitBuildVersionSimple")
+                .Replace("{VALUE}", buildResult.BuildVersionSimple);
+            Assert.Contains(alwaysExpectedMessage, buildResult.LoggedEvents.Select(e => e.Message.TrimEnd()));
+            Assert.Contains(conditionallyExpectedMessage, buildResult.LoggedEvents.Select(e => e.Message.TrimEnd()));
+
             // Assert that project properties are also set.
             Assert.Equal(buildResult.BuildVersion, buildResult.GitBuildVersion);
+            Assert.Equal(buildResult.BuildVersionSimple, buildResult.GitBuildVersionSimple);
             Assert.Equal(buildResult.AssemblyInformationalVersion, buildResult.GitAssemblyInformationalVersion);
 
             // Assert that env variables were also set in context of the build.
@@ -450,12 +460,22 @@ public class BuildIntegrationTests : RepoTestBase
             this.WriteVersionFile(versionOptions);
             buildResult = await this.BuildAsync();
             AssertStandardProperties(versionOptions, buildResult);
+
+            // Assert GitBuildVersion was not set
             conditionallyExpectedMessage = UnitTestCloudBuildPrefix + expectedMessage
                 .Replace("{NAME}", "GitBuildVersion")
                 .Replace("{VALUE}", buildResult.BuildVersion);
             Assert.Contains(alwaysExpectedMessage, buildResult.LoggedEvents.Select(e => e.Message.TrimEnd()));
             Assert.DoesNotContain(conditionallyExpectedMessage, buildResult.LoggedEvents.Select(e => e.Message.TrimEnd()));
             Assert.NotEqual(buildResult.BuildVersion, buildResult.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitBuildVersion"));
+
+            // Assert GitBuildVersionSimple was not set
+            conditionallyExpectedMessage = UnitTestCloudBuildPrefix + expectedMessage
+                .Replace("{NAME}", "GitBuildVersionSimple")
+                .Replace("{VALUE}", buildResult.BuildVersionSimple);
+            Assert.Contains(alwaysExpectedMessage, buildResult.LoggedEvents.Select(e => e.Message.TrimEnd()));
+            Assert.DoesNotContain(conditionallyExpectedMessage, buildResult.LoggedEvents.Select(e => e.Message.TrimEnd()));
+            Assert.NotEqual(buildResult.BuildVersionSimple, buildResult.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitBuildVersionSimple"));
         }
     }
 
@@ -944,6 +964,7 @@ public class BuildIntegrationTests : RepoTestBase
         public string RootNamespace => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("RootNamespace");
 
         public string GitBuildVersion => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitBuildVersion");
+        public string GitBuildVersionSimple => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitBuildVersionSimple");
         public string GitAssemblyInformationalVersion => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitAssemblyInformationalVersion");
 
         public override string ToString()

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -209,6 +209,7 @@
                 {
                     { "GitAssemblyInformationalVersion", this.AssemblyInformationalVersion },
                     { "GitBuildVersion", this.Version.ToString() },
+                    { "GitBuildVersionSimple", this.SimpleVersion.ToString() },
                 };
             }
         }


### PR DESCRIPTION
For use cases that require just a simple semver, also set the
GitBuildVersionSimple cloud build variable from BuildVersionSimple.