### PR TITLE
Use SemVer 2.0 for NPM packages

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -193,7 +193,7 @@ public class VersionOracleTests : RepoTestBase
     }
 
     [Fact]
-    public void NpmPackageVersionIsSemVer1()
+    public void NpmPackageVersionIsSemVer2()
     {
         VersionOptions workingCopyVersion = new VersionOptions
         {
@@ -204,7 +204,7 @@ public class VersionOracleTests : RepoTestBase
         this.InitializeSourceControl();
         var oracle = VersionOracle.Create(this.RepoPath);
         oracle.PublicRelease = true;
-        Assert.Equal("7.8.9-foo-25", oracle.NpmPackageVersion);
+        Assert.Equal("7.8.9-foo.25", oracle.NpmPackageVersion);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -340,7 +340,7 @@
         /// <summary>
         /// Gets the version to use for NPM packages.
         /// </summary>
-        public string NpmPackageVersion => this.SemVer1;
+        public string NpmPackageVersion => this.SemVer2;
 
         /// <summary>
         /// Gets a SemVer 1.0 compliant string that represents this version, including the -gCOMMITID suffix

--- a/src/nerdbank-gitversioning.npm/ts/index.ts
+++ b/src/nerdbank-gitversioning.npm/ts/index.ts
@@ -66,8 +66,8 @@ export async function setPackageVersion(packageDirectory?: string, srcDirectory?
     packageDirectory = packageDirectory || '.';
     srcDirectory = srcDirectory || packageDirectory;
     const gitVersion = await getVersion(srcDirectory);
-    console.log(`Setting package version to ${gitVersion.semVer1}`);
-    var result = await execAsync(`npm version ${gitVersion.semVer1} --no-git-tag-version`, { cwd: packageDirectory });
+    console.log(`Setting package version to ${gitVersion.npmPackageVersion}`);
+    var result = await execAsync(`npm version ${gitVersion.npmPackageVersion} --no-git-tag-version`, { cwd: packageDirectory });
     if (result.stderr) {
         console.log(result.stderr);
     }


### PR DESCRIPTION
This has been around and supported for at least six years in NPM.

Fixes #236