### PR TITLE
Support for the new NuGet dependency 

### DIFF
--- a/src/Nerdbank.GitVersioning.NuGet/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.NuGet/build/Nerdbank.GitVersioning.targets
@@ -28,6 +28,11 @@
       $(GenerateNuspecDependsOn)
     </GenerateNuspecDependsOn>
 
+    <GetPackageVersionDependsOn>
+      GetBuildVersion;
+      $(GetPackageVersionDependsOn)
+    </GetPackageVersionDependsOn>
+    
     <!-- Suppress assembly version info generation if not obviously compiling an assembly. -->
     <GenerateAssemblyVersionInfo Condition=" '$(GenerateAssemblyVersionInfo)' == '' and '$(TargetExt)' != '.dll' and '$(TargetExt)' != '.exe'">false</GenerateAssemblyVersionInfo>
 


### PR DESCRIPTION
Hooks into the new NuGet property `GetPackageVersionDependsOn` defined in  https://github.com/NuGet/NuGet.Client/pull/1915