### PR TITLE
Add a CodeGenerator for Visual Basic

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -289,6 +289,7 @@
                 case "visual basic":
                 case "visualbasic":
                 case "vb":
+                    return new VisualBasicCodeGenerator();
                 default:
                     this.Log.LogError("Code provider not available for language: {0}. No version info will be embedded into assembly.", this.CodeLanguage);
                     return null;
@@ -358,6 +359,34 @@
             internal override void EndThisAssemblyClass()
             {
                 this.codeBuilder.AppendLine("}");
+            }
+        }
+
+        private class VisualBasicCodeGenerator : CodeGenerator
+        {
+            internal override void AddComment(string comment)
+            {
+                this.AddCodeComment(comment, "'");
+            }
+
+            internal override void DeclareAttribute(Type type, string arg)
+            {
+                this.codeBuilder.AppendLine($"<Assembly: {type.FullName}(\"{arg}\")>");
+            }
+
+            internal override void StartThisAssemblyClass()
+            {
+                this.codeBuilder.AppendLine("Partial Friend NotInheritable Class ThisAssembly");
+            }
+
+            internal override void AddThisAssemblyMember(string name, string value)
+            {
+                this.codeBuilder.AppendLine($"    Friend Const {name} As String = \"{value}\"");
+            }
+
+            internal override void EndThisAssemblyClass()
+            {
+                this.codeBuilder.AppendLine("End Class");
             }
         }
 #endif


### PR DESCRIPTION
This will enable a build server (with just Dotnet SDK and .Net Framework installed) to generate the AssemblyVersionInfo file for Visual Basic.

Before I got the following error on my build server:
`C:\Users\TFSBUILD\.nuget\packages\nerdbank.gitversioning\2.1.65\build\Nerdbank.GitVersioning.targets(141,5): error : Code provider not available for language: VB. No version info will be embedded into assembly. [D:\tfs_agent_1\_work\1\s\MyProject\MyProject.vbproj]`