### PR TITLE
Pack additional copies of osx and linux libraries under MSBuildFull

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
+++ b/src/Nerdbank.GitVersioning.Tasks/Nerdbank.GitVersioning.nuspec
@@ -28,6 +28,11 @@
     <file src="$LibGit2SharpNativeBinaries$runtimes\win7-x86\native\git2-6311e88.pdb" target="build\lib\win32\x86\git2-6311e88.pdb" />
     <file src="$LibGit2SharpNativeBinaries$runtimes\osx\native\libgit2-6311e88.dylib" target="build\lib\osx\libgit2-6311e88.dylib" />
     <file src="$LibGit2SharpNativeBinaries$runtimes\linux-x64\native\libgit2-6311e88.so" target="build\lib\linux\x86_64\libgit2-6311e88.so" />
+    
+    <!-- Additional copies to work around DllNotFoundException on Mono (https://github.com/AArnott/Nerdbank.GitVersioning/issues/222) -->
+    <file src="$LibGit2SharpNativeBinaries$runtimes\osx\native\libgit2-6311e88.dylib" target="build\MSBuildFull\lib\osx\libgit2-6311e88.dylib" />
+    <file src="$LibGit2SharpNativeBinaries$runtimes\linux-x64\native\libgit2-6311e88.so" target="build\MSBuildFull\lib\linux\x86_64\libgit2-6311e88.so" />
+
     <file src="$LibGit2SharpNativeBinaries$libgit2\LibGit2Sharp.dll.config" target="build\MSBuildCore\LibGit2Sharp.dll.config" />
     <file src="$BaseOutputPath$netcoreapp2.0\LibGit2Sharp.dll" target="build\MSBuildCore\LibGit2Sharp.dll" />
     <file src="$BaseOutputPath$netcoreapp2.0\MSBuildExtensionTask.dll" target="build\MSBuildCore\MSBuildExtensionTask.dll" />


### PR DESCRIPTION
Update nuspec to add back copies of native libraries for OSX and Linux to work around DllNotFoundException when running msbuild under Mono (#222).

Manually verified these now work:

- Mono `msbuild` on Mac OS X 10.13.6 (MS Build 15.7.224 on Mono 5.12.0)
- Mono `msbuild` on Ubuntu 18.04.1 (MS Build 15.6.0.0 on Mono 5.14.0

Manually verified these continue to work:

- `dotnet build` on Mac OS X 10.13.6 (.NET Core SDK 2.1.402)
- `dotnet build` on Ubuntu 18.04.1 (.NET Core SDK 2.1.402)
- `dotnet build` on Windows 10.0.17134 (.NET Core SDK 2.1.402)
- .NET Framework `msbuild` on Windows 10.0.17134 (MS Build 15.8.169)

All tests in NerdBank.GitVersioning.Tests pass (`dotnet test` on Windows) except one: `BuildIntegrationTests.NativeVersionInfo_CreateNativeResourceDll` fails with:


    InvalidProjectFileException : The imported project "C:\Microsoft.Cpp.Default.props" was not found.

