### PR TITLE
Add a few properties for easier processing at the command line

### DIFF
--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -98,7 +98,7 @@
 
             this.VersionHeightOffset = this.VersionOptions?.BuildNumberOffsetOrDefault ?? 0;
 
-            this.PrereleaseVersion = ReplaceMacros(this.VersionOptions?.Version.Prerelease ?? string.Empty);
+            this.PrereleaseVersion = this.ReplaceMacros(this.VersionOptions?.Version.Prerelease ?? string.Empty);
 
             this.CloudBuildNumberOptions = this.VersionOptions?.CloudBuild?.BuildNumberOrDefault ?? VersionOptions.CloudBuildNumberOptions.DefaultInstance;
 
@@ -186,9 +186,14 @@
         public bool PublicRelease { get; set; }
 
         /// <summary>
-        /// Gets the prerelease version information.
+        /// Gets the prerelease version information, including a leading hyphen.
         /// </summary>
         public string PrereleaseVersion { get; }
+
+        /// <summary>
+        /// Gets the prerelease version information, omitting the leading hyphen, if any.
+        /// </summary>
+        public string PrereleaseVersionNoLeadingHyphen => this.PrereleaseVersion?.TrimStart('-');
 
         /// <summary>
         /// Gets the version information without a Revision component.
@@ -203,12 +208,27 @@
         public int BuildNumber => Math.Max(0, this.Version.Build);
 
         /// <summary>
-        /// Gets or sets the major.minor version string.
+        /// Gets the <see cref="Version.Revision"/> component of the <see cref="Version"/>.
+        /// </summary>
+        public int VersionRevision => this.Version.Revision;
+
+        /// <summary>
+        /// Gets the major.minor version string.
         /// </summary>
         /// <value>
         /// The x.y string (no build number or revision number).
         /// </value>
         public Version MajorMinorVersion => new Version(this.Version.Major, this.Version.Minor);
+
+        /// <summary>
+        /// Gets the <see cref="Version.Major"/> component of the <see cref="Version"/>.
+        /// </summary>
+        public int VersionMajor => this.Version.Major;
+
+        /// <summary>
+        /// Gets the <see cref="Version.Minor"/> component of the <see cref="Version"/>.
+        /// </summary>
+        public int VersionMinor => this.Version.Minor;
 
         /// <summary>
         /// Gets the Git revision control commit id for HEAD (the current source code version).
@@ -355,7 +375,7 @@
         private string SemVer2BuildMetadata =>
             (this.PublicRelease ? string.Empty : this.GitCommitIdShortForNonPublicPrereleaseTag) + FormatBuildMetadata(this.BuildMetadata);
 
-        private string PrereleaseVersionSemVer1 => MakePrereleaseSemVer1Compliant(this.PrereleaseVersion, SemVer1NumericIdentifierPadding);
+        private string PrereleaseVersionSemVer1 => MakePrereleaseSemVer1Compliant(this.PrereleaseVersion, this.SemVer1NumericIdentifierPadding);
 
         private string GitCommitIdShortForNonPublicPrereleaseTag => (string.IsNullOrEmpty(this.PrereleaseVersion) ? "-" : ".") + $"g{this.GitCommitIdShort}";
 


### PR DESCRIPTION
The properties (excluding the `NBGV_` prefix) are:

1. `VersionMajor`
1. `VersionMinor`
1. `BuildNumber` (this was preexisting)
1. `VersionRevision`

The `BuildNumber` always represents the 3rd integer in the version. If you want the version/git height specifically, use `VersionHeight`, since as you say that *may* not appear as the 3rd integer.

I've also added a `PrereleaseVersionNoLeadingHyphen` property for you.

Closes #233 