### PR TITLE
Fixes failures on non-Windows platforms

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -5,6 +5,7 @@
     using System.Globalization;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
     using MSBuildExtensionTask;
@@ -169,7 +170,7 @@
         [Output]
         public ITaskItem[] CloudBuildVersionVars { get; private set; }
 
-        protected override string UnmanagedDllDirectory => GitExtensions.FindLibGit2NativeBinaries(Path.Combine(this.TargetsPath, "MSBuildFull"));
+        protected override string UnmanagedDllDirectory => GitExtensions.FindLibGit2NativeBinaries(this.TargetsPath);
 
         protected override bool ExecuteInner()
         {
@@ -179,7 +180,7 @@
                 {
                     Requires.Argument(!Path.IsPathRooted(this.ProjectPathRelativeToGitRepoRoot), nameof(this.ProjectPathRelativeToGitRepoRoot), "Path must be relative.");
                     Requires.Argument(!(
-                        this.ProjectPathRelativeToGitRepoRoot.Contains(".." + Path.DirectorySeparatorChar) || 
+                        this.ProjectPathRelativeToGitRepoRoot.Contains(".." + Path.DirectorySeparatorChar) ||
                         this.ProjectPathRelativeToGitRepoRoot.Contains(".." + Path.AltDirectorySeparatorChar)),
                         nameof(this.ProjectPathRelativeToGitRepoRoot),
                         "Path must not use ..\\");

--- a/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
+++ b/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
@@ -22,18 +22,12 @@
     <file src="$BaseOutputPath$net461\Nerdbank.GitVersioning.Tasks.dll" target="build\MSBuildFull\Nerdbank.GitVersioning.Tasks.dll" />
     <file src="$BaseOutputPath$net461\Newtonsoft.Json.dll" target="build\MSBuildFull\Newtonsoft.Json.dll" />
     <file src="$BaseOutputPath$net461\Validation.dll" target="build\MSBuildFull\Validation.dll" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x64\native\git2-6311e88.dll" target="build\MSBuildFull\lib\win32\x64\git2-6311e88.dll" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x64\native\git2-6311e88.dll" target="build\MSBuildCore\lib\win32\x64\git2-6311e88.dll" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x64\native\git2-6311e88.pdb" target="build\MSBuildFull\lib\win32\x64\git2-6311e88.pdb" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x64\native\git2-6311e88.pdb" target="build\MSBuildCore\lib\win32\x64\git2-6311e88.pdb" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x86\native\git2-6311e88.dll" target="build\MSBuildFull\lib\win32\x86\git2-6311e88.dll" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x86\native\git2-6311e88.dll" target="build\MSBuildCore\lib\win32\x86\git2-6311e88.dll" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x86\native\git2-6311e88.pdb" target="build\MSBuildFull\lib\win32\x86\git2-6311e88.pdb" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x86\native\git2-6311e88.pdb" target="build\MSBuildCore\lib\win32\x86\git2-6311e88.pdb" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\osx\native\libgit2-6311e88.dylib" target="build\MSBuildFull\lib\osx\libgit2-6311e88.dylib" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\osx\native\libgit2-6311e88.dylib" target="build\MSBuildCore\lib\osx\libgit2-6311e88.dylib" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\linux-x64\native\libgit2-6311e88.so" target="build\MSBuildFull\lib\linux\x86_64\libgit2-6311e88.so" />
-    <file src="$LibGit2SharpNativeBinaries$runtimes\linux-x64\native\libgit2-6311e88.so" target="build\MSBuildCore\lib\linux\x86_64\libgit2-6311e88.so" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x64\native\git2-6311e88.dll" target="build\lib\win32\x64\git2-6311e88.dll" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x64\native\git2-6311e88.pdb" target="build\lib\win32\x64\git2-6311e88.pdb" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x86\native\git2-6311e88.dll" target="build\lib\win32\x86\git2-6311e88.dll" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x86\native\git2-6311e88.pdb" target="build\lib\win32\x86\git2-6311e88.pdb" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\osx\native\libgit2-6311e88.dylib" target="build\lib\osx\libgit2-6311e88.dylib" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\linux-x64\native\libgit2-6311e88.so" target="build\lib\linux\x86_64\libgit2-6311e88.so" />
     <file src="$LibGit2SharpNativeBinaries$libgit2\LibGit2Sharp.dll.config" target="build\MSBuildCore\LibGit2Sharp.dll.config" />
     <file src="$BaseOutputPath$netcoreapp2.0\LibGit2Sharp.dll" target="build\MSBuildCore\LibGit2Sharp.dll" />
     <file src="$BaseOutputPath$netcoreapp2.0\MSBuildExtensionTask.dll" target="build\MSBuildCore\MSBuildExtensionTask.dll" />


### PR DESCRIPTION
Also reduce package size by ~6MB by removing the redundancy in storing libgit2 (native binaries).

Fixes #217