### PR TITLE
Enable '-' to be used to split height in prerelease label

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/SemanticVersionTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/SemanticVersionTests.cs
@@ -98,6 +98,24 @@ public class SemanticVersionTests
         Assert.Equal("+build", result.BuildMetadata);
     }
 
+    [Theory]
+    [InlineData(".")]
+    [InlineData("-")]
+    public void TryParse_WithHeight(char splitter)
+    {
+        var pre = "-alpha1" + splitter + "{height}";
+        var version = "1.2.3.4" + pre;
+
+        SemanticVersion result;
+        Assert.True(SemanticVersion.TryParse(version, out result));
+        Assert.Equal(1, result.Version.Major);
+        Assert.Equal(2, result.Version.Minor);
+        Assert.Equal(3, result.Version.Build);
+        Assert.Equal(4, result.Version.Revision);
+        Assert.Equal(pre, result.Prerelease);
+
+    }
+
     [Fact]
     public void Parse()
     {

--- a/src/NerdBank.GitVersioning/SemanticVersion.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersion.cs
@@ -26,7 +26,7 @@
         /// <remarks>
         /// Keep in sync with the regex for the version field found in the version.schema.json file.
         /// </remarks>
-        private static readonly Regex PrereleasePattern = new Regex("-(?:[\\da-z\\-]+|\\{height\\})(?:\\.(?:[\\da-z\\-]+|\\{height\\}))*", RegexOptions.IgnoreCase);
+        private static readonly Regex PrereleasePattern = new Regex("-(?:[\\da-z\\-]+|\\{height\\})(?:(\\.|(?<=-))(?:[\\da-z\\-]+|\\{height\\}))*", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// The regex pattern that build metadata must match.


### PR DESCRIPTION
A small adjustment to the prerelease regex to enable the format `1.0.0.0-alpha1-{height}` to be used as well as the existing format of `1.0.0-alpha1.{height}`