### PR TITLE
Fixes #198

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -82,6 +82,32 @@ public class VersionOracleTests : RepoTestBase
         Assert.Equal(0, oracle.VersionHeightOffset);
     }
 
+    [Theory]
+    [InlineData("0.1", "0.2")]
+    [InlineData("0.1.0+{height}", "0.1.5+{height}")]
+    [InlineData("0.1.5-alpha0.{height}", "0.1.5-alpha1.{height}")]
+    [InlineData("0.1.5-beta.{height}", "0.1.5-beta1.{height}")]
+    public void CompareFullVersionResetsHeight(string initial, string next)
+    {
+        var options = new VersionOptions
+        {
+            Version = SemanticVersion.Parse(initial),
+            CompareFullVersion = true
+        };
+        this.WriteVersionFile(options);
+        this.InitializeSourceControl();
+        this.AddCommits(10);
+
+        var oracle = VersionOracle.Create(this.RepoPath);
+        Assert.Equal(11, oracle.VersionHeight);
+
+        options.Version = SemanticVersion.Parse(next);
+
+        this.WriteVersionFile(options);
+        oracle = VersionOracle.Create(this.RepoPath);
+        Assert.Equal(1, oracle.VersionHeight);
+    }
+
     [Fact]
     public void HeightInPrerelease()
     {

--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -411,6 +411,17 @@
             return majorMinorFromFile?.Major == expectedVersion.Major && majorMinorFromFile?.Minor == expectedVersion.Minor;
         }
 
+        internal static bool CommitMatchesFormat(this Commit commit, SemanticVersion expectedVersion, string repoRelativeProjectDirectory)
+        {
+            Requires.NotNull(commit, nameof(commit));
+            Requires.NotNull(expectedVersion, nameof(expectedVersion));
+
+            var commitVersionData = VersionFile.GetVersion(commit, repoRelativeProjectDirectory);
+            var majorMinorFromFile = commitVersionData?.Version;
+            return majorMinorFromFile.Equals(expectedVersion);
+        }
+
+
         private static string FindGitDir(string startingDir)
         {
             while (startingDir != null)

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using System.Diagnostics;
     using System.Reflection;
     using Newtonsoft.Json;
@@ -63,6 +62,12 @@
         /// </remarks>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int? BuildNumberOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the build number is reset when the label changes.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool CompareFullVersion { get; set; } = false;
 
         /// <summary>
         /// Gets a number to add to the git height when calculating the <see cref="Version.Build"/> number.

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -434,7 +434,14 @@
                 }
             }
 
-            return headCommit?.GetHeight(c => c.CommitMatchesMajorMinorVersion(headCommitVersion, relativeRepoProjectDirectory)) ?? 0;
+            if (committedVersion != null && committedVersion.CompareFullVersion)
+            {
+                return headCommit?.GetHeight(c => c.CommitMatchesFormat(committedVersion?.Version, relativeRepoProjectDirectory)) ?? 0;
+            }
+            else
+            {
+                return headCommit?.GetHeight(c => c.CommitMatchesMajorMinorVersion(headCommitVersion, relativeRepoProjectDirectory)) ?? 0;
+            }
         }
 
         private static Version GetIdAsVersion(LibGit2Sharp.Commit headCommit, VersionOptions committedVersion, VersionOptions workingVersion, int versionHeight)

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -61,6 +61,11 @@
           "description": "A number to add to the git height when calculating the build number.",
           "default": 0
         },
+        "compareFullVersion": {
+          "type": "boolean",
+          "description": "Compare the whole version string when calculating the value of {height}.",
+          "default": false
+        },
         "semVer1NumericIdentifierPadding": {
           "type": "integer",
           "description": "The minimum number of digits to use for numeric identifiers in SemVer 1.",


### PR DESCRIPTION
Enables option to compare full version string when calculating height reset.  This resolves issue: https://github.com/AArnott/Nerdbank.GitVersioning/issues/198.

By adding the following property to `version.json`, the full version string is used for comparison during the calculation of the version height.  The option requires explicit enablement to prevent breaking changes.
```
{
  "compareFullVersion": true
}
```

