### PR TITLE
Remove the `g` prefix in commit IDs almost everywhere

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -176,7 +176,7 @@ public class BuildIntegrationTests : RepoTestBase
         Assumes.True(repo.Index[VersionFile.JsonFileName] == null);
         var buildResult = await this.BuildAsync();
         Assert.Equal("3.4.0." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("3.4.0+g" + repo.Head.Commits.First().Id.Sha.Substring(0, 10), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("3.4.0+" + repo.Head.Commits.First().Id.Sha.Substring(0, 10), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]
@@ -201,7 +201,7 @@ public class BuildIntegrationTests : RepoTestBase
         repo.Commit("empty", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
         var buildResult = await this.BuildAsync();
         Assert.Equal("0.0.1." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("0.0.1+g" + repo.Head.Commits.First().Id.Sha.Substring(0, 10), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("0.0.1+" + repo.Head.Commits.First().Id.Sha.Substring(0, 10), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]
@@ -915,7 +915,7 @@ public class BuildIntegrationTests : RepoTestBase
         Version assemblyVersion = GetExpectedAssemblyVersion(versionOptions, version);
         var additionalBuildMetadata = from item in buildResult.BuildResult.ProjectStateAfterBuild.GetItems("BuildMetadata")
                                       select item.EvaluatedInclude;
-        var expectedBuildMetadata = $"+g{commitIdShort}";
+        var expectedBuildMetadata = $"+{commitIdShort}";
         if (additionalBuildMetadata.Any())
         {
             expectedBuildMetadata += "." + string.Join(".", additionalBuildMetadata);
@@ -944,7 +944,8 @@ public class BuildIntegrationTests : RepoTestBase
 
         // NuGet is now SemVer 2.0 and will pass additional build metadata if provided
         bool semVer2 = versionOptions?.NuGetPackageVersionOrDefault.SemVer == 2;
-        string pkgVersionSuffix = buildResult.PublicRelease ? string.Empty : $"-g{commitIdShort}";
+        string semVer1CommitPrefix = semVer2 ? string.Empty : "g";
+        string pkgVersionSuffix = buildResult.PublicRelease ? string.Empty : $"-{semVer1CommitPrefix}{commitIdShort}";
         if (semVer2)
         {
             pkgVersionSuffix += expectedBuildMetadataWithoutCommitId;
@@ -965,7 +966,7 @@ public class BuildIntegrationTests : RepoTestBase
             Assert.Equal(expectedVersion, buildNumberSemVer.Version);
             Assert.Equal(buildResult.PrereleaseVersion, buildNumberSemVer.Prerelease);
             string expectedBuildNumberMetadata = hasCommitData && commitIdOptions.WhereOrDefault == VersionOptions.CloudBuildNumberCommitWhere.BuildMetadata
-                ? $"+g{commitIdShort}"
+                ? $"+{commitIdShort}"
                 : string.Empty;
             if (additionalBuildMetadata.Any())
             {

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -240,7 +240,7 @@ public class VersionOracleTests : RepoTestBase
         this.InitializeSourceControl();
         var oracle = VersionOracle.Create(this.RepoPath);
         oracle.PublicRelease = false;
-        Assert.Equal($"7.8.9-foo.25.g{this.CommitIdShort}", oracle.NuGetPackageVersion);
+        Assert.Equal($"7.8.9-foo.25.{this.CommitIdShort}", oracle.NuGetPackageVersion);
     }
 
     [Fact]


### PR DESCRIPTION
This removes `g` basically everywhere except for semver 1.0 compliant NuGet package versions, since older NuGet clients can't handle -prerelease tags that start with a digit (which some commit IDs do). For these, we still prefix the `g` as the convention to ensure that the prerelease tag starts with a letter.

Fixes #260