### PR TITLE
[WIP] Allow skipping commits that don't contain changes relative to the project path.

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -38,6 +38,12 @@
         public string DefaultPublicRelease { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether only commits that contain changes
+        /// in the project path contribute to git version height.
+        /// </summary>
+        public string SkipCommitsWithoutChangesInPath { get; set; }
+
+        /// <summary>
         /// Gets or sets the path to the repo root. If null or empty, behavior defaults to using Environment.CurrentDirectory and searching upwards.
         /// </summary>
         public string GitRepoRoot { get; set; }
@@ -77,7 +83,7 @@
         /// </summary>
         [Output]
         public bool PublicRelease { get; private set; }
-
+        
         /// <summary>
         /// Gets the version string to use in the compiled assemblies.
         /// </summary>
@@ -188,7 +194,7 @@
 
                 var cloudBuild = CloudBuild.Active;
                 var overrideBuildNumberOffset = (this.OverrideBuildNumberOffset == int.MaxValue) ? (int?)null : this.OverrideBuildNumberOffset;
-                var oracle = VersionOracle.Create(Directory.GetCurrentDirectory(), this.GitRepoRoot, cloudBuild, overrideBuildNumberOffset, this.ProjectPathRelativeToGitRepoRoot);
+                var oracle = VersionOracle.Create(Directory.GetCurrentDirectory(), this.GitRepoRoot, cloudBuild, overrideBuildNumberOffset, this.ProjectPathRelativeToGitRepoRoot, string.Equals(this.SkipCommitsWithoutChangesInPath, "true", StringComparison.OrdinalIgnoreCase));
                 if (!string.IsNullOrEmpty(this.DefaultPublicRelease))
                 {
                     oracle.PublicRelease = string.Equals(this.DefaultPublicRelease, "true", StringComparison.OrdinalIgnoreCase);

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -65,6 +65,7 @@
       BuildMetadata="@(BuildMetadata)"
       DefaultPublicRelease="$(PublicRelease)"
       GitRepoRoot="$(GitRepoRoot)"
+      SkipCommitsWithoutChangesInPath="$(SkipCommitsWithoutChangesInPath)"
       ProjectPathRelativeToGitRepoRoot="$(ProjectPathRelativeToGitRepoRoot)"
       OverrideBuildNumberOffset="$(OverrideBuildNumberOffset)"
       TargetsPath="$(MSBuildThisFileDirectory)">


### PR DESCRIPTION
Consider the following scenario:

- I have a solution (.sln) with multiple projects (.csproj) in subfolders.
- These projects each produce a nuget package.
- A version.json is present in the solution-folder.
- On a build server (DevOps), always the complete solution is built, resulting in a new nupkg for each project, even if there were only changes in one of the projects.

I want to have a new package version only for the projects that have had changes. Having a separate version.json in each subfolder obviously won't work since the git height will still increase each time. This PR is a proof of concept and work in progress to enable skipping commits that don't contain any changes for the directory of the project, thus excluding them from contributing to the git height. This is enabled by setting `<SkipCommitsWithoutChangesInPath>true</SkipCommitsWithoutChangesInPath>` in MsBuild.

The PR is in early stages, there are changes in signatures of public methods and I'm sure I missed a lot of code paths so that the new feature won't work in all cases. Depending on whether this change is considered useful, I will continue work on this.