### PR TITLE
Add NuGet-semver v1 compatible version as ChocolateyPackageVersion

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -177,6 +177,7 @@ public class VersionOracleTests : RepoTestBase
         Assert.True(Regex.IsMatch(oracle.SemVer1, @"^2.3.1-[^g]{10}$"));
         Assert.True(Regex.IsMatch(oracle.SemVer2, @"^2.3.1-[^g]{10}$"));
         Assert.True(Regex.IsMatch(oracle.NuGetPackageVersion, @"^2.3.1-g[a-f0-9]{10}$"));
+        Assert.True(Regex.IsMatch(oracle.ChocolateyPackageVersion, @"^2.3.1-g[a-f0-9]{10}$"));
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -338,6 +338,14 @@
         public string NuGetPackageVersion => this.VersionOptions?.NuGetPackageVersionOrDefault.SemVerOrDefault == 1 ? this.NuGetSemVer1 : this.SemVer2;
 
         /// <summary>
+        /// Gets the version to use for Chocolatey packages.
+        /// </summary>
+        /// <remarks>
+        /// This always returns the NuGet subset of SemVer 1.0.
+        /// </remarks>
+        public string ChocolateyPackageVersion => this.NuGetSemVer1;
+
+        /// <summary>
         /// Gets the version to use for NPM packages.
         /// </summary>
         public string NpmPackageVersion => this.SemVer2;

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -153,6 +153,9 @@
         public string NuGetPackageVersion { get; private set; }
 
         [Output]
+        public string ChocolateyPackageVersion { get; private set; }
+
+        [Output]
         public string NpmPackageVersion { get; private set; }
 
         /// <summary>
@@ -214,6 +217,7 @@
                 this.BuildMetadataFragment = oracle.BuildMetadataFragment;
                 this.CloudBuildNumber = oracle.CloudBuildNumberEnabled ? oracle.CloudBuildNumber : null;
                 this.NuGetPackageVersion = oracle.NuGetPackageVersion;
+                this.ChocolateyPackageVersion = oracle.ChocolateyPackageVersion;
                 this.NpmPackageVersion = oracle.NpmPackageVersion;
 
                 IEnumerable<ITaskItem> cloudBuildVersionVars = null;

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -86,6 +86,7 @@
       <Output TaskParameter="CloudBuildNumber" PropertyName="CloudBuildNumber" Condition=" '$(CloudBuildNumber)' == '' "/>
       <Output TaskParameter="BuildMetadataFragment" PropertyName="SemVerBuildSuffix" />
       <Output TaskParameter="NuGetPackageVersion" PropertyName="NuGetPackageVersion" />
+      <Output TaskParameter="ChocolateyPackageVersion" PropertyName="ChocolateyPackageVersion" />
       <Output TaskParameter="NuGetPackageVersion" PropertyName="Version" />
       <Output TaskParameter="NuGetPackageVersion" PropertyName="PackageVersion" />
       <Output TaskParameter="NPMPackageVersion" PropertyName="NPMPackageVersion" />


### PR DESCRIPTION
- Add ChocolateyPackageVersion to VersionOracle
- Define ChocolateyPackageVersion as an MSBuild property

Fixes #275