### PR TITLE
Workaround/fix for libgit2sharp custom marshal type cast failure

### DIFF
--- a/src/MSBuildExtensionTask/ContextAwareTask.cs
+++ b/src/MSBuildExtensionTask/ContextAwareTask.cs
@@ -80,10 +80,15 @@
 
             protected override Assembly Load(AssemblyName assemblyName)
             {
+                // Always load libgit2sharp in the default context.
+                // Something about the p/invoke done in that library with its custom marshaler
+                // doesn't sit well with Core CLR 2.x.
+                // See https://github.com/AArnott/Nerdbank.GitVersioning/issues/215 and https://github.com/dotnet/coreclr/issues/19654
+                AssemblyLoadContext preferredContext = assemblyName.Name.Equals("libgit2sharp", StringComparison.OrdinalIgnoreCase) ? Default : this;
                 string assemblyPath = Path.Combine(this.loaderTask.ManagedDllDirectory, assemblyName.Name) + ".dll";
                 if (File.Exists(assemblyPath))
                 {
-                    return LoadFromAssemblyPath(assemblyPath);
+                    return preferredContext.LoadFromAssemblyPath(assemblyPath);
                 }
 
                 return Default.LoadFromAssemblyName(assemblyName);

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -247,7 +247,7 @@
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Log.LogErrorFromException(ex);
+                this.Log.LogErrorFromException(ex);
                 return false;
             }
         }


### PR DESCRIPTION
It seems that although we were always consistently loading libgit2sharp in our own load context (as we do with all assemblies we can find in our directory), the CLR fails in its p/invoke custom marshaler unless we've loaded it in the default load context -- as if someone else loaded it in the Default context and somehow we were using one context to create the `FilePath` object and the other to cast it to `FilePath`. That doesn't seem to be the case here, but at least loading it in the default context works around what may be a bug (https://github.com/dotnet/coreclr/issues/19654).

Fixes #215