### PR TITLE
Add dotnet tool: nbgv 

### DIFF
--- a/doc/dotnet-cli.md
+++ b/doc/dotnet-cli.md
@@ -2,4 +2,6 @@
 
 The dotnet CLI works very much like [full MSBuild](msbuild.md). Just use `dotnet build` instead of `msbuild.exe`.
 
+Check out our [nbgv .NET Core CLI tool](nbgv-cli.md) to install Nerdbank.GitVersioning and maintain your repos/projects more easily.
+
 [DNX never supported extensible versioning systems](https://github.com/aspnet/dnx/issues/3178). But DNX is dead now, so you probably don't care.

--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -1,0 +1,39 @@
+# Using the nbgv .NET Core CLI tool
+
+Perform a one-time install of the `nbgv` tool using the following dotnet CLI command:
+
+```cmd
+dotnet tool install -g nbgv
+```
+
+You may then use the `nbgv` tool to install Nerdbank.GitVersioning into your repos, as well as query and update version information for your repos and projects.
+
+Install Nerdbank.GitVersioning into your repo using this command from within your repo:
+
+```cmd
+nbgv install
+```
+
+This will create your initial `version.json` file.
+It will also add/modify your `Directory.Build.props` file in the root of your repo to add the `PackageReference` to the latest `Nerdbank.GitVersioning` package available on nuget.org.
+
+## Learn more
+
+There are several more sub-commands and switches to each to help you build and maintain your projects, find a commit that built a particular version later on, create tags, etc.
+
+Use the `--help` switch on the `nbgv` command or one of its sub-commands to learn about the sub-commands available and how to use them. For example, this is the basic usage help text:
+
+```cmd
+nbgv --help
+usage: nbgv <command> [<args>]
+
+    install        Prepares a project to have version stamps applied
+                   using Nerdbank.GitVersioning.
+    get-version    Gets the version information for a project.
+    set-version    Updates the version stamp that is applied to a
+                   project.
+    tag            Creates a git tag to mark a version.
+    get-commits    Gets the commit(s) that match a given version.
+    cloud          Communicates with the ambient cloud build to set the
+                   build number and/or other cloud build variables.
+```

--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -2,7 +2,7 @@
 
 Perform a one-time install of the `nbgv` tool using the following dotnet CLI command:
 
-```cmd
+```ps1
 dotnet tool install -g nbgv
 ```
 
@@ -10,12 +10,22 @@ You may then use the `nbgv` tool to install Nerdbank.GitVersioning into your rep
 
 Install Nerdbank.GitVersioning into your repo using this command from within your repo:
 
-```cmd
+```ps1
 nbgv install
 ```
 
 This will create your initial `version.json` file.
 It will also add/modify your `Directory.Build.props` file in the root of your repo to add the `PackageReference` to the latest `Nerdbank.GitVersioning` package available on nuget.org.
+
+## CI Builds
+
+If scripting for running in a CI build where global impact from installing a tool is undesirable, you can localize the tool installation:
+
+```ps1
+dotnet tool install --tool-path . nbgv
+```
+
+At this point you can launch the tool using `.\nbgv` in your build script.
 
 ## Learn more
 

--- a/doc/nuget-acquisition.md
+++ b/doc/nuget-acquisition.md
@@ -1,7 +1,7 @@
-# Nerdbank.GitVersioning installation via NuGet 
+# Nerdbank.GitVersioning installation via NuGet
 
 Install the Nerdbank.GitVersioning package using the Visual Studio
-NuGet Package Manager GUI, or the NuGet Package Manager Console: 
+NuGet Package Manager GUI, or the NuGet Package Manager Console:
 
 ```
 Install-Package Nerdbank.GitVersioning
@@ -57,7 +57,7 @@ Note: After first installing the package, you need to commit the version file so
 it will be picked up during the build's version generation. If you build prior to committing,
 the version number produced will be 0.0.x.
 
-# Next steps 
+# Next steps
 
-You must also create [a version.json file](versionJson.md) in your repo. 
+You must also create [a version.json file](versionJson.md) in your repo.
 Learn more about [how .NET projects are stamped with version information](dotnet.md).

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ What sets this package apart from other git-based versioning projects is:
 
 You can install Nerdbank.GitVersioning into your projects via NuGet or NPM.
 
+* Use the [nbgv .NET Core CLI tool](doc/nbgv-cli.md) (recommended)
 * [NuGet installation instructions](doc/nuget-acquisition.md)
 * [NPM installation instructions](doc/npm-acquisition.md)
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,5 +5,15 @@
     <OutputPath>$(MSBuildThisFileDirectory)..\bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)strongname.snk</AssemblyOriginatorKeyFile>
+
+    <authors>Andrew Arnott</authors>
+    <owners>aarnott</owners>
+    <PackageTags>git commit versioning version assemblyinfo</PackageTags>
   </PropertyGroup>
+
+  <Target Name="SetNuSpecProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
+    <PropertyGroup>
+      <PackageLicenseUrl>https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/$(GitCommitIdShort)/LICENSE.txt</PackageLicenseUrl>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -1,13 +1,15 @@
 ﻿namespace Nerdbank.GitVersioning
 {
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
-    using Newtonsoft.Json.Serialization;
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using Validation;
     using System.Linq;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using Newtonsoft.Json.Linq;
+    using Newtonsoft.Json.Serialization;
+    using Validation;
+
     /// <summary>
     /// Extension methods for interacting with the version.txt file.
     /// </summary>
@@ -122,7 +124,15 @@
         /// </summary>
         /// <param name="projectDirectory">The path to the directory which may (or its ancestors may) define the version.txt file.</param>
         /// <returns>The version information read from the file, or <c>null</c> if the file wasn't found.</returns>
-        public static VersionOptions GetVersion(string projectDirectory)
+        public static VersionOptions GetVersion(string projectDirectory) => GetVersion(projectDirectory, out string _);
+
+        /// <summary>
+        /// Reads the version.txt file and returns the <see cref="Version"/> and prerelease tag from it.
+        /// </summary>
+        /// <param name="projectDirectory">The path to the directory which may (or its ancestors may) define the version.txt file.</param>
+        /// <param name="actualDirectory">Set to the actual directory that the version file was found in, which may be <paramref name="projectDirectory"/> or one of its ancestors.</param>
+        /// <returns>The version information read from the file, or <c>null</c> if the file wasn't found.</returns>
+        public static VersionOptions GetVersion(string projectDirectory, out string actualDirectory)
         {
             Requires.NotNullOrEmpty(projectDirectory, nameof(projectDirectory));
 
@@ -138,6 +148,7 @@
                         var result = TryReadVersionFile(sr, isJsonFile: false);
                         if (result != null)
                         {
+                            actualDirectory = searchDirectory;
                             return result;
                         }
                     }
@@ -156,6 +167,7 @@
                             if (result != null)
                             {
                                 JsonConvert.PopulateObject(versionJsonContent, result, VersionOptions.GetJsonSettings());
+                                actualDirectory = searchDirectory;
                                 return result;
                             }
                         }
@@ -164,6 +176,7 @@
                     }
                     else if (result != null)
                     {
+                        actualDirectory = searchDirectory;
                         return result;
                     }
                 }
@@ -171,6 +184,7 @@
                 searchDirectory = parentDirectory;
             }
 
+            actualDirectory = null;
             return null;
         }
 

--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -199,12 +199,12 @@
         }
 
         /// <summary>
-        /// Writes the version.txt file to a directory within a repo with the specified version information.
+        /// Writes the version.json file to a directory within a repo with the specified version information.
         /// </summary>
         /// <param name="projectDirectory">
-        /// The path to the directory in which to write the version.txt file.
+        /// The path to the directory in which to write the version.json file.
         /// The file's impact will be all descendent projects and directories from this specified directory,
-        /// except where any of those directories have their own version.txt file.
+        /// except where any of those directories have their own version.json file.
         /// </param>
         /// <param name="version">The version information to write to the file.</param>
         /// <returns>The path to the file written.</returns>

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -25,6 +25,12 @@
         /// </summary>
         private const int DefaultSemVer1NumericIdentifierPadding = 4;
 
+        /////// <summary>
+        /////// The $schema field that should be serialized when writing
+        /////// </summary>
+        ////[JsonProperty(PropertyName = "$schema")]
+        ////private string Schema => "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json";
+
         /// <summary>
         /// Gets or sets the default version to use.
         /// </summary>

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -35,7 +35,7 @@
                 gitRepoDirectory = projectDirectory;
             }
 
-            using (var git = OpenGitRepo(gitRepoDirectory))
+            using (var git = GitExtensions.OpenGitRepo(gitRepoDirectory))
             {
                 return new VersionOracle(projectDirectory, git, cloudBuild, overrideBuildNumberOffset, projectPathRelativeToGitRepoRoot);
             }
@@ -355,58 +355,6 @@
 
         private static string FormatBuildMetadataSemVerV1(IEnumerable<string> identifiers) =>
             (identifiers?.Any() ?? false) ? "-" + string.Join("-", identifiers) : string.Empty;
-
-        private static LibGit2Sharp.Repository OpenGitRepo(string repoRoot)
-        {
-            Requires.NotNullOrEmpty(repoRoot, nameof(repoRoot));
-            var gitDir = FindGitDir(repoRoot);
-
-            // Override Config Search paths to empty path to avoid new Repository instance to lookup for Global\System .gitconfig file
-            LibGit2Sharp.GlobalSettings.SetConfigSearchPaths(LibGit2Sharp.ConfigurationLevel.Global, string.Empty);
-            LibGit2Sharp.GlobalSettings.SetConfigSearchPaths(LibGit2Sharp.ConfigurationLevel.System, string.Empty);
-
-            return gitDir == null ? null : new LibGit2Sharp.Repository(gitDir);
-        }
-
-        private static string FindGitDir(string startingDir)
-        {
-            while (startingDir != null)
-            {
-                var dirOrFilePath = Path.Combine(startingDir, ".git");
-                if (Directory.Exists(dirOrFilePath))
-                {
-                    return dirOrFilePath;
-                }
-                else if (File.Exists(dirOrFilePath))
-                {
-                    var relativeGitDirPath = ReadGitDirFromFile(dirOrFilePath);
-                    if (!string.IsNullOrWhiteSpace(relativeGitDirPath))
-                    {
-                        var fullGitDirPath = Path.GetFullPath(Path.Combine(startingDir, relativeGitDirPath));
-                        if (Directory.Exists(fullGitDirPath))
-                        {
-                            return fullGitDirPath;
-                        }
-                    }
-                }
-
-                startingDir = Path.GetDirectoryName(startingDir);
-            }
-
-            return null;
-        }
-
-        private static string ReadGitDirFromFile(string fileName)
-        {
-            const string expectedPrefix = "gitdir: ";
-            var firstLineOfFile = File.ReadLines(fileName).FirstOrDefault();
-            if (firstLineOfFile?.StartsWith(expectedPrefix) ?? false)
-            {
-                return firstLineOfFile.Substring(expectedPrefix.Length); // strip off the prefix, leaving just the path
-            }
-
-            return null;
-        }
 
         private static Version GetAssemblyVersion(Version version, VersionOptions versionOptions)
         {

--- a/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.Tasks.csproj
+++ b/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.Tasks.csproj
@@ -16,9 +16,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
-  <Target Name="SetNuSpecProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
+  <Target Name="SetNuSpecPropertiesFinal" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion;SetNuSpecProperties">
     <PropertyGroup>
-      <PackageLicenseUrl>https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/$(GitCommitIdShort)/LICENSE.txt</PackageLicenseUrl>
       <LibGit2SharpNativeBinaries>$(NuGetPackageRoot)libgit2sharp.nativebinaries\1.0.165\</LibGit2SharpNativeBinaries>
       <NuspecProperties>$(NuspecProperties);LicenseUrl=$(PackageLicenseUrl);Version=$(Version);BaseOutputPath=$(OutputPath);LibGit2SharpNativeBinaries=$(LibGit2SharpNativeBinaries)</NuspecProperties>
     </PropertyGroup>

--- a/src/Nerdbank.GitVersioning.Tasks/SetCloudBuildVariables.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/SetCloudBuildVariables.cs
@@ -65,8 +65,8 @@
 
                 if (isUnitTest)
                 {
-                    PipeOutputToMSBuildLog(testStdOut.ToString(), warning: false);
-                    PipeOutputToMSBuildLog(testStdErr.ToString(), warning: true);
+                    this.PipeOutputToMSBuildLog(testStdOut.ToString(), warning: false);
+                    this.PipeOutputToMSBuildLog(testStdErr.ToString(), warning: true);
                 }
             }
             else

--- a/src/Nerdbank.GitVersioning.sln
+++ b/src/Nerdbank.GitVersioning.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.gitignore = ..\.gitignore
 		..\appveyor.yml = ..\appveyor.yml
 		..\build.ps1 = ..\build.ps1
+		Directory.Build.props = Directory.Build.props
 		..\init.ps1 = ..\init.ps1
 		nuget.config = nuget.config
 		..\readme.md = ..\readme.md
@@ -25,7 +26,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nerdbank.GitVersioning.Task
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSBuildExtensionTask", "MSBuildExtensionTask\MSBuildExtensionTask.csproj", "{568CD02D-49C4-49DB-A34D-2DE9D7A0FE85}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nbgv", "nbgv\nbgv.csproj", "{EF4DAF23-6CE9-48C5-84C5-80AC80D3D07D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nbgv", "nbgv\nbgv.csproj", "{EF4DAF23-6CE9-48C5-84C5-80AC80D3D07D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Nerdbank.GitVersioning.sln
+++ b/src/Nerdbank.GitVersioning.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nerdbank.GitVersioning.Task
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSBuildExtensionTask", "MSBuildExtensionTask\MSBuildExtensionTask.csproj", "{568CD02D-49C4-49DB-A34D-2DE9D7A0FE85}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nbgv", "nbgv\nbgv.csproj", "{EF4DAF23-6CE9-48C5-84C5-80AC80D3D07D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +51,10 @@ Global
 		{568CD02D-49C4-49DB-A34D-2DE9D7A0FE85}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{568CD02D-49C4-49DB-A34D-2DE9D7A0FE85}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{568CD02D-49C4-49DB-A34D-2DE9D7A0FE85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF4DAF23-6CE9-48C5-84C5-80AC80D3D07D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF4DAF23-6CE9-48C5-84C5-80AC80D3D07D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF4DAF23-6CE9-48C5-84C5-80AC80D3D07D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF4DAF23-6CE9-48C5-84C5-80AC80D3D07D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -1,0 +1,258 @@
+namespace Nerdbank.GitVersioning.Tool
+{
+    using System;
+    using System.Collections.Generic;
+    using System.CommandLine;
+    using System.ComponentModel.DataAnnotations;
+    using System.IO;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    internal class Program
+    {
+        private const string DefaultVersionSpec = "1.0-beta";
+
+        private const string DefaultVersionInfoFormat = "json";
+
+        private enum ExitCodes
+        {
+            OK,
+            NoGitRepo,
+            InvalidVersionSpec,
+            BadCloudVariable,
+            DuplicateCloudVariable,
+            NoCloudBuildEnvDetected,
+            UnsupportedFormat,
+        }
+
+
+        private static ExitCodes exitCode;
+
+        public static int Main(string[] args)
+        {
+            ArgumentSyntax.Parse(args, syntax =>
+            {
+                var commandText = string.Empty;
+                var projectPath = string.Empty;
+                var versionJsonRoot = string.Empty;
+                var version = string.Empty;
+                IReadOnlyList<string> cloudVariables = Array.Empty<string>();
+                var format = string.Empty;
+
+                var install = syntax.DefineCommand("install", ref commandText, "Prepares a project to have version stamps applied using Nerdbank.GitVersioning.");
+                syntax.DefineOption("p|path", ref versionJsonRoot, "The path to the directory that should contain the version.json file. The default is the root of the git repo.");
+                syntax.DefineOption("v|version", ref version, $"The initial version to set. The default is {DefaultVersionSpec}.");
+
+                var getVersion = syntax.DefineCommand("get-version", ref commandText, "Gets the version information for a project.");
+                syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the current directory.");
+                syntax.DefineOption("f|format", ref format, $"The format to write the version information. Allowed values are: json. The default is {DefaultVersionInfoFormat}.");
+
+                var setVersion = syntax.DefineCommand("set-version", ref commandText, "Updates the version stamp that is applied to a project.");
+                syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the root directory of the repo that spans the current directory, or an existing version.json file, if applicable.");
+                syntax.DefineParameter("version", ref version, "The version to set.");
+
+                var cloud = syntax.DefineCommand("cloud", ref commandText, "Communicates with the ambient cloud build to set the build number and/or other cloud build variables.");
+                syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory used to calculate the version. The default is the current directory. Ignored if the -v option is specified.");
+                syntax.DefineOption("v|version", ref version, "The string to use for the cloud build number. If not specified, the computed version will be used.");
+                syntax.DefineOptionList("d|define", ref cloudVariables, "Additional cloud build variables to define. Each should be in the NAME=VALUE syntax.");
+
+                if (install.IsActive)
+                {
+                    exitCode = OnInstallCommand(versionJsonRoot, version);
+                }
+                else if (getVersion.IsActive)
+                {
+                    exitCode = OnGetVersionCommand(projectPath, format);
+                }
+                else if (setVersion.IsActive)
+                {
+                    exitCode = OnSetVersionCommand(projectPath, version);
+                }
+                else if (cloud.IsActive)
+                {
+                    exitCode = OnCloudCommand(projectPath, version, cloudVariables);
+                }
+            });
+
+            return (int)exitCode;
+        }
+
+        private static ExitCodes OnInstallCommand(string versionJsonRoot, string version)
+        {
+            if (!SemanticVersion.TryParse(string.IsNullOrEmpty(version) ? DefaultVersionSpec : version, out var semver))
+            {
+                Console.Error.WriteLine($"\"{version}\" is not a semver-compliant version spec.");
+                return ExitCodes.InvalidVersionSpec;
+            }
+
+            var options = new VersionOptions
+            {
+                Version = semver,
+                PublicReleaseRefSpec = new string[]
+                {
+                    @"^refs/heads/master$",
+                    @"^refs/heads/v\d+(?:\.\d+)?$",
+                },
+                CloudBuild = new VersionOptions.CloudBuildOptions
+                {
+                    BuildNumber = new VersionOptions.CloudBuildNumberOptions
+                    {
+                        Enabled = true,
+                    },
+                },
+            };
+            string searchPath = GetSpecifiedOrCurrentDirectoryPath(versionJsonRoot);
+            if (!Directory.Exists(searchPath))
+            {
+                Console.Error.WriteLine("\"{0}\" is not an existing directory.", searchPath);
+                return ExitCodes.NoGitRepo;
+            }
+
+            var repository = GitExtensions.OpenGitRepo(searchPath);
+            if (repository == null)
+            {
+                Console.Error.WriteLine("No git repo found at or above: \"{0}\"", searchPath);
+                return ExitCodes.NoGitRepo;
+            }
+
+            if (string.IsNullOrEmpty(versionJsonRoot))
+            {
+                versionJsonRoot = repository.Info.WorkingDirectory;
+            }
+
+            var existingOptions = VersionFile.GetVersion(versionJsonRoot);
+            if (existingOptions != null)
+            {
+                if (!string.IsNullOrEmpty(version))
+                {
+                    var setVersionExitCode = OnSetVersionCommand(versionJsonRoot, version);
+                    if (setVersionExitCode != ExitCodes.OK)
+                    {
+                        return setVersionExitCode;
+                    }
+                }
+            }
+            else
+            {
+                string versionJsonPath= VersionFile.SetVersion(versionJsonRoot, options);
+                LibGit2Sharp.Commands.Stage(repository, versionJsonPath);
+            }
+
+            // TODO: Add/modify Directory.Build.props to reference NB.GV package
+            // TODO: git add Directory.Build.props.
+
+            return ExitCodes.OK;
+        }
+
+        private static string GetSpecifiedOrCurrentDirectoryPath(string versionJsonRoot)
+        {
+            return Path.GetFullPath(string.IsNullOrEmpty(versionJsonRoot) ? "." : versionJsonRoot);
+        }
+
+        private static ExitCodes OnGetVersionCommand(string projectPath, string format)
+        {
+            if (string.IsNullOrEmpty(format))
+            {
+                format = DefaultVersionInfoFormat;
+            }
+
+            string searchPath = GetSpecifiedOrCurrentDirectoryPath(projectPath);
+            var oracle = VersionOracle.Create(searchPath);
+            switch (format.ToLowerInvariant())
+            {
+                case "json":
+                    Console.WriteLine(JsonConvert.SerializeObject(oracle, Formatting.Indented));
+                    break;
+                default:
+                    Console.Error.WriteLine("Unsupported format: {0}", format);
+                    return ExitCodes.UnsupportedFormat;
+            }
+
+            return ExitCodes.OK;
+        }
+
+        private static ExitCodes OnSetVersionCommand(string projectPath, string version)
+        {
+            if (!SemanticVersion.TryParse(string.IsNullOrEmpty(version) ? DefaultVersionSpec : version, out var semver))
+            {
+                Console.Error.WriteLine($"\"{version}\" is not a semver-compliant version spec.");
+                return ExitCodes.InvalidVersionSpec;
+            }
+
+            var defaultOptions = new VersionOptions
+            {
+                Version = semver,
+            };
+
+            string searchPath = GetSpecifiedOrCurrentDirectoryPath(projectPath);
+            var repository = GitExtensions.OpenGitRepo(searchPath);
+            var existingOptions = VersionFile.GetVersion(searchPath, out string actualDirectory);
+            string versionJsonPath;
+            if (existingOptions != null)
+            {
+                existingOptions.Version = semver;
+                versionJsonPath = VersionFile.SetVersion(actualDirectory, existingOptions);
+            }
+            else if (string.IsNullOrEmpty(projectPath))
+            {
+                if (repository == null)
+                {
+                    Console.Error.WriteLine("No version file and no git repo found at or above: \"{0}\"", searchPath);
+                    return ExitCodes.NoGitRepo;
+                }
+
+                versionJsonPath = VersionFile.SetVersion(repository.Info.WorkingDirectory, defaultOptions);
+            }
+            else
+            {
+                versionJsonPath = VersionFile.SetVersion(projectPath, defaultOptions);
+            }
+
+            if (repository != null)
+            {
+                LibGit2Sharp.Commands.Stage(repository, versionJsonPath);
+            }
+
+            return ExitCodes.OK;
+        }
+
+        private static ExitCodes OnCloudCommand(string projectPath, string version, IReadOnlyList<string> cloudVariables)
+        {
+            var variables = new Dictionary<string, string>();
+            foreach (string def in cloudVariables)
+            {
+                string[] split = def.Split(new char[] { '=' }, 2);
+                if (split.Length < 2)
+                {
+                    Console.Error.WriteLine($"\"{def}\" is not in the NAME=VALUE syntax required for cloud variables.");
+                    return ExitCodes.BadCloudVariable;
+                }
+
+                if (variables.ContainsKey(split[0]))
+                {
+                    Console.Error.WriteLine($"Cloud build variable \"{split[0]}\" specified more than once.");
+                    return ExitCodes.DuplicateCloudVariable;
+                }
+
+                variables.Add(split[0], split[1]);
+            }
+
+            ICloudBuild activeCloudBuild = CloudBuild.Active;
+            if (activeCloudBuild != null)
+            {
+                activeCloudBuild.SetCloudBuildNumber(version, Console.Out, Console.Error);
+                foreach (var pair in variables)
+                {
+                    activeCloudBuild.SetCloudBuildVariable(pair.Key, pair.Value, Console.Out, Console.Error);
+                }
+
+                return ExitCodes.OK;
+            }
+            else
+            {
+                Console.Error.WriteLine("No cloud build detected.");
+                return ExitCodes.NoCloudBuildEnvDetected;
+            }
+        }
+    }
+}

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -164,23 +164,28 @@ namespace Nerdbank.GitVersioning.Tool
             MSBuild.Project propsFile;
             if (File.Exists(directoryBuildPropsPath))
             {
-                propsFile = MSBuild.Project.FromFile(directoryBuildPropsPath, null);
+                propsFile = new MSBuild.Project(directoryBuildPropsPath);
             }
             else
             {
                 propsFile = new MSBuild.Project();
             }
 
-            propsFile.AddItem(
-                "PackageReference",
-                "Nerdbank.GitVersioning",
-                new Dictionary<string, string>
-                {
-                    { "Version", "2.1.23" }, // TODO: use the latest version... somehow...
-                    { "PrivateAssets", "all" },
-                });
+            const string PackageReferenceItemType = "PackageReference";
+            const string PackageId = "Nerdbank.GitVersioning";
+            if (!propsFile.GetItemsByEvaluatedInclude(PackageId).Any(i => i.ItemType == "PackageReference"))
+            {
+                propsFile.AddItem(
+                    PackageReferenceItemType,
+                    PackageId,
+                    new Dictionary<string, string>
+                    {
+                        { "Version", "2.1.23" }, // TODO: use the latest version... somehow...
+                        { "PrivateAssets", "all" },
+                    });
 
-            propsFile.Save(directoryBuildPropsPath);
+                propsFile.Save(directoryBuildPropsPath);
+            }
 
             LibGit2Sharp.Commands.Stage(repository, directoryBuildPropsPath);
 

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -3,16 +3,18 @@ namespace Nerdbank.GitVersioning.Tool
     using System;
     using System.Collections.Generic;
     using System.CommandLine;
-    using System.ComponentModel.DataAnnotations;
     using System.IO;
+    using System.Linq;
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
+    using MSBuild = Microsoft.Build.Evaluation;
 
     internal class Program
     {
         private const string DefaultVersionSpec = "1.0-beta";
 
-        private const string DefaultVersionInfoFormat = "json";
+        private const string DefaultVersionInfoFormat = "text";
+
+        private const string DefaultRef = "HEAD";
 
         private enum ExitCodes
         {
@@ -23,6 +25,7 @@ namespace Nerdbank.GitVersioning.Tool
             DuplicateCloudVariable,
             NoCloudBuildEnvDetected,
             UnsupportedFormat,
+            NoMatchingVersion,
         }
 
 
@@ -38,6 +41,7 @@ namespace Nerdbank.GitVersioning.Tool
                 var version = string.Empty;
                 IReadOnlyList<string> cloudVariables = Array.Empty<string>();
                 var format = string.Empty;
+                bool quiet = false;
 
                 var install = syntax.DefineCommand("install", ref commandText, "Prepares a project to have version stamps applied using Nerdbank.GitVersioning.");
                 syntax.DefineOption("p|path", ref versionJsonRoot, "The path to the directory that should contain the version.json file. The default is the root of the git repo.");
@@ -45,11 +49,20 @@ namespace Nerdbank.GitVersioning.Tool
 
                 var getVersion = syntax.DefineCommand("get-version", ref commandText, "Gets the version information for a project.");
                 syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the current directory.");
-                syntax.DefineOption("f|format", ref format, $"The format to write the version information. Allowed values are: json. The default is {DefaultVersionInfoFormat}.");
+                syntax.DefineOption("f|format", ref format, $"The format to write the version information. Allowed values are: text, json. The default is {DefaultVersionInfoFormat}.");
 
                 var setVersion = syntax.DefineCommand("set-version", ref commandText, "Updates the version stamp that is applied to a project.");
                 syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the root directory of the repo that spans the current directory, or an existing version.json file, if applicable.");
                 syntax.DefineParameter("version", ref version, "The version to set.");
+
+                var tag = syntax.DefineCommand("tag", ref commandText, "Creates a git tag to mark a version.");
+                syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the root directory of the repo that spans the current directory, or an existing version.json file, if applicable.");
+                syntax.DefineParameter("versionOrRef", ref version, $"The a.b.c[.d] version or git ref to be tagged. If not specified, {DefaultRef} is used.");
+
+                var getCommits = syntax.DefineCommand("get-commits", ref commandText, "Gets the commit(s) that match a given version.");
+                syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the root directory of the repo that spans the current directory, or an existing version.json file, if applicable.");
+                syntax.DefineOption("q|quiet", ref quiet, "Use minimal output.");
+                syntax.DefineParameter("version", ref version, "The a.b.c[.d] version to find.");
 
                 var cloud = syntax.DefineCommand("cloud", ref commandText, "Communicates with the ambient cloud build to set the build number and/or other cloud build variables.");
                 syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory used to calculate the version. The default is the current directory. Ignored if the -v option is specified.");
@@ -67,6 +80,14 @@ namespace Nerdbank.GitVersioning.Tool
                 else if (setVersion.IsActive)
                 {
                     exitCode = OnSetVersionCommand(projectPath, version);
+                }
+                else if (tag.IsActive)
+                {
+                    exitCode = OnTagCommand(projectPath, version);
+                }
+                else if (getCommits.IsActive)
+                {
+                    exitCode = OnGetCommitsCommand(projectPath, version, quiet);
                 }
                 else if (cloud.IsActive)
                 {
@@ -134,12 +155,34 @@ namespace Nerdbank.GitVersioning.Tool
             }
             else
             {
-                string versionJsonPath= VersionFile.SetVersion(versionJsonRoot, options);
+                string versionJsonPath = VersionFile.SetVersion(versionJsonRoot, options);
                 LibGit2Sharp.Commands.Stage(repository, versionJsonPath);
             }
 
-            // TODO: Add/modify Directory.Build.props to reference NB.GV package
-            // TODO: git add Directory.Build.props.
+            // Create/update the Directory.Build.props file in the directory of the version.json file to add the NB.GV package.
+            string directoryBuildPropsPath = Path.Combine(versionJsonRoot, "Directory.Build.props");
+            MSBuild.Project propsFile;
+            if (File.Exists(directoryBuildPropsPath))
+            {
+                propsFile = MSBuild.Project.FromFile(directoryBuildPropsPath, null);
+            }
+            else
+            {
+                propsFile = new MSBuild.Project();
+            }
+
+            propsFile.AddItem(
+                "PackageReference",
+                "Nerdbank.GitVersioning",
+                new Dictionary<string, string>
+                {
+                    { "Version", "2.1.23" }, // TODO: use the latest version... somehow...
+                    { "PrivateAssets", "all" },
+                });
+
+            propsFile.Save(directoryBuildPropsPath);
+
+            LibGit2Sharp.Commands.Stage(repository, directoryBuildPropsPath);
 
             return ExitCodes.OK;
         }
@@ -160,6 +203,13 @@ namespace Nerdbank.GitVersioning.Tool
             var oracle = VersionOracle.Create(searchPath);
             switch (format.ToLowerInvariant())
             {
+                case "text":
+                    Console.WriteLine("Version:                      {0}", oracle.Version);
+                    Console.WriteLine("AssemblyVersion:              {0}", oracle.AssemblyVersion);
+                    Console.WriteLine("AssemblyInformationalVersion: {0}", oracle.AssemblyInformationalVersion);
+                    Console.WriteLine("NuGet package Version:        {0}", oracle.NuGetPackageVersion);
+                    Console.WriteLine("NPM package Version:          {0}", oracle.NpmPackageVersion);
+                    break;
                 case "json":
                     Console.WriteLine(JsonConvert.SerializeObject(oracle, Formatting.Indented));
                     break;
@@ -216,6 +266,96 @@ namespace Nerdbank.GitVersioning.Tool
             return ExitCodes.OK;
         }
 
+        private static ExitCodes OnTagCommand(string projectPath, string versionOrRef)
+        {
+            if (string.IsNullOrEmpty(versionOrRef))
+            {
+                versionOrRef = DefaultRef;
+            }
+
+            string searchPath = GetSpecifiedOrCurrentDirectoryPath(projectPath);
+
+            var repository = GitExtensions.OpenGitRepo(searchPath);
+            if (repository == null)
+            {
+                Console.Error.WriteLine("No git repo found at or above: \"{0}\"", searchPath);
+                return ExitCodes.NoGitRepo;
+            }
+
+            LibGit2Sharp.GitObject refObject = null;
+            try
+            {
+                repository.RevParse(versionOrRef, out var reference, out refObject);
+            }
+            catch (LibGit2Sharp.NotFoundException) { }
+
+            var commit = refObject as LibGit2Sharp.Commit;
+            if (commit == null)
+            {
+                if (!Version.TryParse(versionOrRef, out Version parsedVersion))
+                {
+                    Console.Error.WriteLine($"\"{versionOrRef}\" is not a simple a.b.c[.d] version spec or git reference.");
+                    return ExitCodes.InvalidVersionSpec;
+                }
+
+                string repoRelativeProjectDir = GetRepoRelativePath(searchPath, repository);
+                var candidateCommits = GitExtensions.GetCommitsFromVersion(repository, parsedVersion, repoRelativeProjectDir).ToList();
+                if (candidateCommits.Count == 0)
+                {
+                    Console.Error.WriteLine("No commit with that version found.");
+                    return ExitCodes.NoMatchingVersion;
+                }
+                else if (candidateCommits.Count > 1)
+                {
+                    PrintCommits(false, searchPath, repository, candidateCommits, includeOptions: true);
+                    int selection;
+                    do
+                    {
+                        Console.Write("Enter selection: ");
+                    }
+                    while (!int.TryParse(Console.ReadLine(), out selection) || selection > candidateCommits.Count || selection < 1);
+                    commit = candidateCommits[selection - 1];
+                }
+                else
+                {
+                    commit = candidateCommits.Single();
+                }
+            }
+
+            var oracle = new VersionOracle(searchPath, repository, commit, CloudBuild.Active);
+            oracle.PublicRelease = true; // assume a public release so we don't get a redundant -gCOMMITID in the tag name
+            string tagName = $"v{oracle.SemVer2}";
+            repository.Tags.Add(tagName, commit);
+            Console.WriteLine("{0} tag created at {1}.", tagName, commit.Sha);
+            Console.WriteLine("Remember to push to a remote: git push origin {0}", tagName);
+
+            return ExitCodes.OK;
+        }
+
+        private static ExitCodes OnGetCommitsCommand(string projectPath, string version, bool quiet)
+        {
+            if (!Version.TryParse(version, out Version parsedVersion))
+            {
+                Console.Error.WriteLine($"\"{version}\" is not a simple a.b.c[.d] version spec.");
+                return ExitCodes.InvalidVersionSpec;
+            }
+
+            string searchPath = GetSpecifiedOrCurrentDirectoryPath(projectPath);
+
+            var repository = GitExtensions.OpenGitRepo(searchPath);
+            if (repository == null)
+            {
+                Console.Error.WriteLine("No git repo found at or above: \"{0}\"", searchPath);
+                return ExitCodes.NoGitRepo;
+            }
+
+            string repoRelativeProjectDir = GetRepoRelativePath(searchPath, repository);
+            var candidateCommits = GitExtensions.GetCommitsFromVersion(repository, parsedVersion, repoRelativeProjectDir).ToList();
+            PrintCommits(quiet, searchPath, repository, candidateCommits);
+
+            return ExitCodes.OK;
+        }
+
         private static ExitCodes OnCloudCommand(string projectPath, string version, IReadOnlyList<string> cloudVariables)
         {
             var variables = new Dictionary<string, string>();
@@ -252,6 +392,33 @@ namespace Nerdbank.GitVersioning.Tool
             {
                 Console.Error.WriteLine("No cloud build detected.");
                 return ExitCodes.NoCloudBuildEnvDetected;
+            }
+        }
+
+        private static string GetRepoRelativePath(string searchPath, LibGit2Sharp.Repository repository)
+        {
+            return searchPath.Substring(repository.Info.WorkingDirectory.Length);
+        }
+
+        private static void PrintCommits(bool quiet, string projectDirectory, LibGit2Sharp.Repository repository, List<LibGit2Sharp.Commit> candidateCommits, bool includeOptions = false)
+        {
+            int index = 1;
+            foreach (var commit in candidateCommits)
+            {
+                if (includeOptions)
+                {
+                    Console.Write($"{index++,3}. ");
+                }
+
+                if (quiet)
+                {
+                    Console.WriteLine(commit.Sha);
+                }
+                else
+                {
+                    var oracle = new VersionOracle(projectDirectory, repository, commit, null);
+                    Console.WriteLine($"{commit.Sha} {oracle.Version} {commit.MessageShort}");
+                }
             }
         }
     }

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -36,72 +36,78 @@ namespace Nerdbank.GitVersioning.Tool
             NoMatchingVersion,
         }
 
-
         private static ExitCodes exitCode;
 
         public static int Main(string[] args)
         {
+            var commandText = string.Empty;
+            var projectPath = string.Empty;
+            var versionJsonRoot = string.Empty;
+            var version = string.Empty;
+            IReadOnlyList<string> cloudVariables = Array.Empty<string>();
+            var format = string.Empty;
+            bool quiet = false;
+
+            ArgumentCommand<string> install = null;
+            ArgumentCommand<string> getVersion = null;
+            ArgumentCommand<string> setVersion = null;
+            ArgumentCommand<string> tag = null;
+            ArgumentCommand<string> getCommits = null;
+            ArgumentCommand<string> cloud = null;
+
             ArgumentSyntax.Parse(args, syntax =>
             {
-                var commandText = string.Empty;
-                var projectPath = string.Empty;
-                var versionJsonRoot = string.Empty;
-                var version = string.Empty;
-                IReadOnlyList<string> cloudVariables = Array.Empty<string>();
-                var format = string.Empty;
-                bool quiet = false;
-
-                var install = syntax.DefineCommand("install", ref commandText, "Prepares a project to have version stamps applied using Nerdbank.GitVersioning.");
+                install = syntax.DefineCommand("install", ref commandText, "Prepares a project to have version stamps applied using Nerdbank.GitVersioning.");
                 syntax.DefineOption("p|path", ref versionJsonRoot, "The path to the directory that should contain the version.json file. The default is the root of the git repo.");
                 syntax.DefineOption("v|version", ref version, $"The initial version to set. The default is {DefaultVersionSpec}.");
 
-                var getVersion = syntax.DefineCommand("get-version", ref commandText, "Gets the version information for a project.");
+                getVersion = syntax.DefineCommand("get-version", ref commandText, "Gets the version information for a project.");
                 syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the current directory.");
                 syntax.DefineOption("f|format", ref format, $"The format to write the version information. Allowed values are: text, json. The default is {DefaultVersionInfoFormat}.");
 
-                var setVersion = syntax.DefineCommand("set-version", ref commandText, "Updates the version stamp that is applied to a project.");
+                setVersion = syntax.DefineCommand("set-version", ref commandText, "Updates the version stamp that is applied to a project.");
                 syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the root directory of the repo that spans the current directory, or an existing version.json file, if applicable.");
                 syntax.DefineParameter("version", ref version, "The version to set.");
 
-                var tag = syntax.DefineCommand("tag", ref commandText, "Creates a git tag to mark a version.");
+                tag = syntax.DefineCommand("tag", ref commandText, "Creates a git tag to mark a version.");
                 syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the root directory of the repo that spans the current directory, or an existing version.json file, if applicable.");
                 syntax.DefineParameter("versionOrRef", ref version, $"The a.b.c[.d] version or git ref to be tagged. If not specified, {DefaultRef} is used.");
 
-                var getCommits = syntax.DefineCommand("get-commits", ref commandText, "Gets the commit(s) that match a given version.");
+                getCommits = syntax.DefineCommand("get-commits", ref commandText, "Gets the commit(s) that match a given version.");
                 syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the root directory of the repo that spans the current directory, or an existing version.json file, if applicable.");
                 syntax.DefineOption("q|quiet", ref quiet, "Use minimal output.");
                 syntax.DefineParameter("version", ref version, "The a.b.c[.d] version to find.");
 
-                var cloud = syntax.DefineCommand("cloud", ref commandText, "Communicates with the ambient cloud build to set the build number and/or other cloud build variables.");
+                cloud = syntax.DefineCommand("cloud", ref commandText, "Communicates with the ambient cloud build to set the build number and/or other cloud build variables.");
                 syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory used to calculate the version. The default is the current directory. Ignored if the -v option is specified.");
                 syntax.DefineOption("v|version", ref version, "The string to use for the cloud build number. If not specified, the computed version will be used.");
                 syntax.DefineOptionList("d|define", ref cloudVariables, "Additional cloud build variables to define. Each should be in the NAME=VALUE syntax.");
-
-                if (install.IsActive)
-                {
-                    exitCode = OnInstallCommand(versionJsonRoot, version);
-                }
-                else if (getVersion.IsActive)
-                {
-                    exitCode = OnGetVersionCommand(projectPath, format);
-                }
-                else if (setVersion.IsActive)
-                {
-                    exitCode = OnSetVersionCommand(projectPath, version);
-                }
-                else if (tag.IsActive)
-                {
-                    exitCode = OnTagCommand(projectPath, version);
-                }
-                else if (getCommits.IsActive)
-                {
-                    exitCode = OnGetCommitsCommand(projectPath, version, quiet);
-                }
-                else if (cloud.IsActive)
-                {
-                    exitCode = OnCloudCommand(projectPath, version, cloudVariables);
-                }
             });
+
+            if (install.IsActive)
+            {
+                exitCode = OnInstallCommand(versionJsonRoot, version);
+            }
+            else if (getVersion.IsActive)
+            {
+                exitCode = OnGetVersionCommand(projectPath, format);
+            }
+            else if (setVersion.IsActive)
+            {
+                exitCode = OnSetVersionCommand(projectPath, version);
+            }
+            else if (tag.IsActive)
+            {
+                exitCode = OnTagCommand(projectPath, version);
+            }
+            else if (getCommits.IsActive)
+            {
+                exitCode = OnGetCommitsCommand(projectPath, version, quiet);
+            }
+            else if (cloud.IsActive)
+            {
+                exitCode = OnCloudCommand(projectPath, version, cloudVariables);
+            }
 
             return (int)exitCode;
         }

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -5,7 +5,15 @@ namespace Nerdbank.GitVersioning.Tool
     using System.CommandLine;
     using System.IO;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Newtonsoft.Json;
+    using NuGet.Common;
+    using NuGet.Configuration;
+    using NuGet.PackageManagement;
+    using NuGet.Protocol;
+    using NuGet.Protocol.Core.Types;
+    using NuGet.Resolver;
     using MSBuild = Microsoft.Build.Evaluation;
 
     internal class Program
@@ -175,12 +183,13 @@ namespace Nerdbank.GitVersioning.Tool
             const string PackageId = "Nerdbank.GitVersioning";
             if (!propsFile.GetItemsByEvaluatedInclude(PackageId).Any(i => i.ItemType == "PackageReference"))
             {
+                string packageVersion = GetLatestPackageVersionAsync(PackageId).GetAwaiter().GetResult();
                 propsFile.AddItem(
                     PackageReferenceItemType,
                     PackageId,
                     new Dictionary<string, string>
                     {
-                        { "Version", "2.1.23" }, // TODO: use the latest version... somehow...
+                        { "Version", packageVersion }, // TODO: use the latest version... somehow...
                         { "PrivateAssets", "all" },
                     });
 
@@ -190,11 +199,6 @@ namespace Nerdbank.GitVersioning.Tool
             LibGit2Sharp.Commands.Stage(repository, directoryBuildPropsPath);
 
             return ExitCodes.OK;
-        }
-
-        private static string GetSpecifiedOrCurrentDirectoryPath(string versionJsonRoot)
-        {
-            return Path.GetFullPath(string.IsNullOrEmpty(versionJsonRoot) ? "." : versionJsonRoot);
         }
 
         private static ExitCodes OnGetVersionCommand(string projectPath, string format)
@@ -398,6 +402,41 @@ namespace Nerdbank.GitVersioning.Tool
                 Console.Error.WriteLine("No cloud build detected.");
                 return ExitCodes.NoCloudBuildEnvDetected;
             }
+        }
+
+        private static async Task<string> GetLatestPackageVersionAsync(string packageId, CancellationToken cancellationToken = default)
+        {
+            var providers = new List<Lazy<INuGetResourceProvider>>();
+            providers.AddRange(Repository.Provider.GetCoreV3());  // Add v3 API support
+
+            // We SHOULD use all the sources from the target's nuget.config file.
+            // But I don't know what API to use to do that.
+            var packageSource = new PackageSource("https://api.nuget.org/v3/index.json");
+
+            var sourceRepository = new SourceRepository(packageSource, providers);
+            var resolutionContext = new ResolutionContext(
+                DependencyBehavior.Highest,
+                includePrelease: false,
+                includeUnlisted: false,
+                VersionConstraints.None);
+
+            // The target framework doesn't matter, since our package doesn't depend on this for its target projects.
+            var framework = new NuGet.Frameworks.NuGetFramework("net45");
+
+            var pkg = await NuGetPackageManager.GetLatestVersionAsync(
+                packageId,
+                framework,
+                resolutionContext,
+                sourceRepository,
+                NullLogger.Instance,
+                cancellationToken);
+
+            return pkg.LatestVersion.ToNormalizedString();
+        }
+
+        private static string GetSpecifiedOrCurrentDirectoryPath(string versionJsonRoot)
+        {
+            return Path.GetFullPath(string.IsNullOrEmpty(versionJsonRoot) ? "." : versionJsonRoot);
         }
 
         private static string GetRepoRelativePath(string searchPath, LibGit2Sharp.Repository repository)

--- a/src/nbgv/nbgv.csproj
+++ b/src/nbgv/nbgv.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ToolCommandName>nbgv</ToolCommandName>
+    <PackAsTool>True</PackAsTool>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>Nerdbank.GitVersioning.Tool</RootNamespace>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
+    <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="1.6.20-beta-gfea83a8c9e" PrivateAssets="all" />
+    <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NerdBank.GitVersioning\NerdBank.GitVersioning.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/nbgv/nbgv.csproj
+++ b/src/nbgv/nbgv.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.PackageManagement" Version="4.7.0" />
+    <PackageReference Include="NuGet.PackageManagement" Version="4.7.0" NoWarn="NU1701" />
     <PackageReference Include="NuGet.Resolver" Version="4.7.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="1.6.20-beta-gfea83a8c9e" PrivateAssets="all" />

--- a/src/nbgv/nbgv.csproj
+++ b/src/nbgv/nbgv.csproj
@@ -7,12 +7,14 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>Nerdbank.GitVersioning.Tool</RootNamespace>
     <LangVersion>7.3</LangVersion>
+    <Description>A .NET Core Tool that can install, read and set version information based on git history, using Nerdbank.GitVersioning.</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="1.6.20-beta-gfea83a8c9e" PrivateAssets="all" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Build" Version="15.7.179" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/nbgv/nbgv.csproj
+++ b/src/nbgv/nbgv.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NuGet.PackageManagement.NetStandard" Version="4.6.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="1.6.20-beta-gfea83a8c9e" PrivateAssets="all" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />

--- a/src/nbgv/nbgv.csproj
+++ b/src/nbgv/nbgv.csproj
@@ -11,7 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.PackageManagement.NetStandard" Version="4.6.0" />
+    <PackageReference Include="NuGet.PackageManagement" Version="4.7.0" />
+    <PackageReference Include="NuGet.Resolver" Version="4.7.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="1.6.20-beta-gfea83a8c9e" PrivateAssets="all" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -9,5 +9,6 @@
     <add key="myget.org/F/aarnott" value="https://www.myget.org/F/aarnott/api/v3/index.json" protocolVersion="3" />
     <add key="PInvoke CI" value="https://ci.appveyor.com/nuget/pinvoke" />
     <add key="AppVeyor CI" value="https://ci.appveyor.com/nuget/nerdbank-gitversioning" />
+    <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
As a high-level summary of the new nbgv dotnet console tool, here is the top-level usage text:

```
usage: nbgv <command> [<args>]

    install        Prepares a project to have version stamps applied
                   using Nerdbank.GitVersioning.
    get-version    Gets the version information for a project.
    set-version    Updates the version stamp that is applied to a
                   project.
    tag            Creates a git tag to mark a version.
    get-commits    Gets the commit(s) that match a given version.
    cloud          Communicates with the ambient cloud build to set the
                   build number and/or other cloud build variables.
```

Additional help is available for each individual command.

Todo:

* [x] Add documentation 
* [x] Don't execute commands when `--help` trails them
* [x] get-version should accept an optional git ref for which to return version info

Closes #181