### PR TITLE
Fix PR build breaks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,7 +109,7 @@ jobs:
 
 - job: Ubuntu_Xenial
   dependsOn: Windows
-  condition: succeeded()
+  condition: and(succeeded(), ne(variables['system.pullrequest.isfork'], true))
   pool:
     vmImage: Ubuntu 16.04
   container: xenial
@@ -120,7 +120,7 @@ jobs:
 
 - job: Ubuntu_Bionic
   dependsOn: Windows
-  condition: succeeded()
+  condition: and(succeeded(), ne(variables['system.pullrequest.isfork'], true))
   pool:
     vmImage: Ubuntu 16.04 # not a bug. we always use this pool, but use containers for the specific version
   container: bionic
@@ -129,7 +129,7 @@ jobs:
 
 - job: macOS
   dependsOn: Windows
-  condition: succeeded()
+  condition: and(succeeded(), ne(variables['system.pullrequest.isfork'], true))
   pool:
     vmImage: macOS 10.13
   steps:


### PR DESCRIPTION
Azure Pipelines doesn't yet allow publishing artifacts when building PRs from forks. This breaks job-to-job dependencies.