### PR TITLE
Add support for GitLab CI

### DIFF
--- a/src/NerdBank.GitVersioning/CloudBuild.cs
+++ b/src/NerdBank.GitVersioning/CloudBuild.cs
@@ -18,6 +18,7 @@
             new TeamCity(),
             new AtlassianBamboo(), 
             new Jenkins(),
+            new GitLab(),
         };
 
         /// <summary>

--- a/src/NerdBank.GitVersioning/CloudBuildServices/GitLab.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/GitLab.cs
@@ -1,0 +1,40 @@
+﻿namespace Nerdbank.GitVersioning.CloudBuildServices
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Diagnostics;
+    using System.IO;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// The GitLab-specific properties referenced here are documented here:
+    /// https://docs.gitlab.com/ce/ci/variables/README.html
+    /// </remarks>
+    internal class GitLab : ICloudBuild
+    {
+        public string BuildingBranch => Environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME");
+
+        public string BuildingRef => Environment.GetEnvironmentVariable("CI_COMMIT_TAG");
+
+        public string BuildingTag => Environment.GetEnvironmentVariable("CI_COMMIT_TAG");
+
+        public string GitCommitId => Environment.GetEnvironmentVariable("CI_COMMIT_SHA");
+
+        public bool IsApplicable => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITLAB_CI"));
+
+        public bool IsPullRequest => false;
+
+        public IReadOnlyDictionary<string, string> SetCloudBuildNumber(string buildNumber, TextWriter stdout, TextWriter stderr)
+        {
+            return new Dictionary<string, string>();
+        }
+
+        public IReadOnlyDictionary<string, string> SetCloudBuildVariable(string name, string value, TextWriter stdout, TextWriter stderr)
+        {
+            return new Dictionary<string, string>();
+        }
+    }
+}


### PR DESCRIPTION
It looks like NB.GV isn't able to detect the branch name (e.g. master) when building in GitLab CI.

This PR adds support for GitLab CI and reading branch names & other data from the environment variables set by GitLab CI.

Not sure I got the semantics of all variables right, you can find an overview of which variables are set here:
https://docs.gitlab.com/ce/ci/variables/README.html

For those running on GitLab and looking for an immediate solution, here's how you can patch your `.gitlab-ci.yml` file to have GitLab pretend to be VSTS:

```
variables:
  BUILD_SOURCEBRANCH: '$CI_COMMIT_REF_NAME'
  SYSTEM_TEAMPROJECTID: '$CI_PROJECT_ID'
```