### PR TITLE
Add "prepare-release" command

### DIFF
--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -29,41 +29,41 @@ At this point you can launch the tool using `./nbgv` in your build script.
 
 ## Preparing a release
 
-The `prepare-release` helps with creating a  release branchs.
-The command assumes you are the following branching model:
+The `prepare-release` command automates the task of branching off the main development branch to stabilize for an upcoming release. It is optimized for the following workflow:
 
-- There is a main branch (typically `master`) that contains the latest version
-  of your software. Builds of the main branch alwas use a prerelease tag.
-- For releases, separate release branches are created.
-  Builds from release branches use either no or a different prerelease tag than
-  the main branch.
-- Fixes made on a release branch are brought back to the main branch either
-  by merging the branch or by cherry-picking the changes.
+- There is a branch (typically `master` ) where main development happens.
+  This branch typically builds with some `-prerelease` tag.
+  It *may* be a "public release" for early prereleases.
+- To stabilize for and/or ship a release, a branch named after the version to be shipped is created.
+  This branch *may* include a `-prerelease` tag, typically a more advanced tag than any found in `master`. For example, if `master` builds `-alpha` then the stabilization branch would build `-beta` or `-rc`.
+- Each release branch may be periodically merged into the next newer release branch or `master` so that hot fixes also ship in the next major release.
 
 The `prepare-release` command supports this working model by taking care of
 creating the release branch and updating `version.json` on both branches.
 
-To prepare a release, run
+To prepare a release, run:
 
 ```ps1
 nbgv prepare-release
 ```
 
-This will
+This will:
 
-- Read the version on the current branch
-- Create a new release branch for the version. If the version on the current
-  branch is e.g. `1.2-beta`, a release branch named `release/v1.2` will be
-  created.
-- Remove the prerelease tag from `version.json` on the release branch
-- Increment the version and set the prerelease tag on the main branch.
-  By default, `prepare-release` will increment the minor version and set the
-  prerelease tag to `alpha`. If the version has multiple prerelease tags
-  (separated by '.'), only the first tag will be updated.
-  In the above example, the version on the main branch would be set to `1.3-alpha`.
-- Merge the release brach back to the main branch resolving the conflict in `version.json`.
-  This avoids having to resolve the conflict when merging the branch at a later
-  time.
+1. Read `version.json` to ascertain the version under development,
+   and the naming convention of release branches.
+1. Create a new release branch for that version. If the version on the current
+   branch is `1.2-beta` and the release branch naming convention is `release/v{version}`,
+   a release branch named `release/v1.2` will be created.
+1. Remove the prerelease tag from `version.json` on the release branch.
+   Optionally (if an argument is passed to the command) a new prerelease tag is used to replace the old one.
+1. Back on the original branch, increment the version as specified in `version.json`.
+   By default, `prepare-release` will increment the minor version and set the
+   prerelease tag to `alpha`. If the version has multiple prerelease tags
+   (separated by '.'), only the first tag will be updated.
+   In the above example, the version on the main branch would be set to `1.3-alpha`.
+1. Merge the release branch back to the main branch, resolving the conflict in `version.json`.
+   This avoids having to resolve the conflict when merging the branch at a later
+   time.
 
 You can optionally include a prerelease tag on the release branch, e.g. when
 you want to do some stabilization first. This can be achieved by passing a
@@ -75,7 +75,7 @@ nbgv prepare-release rc
 
 **Note:** When the current branch is already the release branch for the current version,
 no new branch will be created. Instead the tool will just update the version
-in the current branch by setting/removing the prerelease tag.
+in the current branch by replacing or removing the prerelease tag.
 
 ### Explicitly setting the next version
 
@@ -105,7 +105,7 @@ The behaviour of the `prepare-release` command can be customized in
 
 | Property         | Default value        | Description                                                                                                                                |
 |------------------|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| branchName       | `v{version}` | Defines the format of release branch names. The value must include a `{version}` placeholder.                                              |
+| branchName       | `v{version}`         | Defines the format of release branch names. The value must include a `{version}` placeholder.                                              |
 | versionIncremnt  | `minor`              | Specifies which part of the version on the current branch is incremented when preparing a release. Allowed values are `minor` and `major`. |
 | firstUnstableTag | `alpha`              | Specified the unstable tag to use for the main branch.                                                                                     |
 

--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -27,6 +27,88 @@ dotnet tool install --tool-path . nbgv
 
 At this point you can launch the tool using `./nbgv` in your build script.
 
+## Preparing a release
+
+The `prepare-release` helps with creating a  release branchs.
+The command assumes you are the following branching model:
+
+- There is a main branch (typically `master`) that contains the latest version
+  of your software. Builds of the main branch alwas use a prerelease tag.
+- For releases, separate release branches are created.
+  Builds from release branches use either no or a different prerelease tag than
+  the main branch.
+- Fixes made on a release branch are brought back to the main branch either
+  by merging the branch or by cherry-picking the changes.
+
+The `prepare-release` command supports this working model by taking care of
+creating the release branch and updating `version.json` on both branches.
+
+To prepare a release, run
+
+```ps1
+nbgv prepare-release
+```
+
+This will
+
+- Read the version on the current branch
+- Create a new release branch for the version. If the version on the current
+  branch is e.g. `1.2-beta`, a release branch named `release/v1.2` will be
+  created.
+- Remove the prerelease tag from `version.json` on the release branch
+- Increment the version and set the prerelease tag on the main branch.
+  By default, `prepare-release` will increment the minor version and set the
+  prerelease tag to `alpha`. If the version has multiple prerelease tags
+  (separated by '.'), only the first tag will be updated.
+  In the above example, the version on the main branch would be set to `1.3-alpha`.
+- Merge the release brach back to the main branch resolving the conflict in `version.json`.
+  This avoids having to resolve the conflict when merging the branch at a later
+  time.
+
+You can optionally include a prerelease tag on the release branch, e.g. when
+you want to do some stabilization first. This can be achieved by passing a
+tag to the command, e.g.:
+
+```ps1
+nbgv prepare-release rc
+```
+
+**Note:** When the current branch is already the release branch for the current version,
+no new branch will be created. Instead the tool will just update the version
+in the current branch by setting/removing the prerelease tag.
+
+### Explicitly setting the next version
+
+If you want to explicitly set the next version of the main branch instead of
+automatically determining it by incrementing the current version, you
+can set the version as commandline parameter:
+
+```ps1
+nbgv prepare-release --nextVersion 2.0-beta
+```
+
+### Customizing the behaviour of `prepare-release`
+
+The behaviour of the `prepare-release` command can be customized in
+`version.json`:
+
+```json
+{
+  "version": "1.0",
+  "release": {
+    "branchName" : "release/v{version}",
+    "versionIncrement" : "minor",
+    "firstUnstableTag" : "alpha"
+  }
+}
+```
+
+| Property         | Default value        | Description                                                                                                                                |
+|------------------|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| branchName       | `release/v{version}` | Defines the format of release branch names. The value must include a `{version}` placeholder.                                              |
+| versionIncremnt  | `minor`              | Specifies which part of the version on the current branch is incremented when preparing a release. Allowed values are `minor` and `major`. |
+| firstUnstableTag | `alpha`              | Specified the unstable tag to use for the main branch.                                                                                     |
+
 ## Learn more
 
 There are several more sub-commands and switches to each to help you build and maintain your projects, find a commit that built a particular version later on, create tags, etc.
@@ -37,13 +119,16 @@ Use the `--help` switch on the `nbgv` command or one of its sub-commands to lear
 nbgv --help
 usage: nbgv <command> [<args>]
 
-    install        Prepares a project to have version stamps applied
-                   using Nerdbank.GitVersioning.
-    get-version    Gets the version information for a project.
-    set-version    Updates the version stamp that is applied to a
-                   project.
-    tag            Creates a git tag to mark a version.
-    get-commits    Gets the commit(s) that match a given version.
-    cloud          Communicates with the ambient cloud build to set the
-                   build number and/or other cloud build variables.
+    install          Prepares a project to have version stamps applied
+                     using Nerdbank.GitVersioning.
+    get-version      Gets the version information for a project.
+    set-version      Updates the version stamp that is applied to a
+                     project.
+    tag              Creates a git tag to mark a version.
+    get-commits      Gets the commit(s) that match a given version.
+    cloud            Communicates with the ambient cloud build to set the
+                     build number and/or other cloud build variables.
+    prepare-release  Prepares a release by creating a release branch for
+                     the current version and adjusting the version on the
+                     current branch.
 ```

--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -105,7 +105,7 @@ The behaviour of the `prepare-release` command can be customized in
 
 | Property         | Default value        | Description                                                                                                                                |
 |------------------|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| branchName       | `release/v{version}` | Defines the format of release branch names. The value must include a `{version}` placeholder.                                              |
+| branchName       | `v{version}` | Defines the format of release branch names. The value must include a `{version}` placeholder.                                              |
 | versionIncremnt  | `minor`              | Specifies which part of the version on the current branch is incremented when preparing a release. Allowed values are `minor` and `major`. |
 | firstUnstableTag | `alpha`              | Specified the unstable tag to use for the main branch.                                                                                     |
 

--- a/doc/versionJson.md
+++ b/doc/versionJson.md
@@ -45,6 +45,11 @@ The content of the version.json file is a JSON serialized object with these prop
       }
     }
   },
+  "release" : {
+    "branchName" : "release/v{version}",
+    "versionIncrement" : "minor",
+    "firstUnstableTag" : "alpha"
+  }
   "inherit": false // optional. Set to true in secondary version.json files used to tweak settings for subsets of projects.
 }
 ```

--- a/doc/versionJson.md
+++ b/doc/versionJson.md
@@ -46,7 +46,7 @@ The content of the version.json file is a JSON serialized object with these prop
     }
   },
   "release" : {
-    "branchName" : "release/v{version}",
+    "branchName" : "v{version}",
     "versionIncrement" : "minor",
     "firstUnstableTag" : "alpha"
   }

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -9,6 +9,9 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Nerdbank.GitVersioning\SemanticVersionExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="..\Nerdbank.GitVersioning.Tasks\build\Nerdbank.GitVersioning.targets">
       <Visible>false</Visible>
       <Link>Targets\%(FileName)%(Extension)</Link>

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -116,9 +116,9 @@ public class ReleaseManagerTests : RepoTestBase
     [InlineData("1.2-beta", null, "rc", "v1.2", "1.2-rc")]
     [InlineData("1.2-beta.{height}", null, "rc", "v1.2", "1.2-rc.{height}")]
     // modify release.branchName
-    [InlineData("1.2-beta",          "v{version}release", null, "v1.2release", "1.2"            )]
-    [InlineData("1.2-beta.{height}", "v{version}release", null, "v1.2release", "1.2"            )]
-    [InlineData("1.2-beta",          "v{version}release", "rc", "v1.2release", "1.2-rc"         )]
+    [InlineData("1.2-beta", "v{version}release", null, "v1.2release", "1.2")]
+    [InlineData("1.2-beta.{height}", "v{version}release", null, "v1.2release", "1.2")]
+    [InlineData("1.2-beta", "v{version}release", "rc", "v1.2release", "1.2-rc")]
     [InlineData("1.2-beta.{height}", "v{version}release", "rc", "v1.2release", "1.2-rc.{height}")]
     public void PrepareRelease_ReleaseBranch(string initialVersion, string releaseOptionsBranchName, string releaseUnstableTag, string releaseBranchName, string resultingVersion)
     {
@@ -176,7 +176,7 @@ public class ReleaseManagerTests : RepoTestBase
     }
 
     [Theory]
-    [InlineData("1.2",          "rc", "release/v{version}", "release/v1.2")]
+    [InlineData("1.2", "rc", "release/v{version}", "release/v1.2")]
     [InlineData("1.2+metadata", "rc", "release/v{version}", "release/v1.2")]
     public void PrepeareRelease_ReleaseBranchWithVersionDecrement(string initialVersion, string releaseUnstableTag, string releaseOptionsBranchName, string branchName)
     {
@@ -205,10 +205,10 @@ public class ReleaseManagerTests : RepoTestBase
     [InlineData("1.2-beta.{height}", null, null, null, null, null, "v1.2", "1.2", "1.3-alpha.{height}")]
     [InlineData("1.2-beta.{height}", null, null, null, "rc", null, "v1.2", "1.2-rc.{height}", "1.3-alpha.{height}")]
     // modify release.branchName
-    [InlineData("1.2-beta",          "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha"          )]
-    [InlineData("1.2-beta",          "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc",          "1.3-alpha"          )]
-    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha.{height}" )]
-    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc.{height}", "1.3-alpha.{height}" )]
+    [InlineData("1.2-beta", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2", "1.3-alpha")]
+    [InlineData("1.2-beta", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc", "1.3-alpha")]
+    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2", "1.3-alpha.{height}")]
+    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc.{height}", "1.3-alpha.{height}")]
     // modify release.versionIncrement
     [InlineData("1.2-beta", null, ReleaseVersionIncrement.Major, "alpha", null, null, "v1.2", "1.2", "2.0-alpha")]
     [InlineData("1.2-beta", null, ReleaseVersionIncrement.Major, "alpha", "rc", null, "v1.2", "1.2-rc", "2.0-alpha")]

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -20,7 +20,7 @@ public class ReleaseManagerTests : RepoTestBase
     [Fact]
     public void PrepareRelease_NoGitRepo()
     {
-        this.AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath), ReleasePreparationError.NoGitRepo);        
+        this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.NoGitRepo);        
     }
 
     [Fact]
@@ -30,7 +30,7 @@ public class ReleaseManagerTests : RepoTestBase
 
         File.WriteAllText(Path.Combine(this.RepoPath, "file1.txt"), "");
 
-        this.AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath), ReleasePreparationError.UncommittedChanges);  
+        this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.UncommittedChanges);  
     }
 
     [Fact]
@@ -43,14 +43,14 @@ public class ReleaseManagerTests : RepoTestBase
 
         Commands.Stage(this.Repo, filePath);
     
-        this.AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath), ReleasePreparationError.UncommittedChanges);
+        this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.UncommittedChanges);
     }
 
     [Fact]
     public void PrepareRelease_NoVersionFile()
     {
         this.InitializeSourceControl();
-        this.AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath), ReleasePreparationError.NoVersionFile);
+        this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.NoVersionFile);
     }
 
     [Fact]
@@ -69,7 +69,7 @@ public class ReleaseManagerTests : RepoTestBase
         };
         this.WriteVersionFile(versionOptions);
 
-        this.AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath), ReleasePreparationError.InvalidBranchNameSetting);
+        this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.InvalidBranchNameSetting);
     }
 
     [Theory]
@@ -116,7 +116,7 @@ public class ReleaseManagerTests : RepoTestBase
         var branchName = string.Format(releaseBranchName, initialVersionOptions.Version.Version);        
         Commands.Checkout(this.Repo, this.Repo.CreateBranch(branchName));
 
-        ReleaseManager.PrepareRelease(this.RepoPath, releaseUnstableTag);
+        new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag);
 
         // TODO: Check if a commit was created
         
@@ -148,7 +148,7 @@ public class ReleaseManagerTests : RepoTestBase
         var branchName = string.Format(versionOptions.ReleaseOrDefault.BranchNameOrDefault, versionOptions.Version.Version);
         Commands.Checkout(this.Repo, this.Repo.CreateBranch(branchName));
 
-        this.AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath, releaseUnstableTag), ReleasePreparationError.VersionDecrement);
+        this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag), ReleasePreparationError.VersionDecrement);
     }
 
 
@@ -218,7 +218,7 @@ public class ReleaseManagerTests : RepoTestBase
         var tipBeforeRelease = this.Repo.Head.Tip;
 
         // prepare release
-        ReleaseManager.PrepareRelease(this.RepoPath, releaseUnstableTag);
+        new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag);
 
         // check if a branch was created
         Assert.Contains(this.Repo.Branches, branch => branch.FriendlyName == expectedBranchName);
@@ -279,7 +279,7 @@ public class ReleaseManagerTests : RepoTestBase
         this.WriteVersionFile(versionOptions);
 
         // switch to release branch        
-        this.AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath, releaseUnstableTag), ReleasePreparationError.VersionDecrement);
+        this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag), ReleasePreparationError.VersionDecrement);
     }
 
 

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -72,11 +72,15 @@ public class ReleaseManagerTests : RepoTestBase
     }
 
     [Theory]
-    [InlineData("1.2-pre", "1.2", "1.3-pre", ReleaseVersionIncrement.Minor)]
-    [InlineData("1.2-pre", "1.2", "2.2-pre", ReleaseVersionIncrement.Major)]
+    [InlineData("1.2-pre", "1.2", "1.3-pre", ReleaseVersionIncrement.Minor, null)]
+    [InlineData("1.2-pre", "1.2", "2.2-pre", ReleaseVersionIncrement.Major, null)]
+    [InlineData("1.2-pre", "1.2", "1.3-pre", ReleaseVersionIncrement.Minor, "v{0}")]
+    [InlineData("1.2-pre+metadata", "1.2", "1.3-pre+metadata", ReleaseVersionIncrement.Minor, null)]
     //TODO: more test cases (different release settings)
-    public void PrepareRelease_OnMaster(string initialVersion, string releaseVersion, string nextVersion, ReleaseVersionIncrement versionIncrement)
+    public void PrepareRelease_OnMaster(string initialVersion, string releaseVersion, string nextVersion, ReleaseVersionIncrement versionIncrement, string releaseBranchName)
     {
+        releaseBranchName = releaseBranchName ?? new ReleaseOptions().BranchNameOrDefault;
+
         // create and configure repository
         this.InitializeSourceControl();
         this.Repo.Config.Set("user.name", this.Signer.Name, ConfigurationLevel.Local);
@@ -88,7 +92,8 @@ public class ReleaseManagerTests : RepoTestBase
             Version = SemanticVersion.Parse(initialVersion),
             Release = new ReleaseOptions()
             {
-                VersionIncrement = versionIncrement
+                VersionIncrement = versionIncrement,
+                BranchName = releaseBranchName
             }
         };
         this.WriteVersionFile(initialVersionOptions);
@@ -98,7 +103,8 @@ public class ReleaseManagerTests : RepoTestBase
             Version = SemanticVersion.Parse(releaseVersion),
             Release = new ReleaseOptions()
             {
-                VersionIncrement = versionIncrement
+                VersionIncrement = versionIncrement,
+                BranchName = releaseBranchName
             }
         };
 
@@ -107,11 +113,12 @@ public class ReleaseManagerTests : RepoTestBase
             Version = SemanticVersion.Parse(nextVersion),
             Release = new ReleaseOptions()
             {
-                VersionIncrement = versionIncrement
+                VersionIncrement = versionIncrement,
+                BranchName = releaseBranchName
             }
         };
 
-        var expectedBranchName = string.Format(initialVersionOptions.ReleaseOrDefault.BranchNameOrDefault, releaseVersion);
+        var expectedBranchName = string.Format(releaseBranchName, releaseVersion);
         var initialBranchName = this.Repo.Head.FriendlyName;
         var tipBeforeRelease = this.Repo.Head.Tip;
 

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -177,7 +177,7 @@ public class ReleaseManagerTests : RepoTestBase
 
     [Theory]
     [InlineData("1.2-pre", null, ReleaseVersionIncrement.Minor, "pre", null, "1.2", "1.3-pre")]
-    [InlineData("1.2-pre", null, ReleaseVersionIncrement.Major, "pre", null, "1.2", "2.2-pre")]
+    [InlineData("1.2-pre", null, ReleaseVersionIncrement.Major, "pre", null, "1.2", "2.0-pre")]
     [InlineData("1.2-pre", "v{0}", ReleaseVersionIncrement.Minor, "pre", null, "1.2", "1.3-pre")]
     [InlineData("1.2-pre+metadata", null, ReleaseVersionIncrement.Minor, "pre", null, "1.2+metadata", "1.3-pre+metadata")]
     [InlineData("1.2-rc.{height}", null, ReleaseVersionIncrement.Minor, "beta", null, "1.2", "1.3-beta.{height}")]

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -47,6 +47,13 @@ public class ReleaseManagerTests : RepoTestBase
     }
 
     [Fact]
+    public void PrepareRelease_NoVersionFile()
+    {
+        this.InitializeSourceControl();
+        this.AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath), ReleasePreparationError.NoVersionFile);
+    }
+
+    [Fact]
     public void PrepareRelease_InvalidBranchNameSetting()
     {
         this.InitializeSourceControl();
@@ -62,8 +69,7 @@ public class ReleaseManagerTests : RepoTestBase
         };
         this.WriteVersionFile(versionOptions);
 
-
-        AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath), ReleasePreparationError.InvalidBranchNameSetting);
+        this.AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath), ReleasePreparationError.InvalidBranchNameSetting);
     }
 
     [Theory]

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -177,33 +177,37 @@ public class ReleaseManagerTests : RepoTestBase
 
     [Theory]
     // base test cases
-    [InlineData("1.2-beta",          null, null, null, null, "release/v1.2", "1.2",             "1.3-alpha"          )]    
-    [InlineData("1.2-beta",          null, null, null, "rc", "release/v1.2", "1.2-rc",          "1.3-alpha"          )]
-    [InlineData("1.2-beta.{height}", null, null, null, null, "release/v1.2", "1.2",             "1.3-alpha.{height}" )]   
-    [InlineData("1.2-beta.{height}", null, null, null, "rc", "release/v1.2", "1.2-rc.{height}", "1.3-alpha.{height}" )]
+    [InlineData("1.2-beta",          null, null, null, null, null, "release/v1.2", "1.2",             "1.3-alpha"          )]    
+    [InlineData("1.2-beta",          null, null, null, "rc", null, "release/v1.2", "1.2-rc",          "1.3-alpha"          )]
+    [InlineData("1.2-beta.{height}", null, null, null, null, null, "release/v1.2", "1.2",             "1.3-alpha.{height}" )]   
+    [InlineData("1.2-beta.{height}", null, null, null, "rc", null, "release/v1.2", "1.2-rc.{height}", "1.3-alpha.{height}" )]
     // modify release.branchName
-    [InlineData("1.2-beta",          "v{0}release", ReleaseVersionIncrement.Minor, "alpha", null, "v1.2release", "1.2",             "1.3-alpha"          )]    
-    [InlineData("1.2-beta",          "v{0}release", ReleaseVersionIncrement.Minor, "alpha", "rc", "v1.2release", "1.2-rc",          "1.3-alpha"          )]
-    [InlineData("1.2-beta.{height}", "v{0}release", ReleaseVersionIncrement.Minor, "alpha", null, "v1.2release", "1.2",             "1.3-alpha.{height}" )]   
-    [InlineData("1.2-beta.{height}", "v{0}release", ReleaseVersionIncrement.Minor, "alpha", "rc", "v1.2release", "1.2-rc.{height}", "1.3-alpha.{height}" )]
+    [InlineData("1.2-beta",          "v{0}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha"          )]    
+    [InlineData("1.2-beta",          "v{0}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc",          "1.3-alpha"          )]
+    [InlineData("1.2-beta.{height}", "v{0}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha.{height}" )]   
+    [InlineData("1.2-beta.{height}", "v{0}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc.{height}", "1.3-alpha.{height}" )]
     // modify release.versionIncrement
-    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Major, "alpha", null, "release/v1.2", "1.2",             "2.0-alpha"          )]    
-    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Major, "alpha", "rc", "release/v1.2", "1.2-rc",          "2.0-alpha"          )]
-    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Major, "alpha", null, "release/v1.2", "1.2",             "2.0-alpha.{height}" )]   
-    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Major, "alpha", "rc", "release/v1.2", "1.2-rc.{height}", "2.0-alpha.{height}" )]
+    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Major, "alpha", null, null, "release/v1.2", "1.2",             "2.0-alpha"          )]    
+    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Major, "alpha", "rc", null, "release/v1.2", "1.2-rc",          "2.0-alpha"          )]
+    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Major, "alpha", null, null, "release/v1.2", "1.2",             "2.0-alpha.{height}" )]   
+    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Major, "alpha", "rc", null, "release/v1.2", "1.2-rc.{height}", "2.0-alpha.{height}" )]
     // modify release.firstUnstableTag
-    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Minor, "preview", null, "release/v1.2", "1.2",             "1.3-preview"          )]    
-    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Minor, "preview", "rc", "release/v1.2", "1.2-rc",          "1.3-preview"          )]
-    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Minor, "preview", null, "release/v1.2", "1.2",             "1.3-preview.{height}" )]   
-    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Minor, "preview", "rc", "release/v1.2", "1.2-rc.{height}", "1.3-preview.{height}" )]
+    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Minor, "preview", null, null, "release/v1.2", "1.2",             "1.3-preview"          )]    
+    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Minor, "preview", "rc", null, "release/v1.2", "1.2-rc",          "1.3-preview"          )]
+    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Minor, "preview", null, null, "release/v1.2", "1.2",             "1.3-preview.{height}" )]   
+    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Minor, "preview", "rc", null, "release/v1.2", "1.2-rc.{height}", "1.3-preview.{height}" )]
     // include build metadata in version
-    [InlineData("1.2-beta+metadata",          null,   ReleaseVersionIncrement.Minor, "alpha", null, "release/v1.2", "1.2+metadata",             "1.3-alpha+metadata"          )]    
-    [InlineData("1.2-beta+metadata",          null,   ReleaseVersionIncrement.Minor, "alpha", "rc", "release/v1.2", "1.2-rc+metadata",          "1.3-alpha+metadata"          )]
-    [InlineData("1.2-beta.{height}+metadata", null,   ReleaseVersionIncrement.Minor, "alpha", null, "release/v1.2", "1.2+metadata",             "1.3-alpha.{height}+metadata" )]   
-    [InlineData("1.2-beta.{height}+metadata", null,   ReleaseVersionIncrement.Minor, "alpha", "rc", "release/v1.2", "1.2-rc.{height}+metadata", "1.3-alpha.{height}+metadata" )]
+    [InlineData("1.2-beta+metadata",          null,   ReleaseVersionIncrement.Minor, "alpha", null, null, "release/v1.2", "1.2+metadata",             "1.3-alpha+metadata"          )]    
+    [InlineData("1.2-beta+metadata",          null,   ReleaseVersionIncrement.Minor, "alpha", "rc", null, "release/v1.2", "1.2-rc+metadata",          "1.3-alpha+metadata"          )]
+    [InlineData("1.2-beta.{height}+metadata", null,   ReleaseVersionIncrement.Minor, "alpha", null, null, "release/v1.2", "1.2+metadata",             "1.3-alpha.{height}+metadata" )]   
+    [InlineData("1.2-beta.{height}+metadata", null,   ReleaseVersionIncrement.Minor, "alpha", "rc", null, "release/v1.2", "1.2-rc.{height}+metadata", "1.3-alpha.{height}+metadata" )]
     // versions without prerelease tags
-    [InlineData("1.2", null,   ReleaseVersionIncrement.Minor, "alpha", null, "release/v1.2", "1.2",  "1.3-alpha")]       
-    [InlineData("1.2", null,   ReleaseVersionIncrement.Major, "alpha", null, "release/v1.2", "1.2",  "2.0-alpha")]       
+    [InlineData("1.2", null,   ReleaseVersionIncrement.Minor, "alpha", null, null, "release/v1.2", "1.2",  "1.3-alpha")]       
+    [InlineData("1.2", null,   ReleaseVersionIncrement.Major, "alpha", null, null, "release/v1.2", "1.2",  "2.0-alpha")]    
+    // explicitly set next version (firstUnstableTag setting will be ignored)
+    [InlineData("1.2-beta",          null, null, null, null, "4.5",              "release/v1.2", "1.2", "4.5"              )]    
+    [InlineData("1.2-beta",          null, null, null, null, "4.5-pre",          "release/v1.2", "1.2", "4.5-pre"          )]
+    [InlineData("1.2-beta.{height}", null, null, null, null, "4.5-pre.{height}", "release/v1.2", "1.2", "4.5-pre.{height}" )]       
     public void PrepareRelease_Master(
         // data for initial setup (version and release options configured in version.json)
         string initialVersion,
@@ -212,6 +216,7 @@ public class ReleaseManagerTests : RepoTestBase
         string releaseOptionsFirstUnstableTag,
         // arguments passed to PrepareRelease()
         string releaseUnstableTag,
+        string nextVersion,
         // expected versions and branch name after running PrepareRelease()
         string expectedBranchName,
         string resultingReleaseVersion,
@@ -262,7 +267,7 @@ public class ReleaseManagerTests : RepoTestBase
 
         // prepare release
         var releaseManager = new ReleaseManager();
-        releaseManager.PrepareRelease(this.RepoPath, releaseUnstableTag);
+        releaseManager.PrepareRelease(this.RepoPath, releaseUnstableTag, (nextVersion == null ? null : SemanticVersion.Parse(nextVersion)));
 
         // check if a branch was created
         Assert.Contains(this.Repo.Branches, branch => branch.FriendlyName == expectedBranchName);
@@ -306,9 +311,10 @@ public class ReleaseManagerTests : RepoTestBase
     }
 
     [Theory]
-    [InlineData("1.2", "rc")]
-    [InlineData("1.2+metadata", "rc")]
-    public void PrepareRelease_MasterWithVersionDecrement(string initialVersion, string releaseUnstableTag)
+    [InlineData("1.2", "rc", null)]
+    [InlineData("1.2+metadata", "rc", null)]
+    [InlineData("1.2+metadata", null, "0.9")]
+    public void PrepareRelease_MasterWithVersionDecrement(string initialVersion, string releaseUnstableTag, string nextVersion)
     {
         // create and configure repository
         this.InitializeSourceControl();
@@ -320,8 +326,10 @@ public class ReleaseManagerTests : RepoTestBase
         this.WriteVersionFile(versionOptions);
 
         // running PrepareRelease should result in an error 
-        // because we're trying to add a prerelease tag to a version without prerelease tag
-        this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag), ReleasePreparationError.VersionDecrement);
+        // because we're trying to add a prerelease tag to a version without prerelease tag        
+        this.AssertError(
+            () => new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag, (nextVersion == null ? null : SemanticVersion.Parse(nextVersion))), 
+            ReleasePreparationError.VersionDecrement);
     }
 
 

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -98,12 +98,14 @@ public class ReleaseManagerTests : RepoTestBase
     }
 
     [Theory]
-    [InlineData("1.2-pre", "1.2", "1.3-pre", ReleaseVersionIncrement.Minor, null, "pre")]
-    [InlineData("1.2-pre", "1.2", "2.2-pre", ReleaseVersionIncrement.Major, null, "pre")]
-    [InlineData("1.2-pre", "1.2", "1.3-pre", ReleaseVersionIncrement.Minor, "v{0}", "pre")]
-    [InlineData("1.2-pre+metadata", "1.2", "1.3-pre+metadata", ReleaseVersionIncrement.Minor, null, "pre")]
-    [InlineData("1.2-rc.{height}", "1.2", "1.3-beta.{height}", ReleaseVersionIncrement.Minor, null, "beta")]
-    [InlineData("1.2-rc.{height}", "1.2", "1.3-beta.{height}", ReleaseVersionIncrement.Minor, null, "-beta")]
+    [InlineData("1.2-pre", "1.2", "1.3-pre", ReleaseVersionIncrement.Minor, null, "pre", null)]
+    [InlineData("1.2-pre", "1.2", "2.2-pre", ReleaseVersionIncrement.Major, null, "pre", null)]
+    [InlineData("1.2-pre", "1.2", "1.3-pre", ReleaseVersionIncrement.Minor, "v{0}", "pre", null)]
+    [InlineData("1.2-pre+metadata", "1.2", "1.3-pre+metadata", ReleaseVersionIncrement.Minor, null, "pre", null)]
+    [InlineData("1.2-rc.{height}", "1.2", "1.3-beta.{height}", ReleaseVersionIncrement.Minor, null, "beta", null)]
+    [InlineData("1.2-rc.{height}", "1.2", "1.3-beta.{height}", ReleaseVersionIncrement.Minor, null, "-beta", null)]
+    [InlineData("1.2-beta.{height}", "1.2-rc.{height}", "1.3-alpha.{height}", ReleaseVersionIncrement.Minor, null, "alpha", "rc")]
+    [InlineData("1.2-beta", "1.2-rc", "1.3-alpha", ReleaseVersionIncrement.Minor, null, "alpha", "rc")]
     //TODO: more test cases (different release settings)
     public void PrepareRelease_OnMaster(
         string initialVersion, 
@@ -111,7 +113,8 @@ public class ReleaseManagerTests : RepoTestBase
         string nextVersion, 
         ReleaseVersionIncrement versionIncrement, 
         string releaseBranchName,
-        string firstUnstableTag)
+        string firstUnstableTag,
+        string releaseUnstableTag)
     {
         releaseBranchName = releaseBranchName ?? new ReleaseOptions().BranchNameOrDefault;
 
@@ -155,12 +158,12 @@ public class ReleaseManagerTests : RepoTestBase
             }
         };
 
-        var expectedBranchName = string.Format(releaseBranchName, releaseVersion);
+        var expectedBranchName = string.Format(releaseBranchName, expectedVersionOptionsReleaseBranch.Version.Version);
         var initialBranchName = this.Repo.Head.FriendlyName;
         var tipBeforeRelease = this.Repo.Head.Tip;
 
         // prepare release
-        ReleaseManager.PrepareRelease(this.RepoPath);
+        ReleaseManager.PrepareRelease(this.RepoPath, releaseUnstableTag);
 
         // check if a branch was created
         Assert.Contains(this.Repo.Branches, branch => branch.FriendlyName == expectedBranchName);

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -72,12 +72,20 @@ public class ReleaseManagerTests : RepoTestBase
     }
 
     [Theory]
-    [InlineData("1.2-pre", "1.2", "1.3-pre", ReleaseVersionIncrement.Minor, null)]
-    [InlineData("1.2-pre", "1.2", "2.2-pre", ReleaseVersionIncrement.Major, null)]
-    [InlineData("1.2-pre", "1.2", "1.3-pre", ReleaseVersionIncrement.Minor, "v{0}")]
-    [InlineData("1.2-pre+metadata", "1.2", "1.3-pre+metadata", ReleaseVersionIncrement.Minor, null)]
+    [InlineData("1.2-pre", "1.2", "1.3-pre", ReleaseVersionIncrement.Minor, null, "pre")]
+    [InlineData("1.2-pre", "1.2", "2.2-pre", ReleaseVersionIncrement.Major, null, "pre")]
+    [InlineData("1.2-pre", "1.2", "1.3-pre", ReleaseVersionIncrement.Minor, "v{0}", "pre")]
+    [InlineData("1.2-pre+metadata", "1.2", "1.3-pre+metadata", ReleaseVersionIncrement.Minor, null, "pre")]
+    [InlineData("1.2-rc.{height}", "1.2", "1.3-beta.{height}", ReleaseVersionIncrement.Minor, null, "beta")]
+    [InlineData("1.2-rc.{height}", "1.2", "1.3-beta.{height}", ReleaseVersionIncrement.Minor, null, "-beta")]
     //TODO: more test cases (different release settings)
-    public void PrepareRelease_OnMaster(string initialVersion, string releaseVersion, string nextVersion, ReleaseVersionIncrement versionIncrement, string releaseBranchName)
+    public void PrepareRelease_OnMaster(
+        string initialVersion, 
+        string releaseVersion, 
+        string nextVersion, 
+        ReleaseVersionIncrement versionIncrement, 
+        string releaseBranchName,
+        string firstUnstableTag)
     {
         releaseBranchName = releaseBranchName ?? new ReleaseOptions().BranchNameOrDefault;
 
@@ -93,7 +101,8 @@ public class ReleaseManagerTests : RepoTestBase
             Release = new ReleaseOptions()
             {
                 VersionIncrement = versionIncrement,
-                BranchName = releaseBranchName
+                BranchName = releaseBranchName,
+                FirstUnstableTag = firstUnstableTag
             }
         };
         this.WriteVersionFile(initialVersionOptions);
@@ -104,7 +113,8 @@ public class ReleaseManagerTests : RepoTestBase
             Release = new ReleaseOptions()
             {
                 VersionIncrement = versionIncrement,
-                BranchName = releaseBranchName
+                BranchName = releaseBranchName,
+                FirstUnstableTag = firstUnstableTag
             }
         };
 
@@ -114,7 +124,8 @@ public class ReleaseManagerTests : RepoTestBase
             Release = new ReleaseOptions()
             {
                 VersionIncrement = versionIncrement,
-                BranchName = releaseBranchName
+                BranchName = releaseBranchName,
+                FirstUnstableTag = firstUnstableTag
             }
         };
 

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -105,7 +105,7 @@ public class ReleaseManagerTests : RepoTestBase
         this.Repo.CreateBranch("release/v1.2");
 
         // running PrepareRelease should result in an error 
-        // because the branchName does not have a placeholder for the version
+        // because the release branch already exists
         this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.BranchAlreadyExists);
     }
 

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -21,7 +21,7 @@ public class ReleaseManagerTests : RepoTestBase
     [Fact]
     public void PrepareRelease_NoGitRepo()
     {
-        // running PrepareRelease should result in an error 
+        // running PrepareRelease should result in an error
         // because the repo directory is not a git repository
         this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.NoGitRepo);
     }
@@ -34,7 +34,7 @@ public class ReleaseManagerTests : RepoTestBase
         // create a file
         File.WriteAllText(Path.Combine(this.RepoPath, "file1.txt"), "");
 
-        // running PrepareRelease should result in an error 
+        // running PrepareRelease should result in an error
         // because there is a new file not under version control
         this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.UncommittedChanges);
     }
@@ -49,7 +49,7 @@ public class ReleaseManagerTests : RepoTestBase
         File.WriteAllText(filePath, "");
         Commands.Stage(this.Repo, filePath);
 
-        // running PrepareRelease should result in an error 
+        // running PrepareRelease should result in an error
         // because there are uncommitted changes
         this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.UncommittedChanges);
     }
@@ -59,7 +59,7 @@ public class ReleaseManagerTests : RepoTestBase
     {
         this.InitializeSourceControl();
 
-        // running PrepareRelease should result in an error 
+        // running PrepareRelease should result in an error
         // because there is no version.json
         this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.NoVersionFile);
     }
@@ -80,7 +80,7 @@ public class ReleaseManagerTests : RepoTestBase
         };
         this.WriteVersionFile(versionOptions);
 
-        // running PrepareRelease should result in an error 
+        // running PrepareRelease should result in an error
         // because the branchName does not have a placeholder for the version
         this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.InvalidBranchNameSetting);
     }
@@ -104,22 +104,22 @@ public class ReleaseManagerTests : RepoTestBase
 
         this.Repo.CreateBranch("release/v1.2");
 
-        // running PrepareRelease should result in an error 
+        // running PrepareRelease should result in an error
         // because the release branch already exists
         this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.BranchAlreadyExists);
     }
 
     [Theory]
     // base test cases
-    [InlineData("1.2-beta",          null, null, "release/v1.2", "1.2"            )]
-    [InlineData("1.2-beta.{height}", null, null, "release/v1.2", "1.2"            )]
-    [InlineData("1.2-beta",          null, "rc", "release/v1.2", "1.2-rc"         )]
-    [InlineData("1.2-beta.{height}", null, "rc", "release/v1.2", "1.2-rc.{height}")]
+    [InlineData("1.2-beta", null, null, "v1.2", "1.2")]
+    [InlineData("1.2-beta.{height}", null, null, "v1.2", "1.2")]
+    [InlineData("1.2-beta", null, "rc", "v1.2", "1.2-rc")]
+    [InlineData("1.2-beta.{height}", null, "rc", "v1.2", "1.2-rc.{height}")]
     // modify release.branchName
     [InlineData("1.2-beta",          "v{version}release", null, "v1.2release", "1.2"            )]
     [InlineData("1.2-beta.{height}", "v{version}release", null, "v1.2release", "1.2"            )]
     [InlineData("1.2-beta",          "v{version}release", "rc", "v1.2release", "1.2-rc"         )]
-    [InlineData("1.2-beta.{height}", "v{version}release", "rc", "v1.2release", "1.2-rc.{height}")]    
+    [InlineData("1.2-beta.{height}", "v{version}release", "rc", "v1.2release", "1.2-rc.{height}")]
     public void PrepareRelease_ReleaseBranch(string initialVersion, string releaseOptionsBranchName, string releaseUnstableTag, string releaseBranchName, string resultingVersion)
     {
         releaseOptionsBranchName = releaseOptionsBranchName ?? new ReleaseOptions().BranchNameOrDefault;
@@ -147,7 +147,7 @@ public class ReleaseManagerTests : RepoTestBase
             }
         };
 
-        // create version.json 
+        // create version.json
         this.WriteVersionFile(initialVersionOptions);
 
         // switch to release branch
@@ -192,7 +192,7 @@ public class ReleaseManagerTests : RepoTestBase
         // switch to release branch
         Commands.Checkout(this.Repo, this.Repo.CreateBranch(branchName));
 
-        // running PrepareRelease should result in an error 
+        // running PrepareRelease should result in an error
         // because we're trying to add a prerelease tag to a version without prerelease tag
         this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag), ReleasePreparationError.VersionDecrement);
     }
@@ -200,37 +200,37 @@ public class ReleaseManagerTests : RepoTestBase
 
     [Theory]
     // base test cases
-    [InlineData("1.2-beta",          null, null, null, null, null, "release/v1.2", "1.2",             "1.3-alpha"          )]    
-    [InlineData("1.2-beta",          null, null, null, "rc", null, "release/v1.2", "1.2-rc",          "1.3-alpha"          )]
-    [InlineData("1.2-beta.{height}", null, null, null, null, null, "release/v1.2", "1.2",             "1.3-alpha.{height}" )]   
-    [InlineData("1.2-beta.{height}", null, null, null, "rc", null, "release/v1.2", "1.2-rc.{height}", "1.3-alpha.{height}" )]
+    [InlineData("1.2-beta", null, null, null, null, null, "v1.2", "1.2", "1.3-alpha")]
+    [InlineData("1.2-beta", null, null, null, "rc", null, "v1.2", "1.2-rc", "1.3-alpha")]
+    [InlineData("1.2-beta.{height}", null, null, null, null, null, "v1.2", "1.2", "1.3-alpha.{height}")]
+    [InlineData("1.2-beta.{height}", null, null, null, "rc", null, "v1.2", "1.2-rc.{height}", "1.3-alpha.{height}")]
     // modify release.branchName
-    [InlineData("1.2-beta",          "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha"          )]    
+    [InlineData("1.2-beta",          "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha"          )]
     [InlineData("1.2-beta",          "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc",          "1.3-alpha"          )]
-    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha.{height}" )]   
+    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha.{height}" )]
     [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc.{height}", "1.3-alpha.{height}" )]
     // modify release.versionIncrement
-    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Major, "alpha", null, null, "release/v1.2", "1.2",             "2.0-alpha"          )]    
-    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Major, "alpha", "rc", null, "release/v1.2", "1.2-rc",          "2.0-alpha"          )]
-    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Major, "alpha", null, null, "release/v1.2", "1.2",             "2.0-alpha.{height}" )]   
-    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Major, "alpha", "rc", null, "release/v1.2", "1.2-rc.{height}", "2.0-alpha.{height}" )]
+    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Major, "alpha", null, null, "v1.2", "1.2", "2.0-alpha")]
+    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Major, "alpha", "rc", null, "v1.2", "1.2-rc", "2.0-alpha")]
+    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Major, "alpha", null, null, "v1.2", "1.2", "2.0-alpha.{height}")]
+    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Major, "alpha", "rc", null, "v1.2", "1.2-rc.{height}", "2.0-alpha.{height}")]
     // modify release.firstUnstableTag
-    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Minor, "preview", null, null, "release/v1.2", "1.2",             "1.3-preview"          )]    
-    [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Minor, "preview", "rc", null, "release/v1.2", "1.2-rc",          "1.3-preview"          )]
-    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Minor, "preview", null, null, "release/v1.2", "1.2",             "1.3-preview.{height}" )]   
-    [InlineData("1.2-beta.{height}", null,   ReleaseVersionIncrement.Minor, "preview", "rc", null, "release/v1.2", "1.2-rc.{height}", "1.3-preview.{height}" )]
+    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Minor, "preview", null, null, "v1.2", "1.2", "1.3-preview")]
+    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Minor, "preview", "rc", null, "v1.2", "1.2-rc", "1.3-preview")]
+    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Minor, "preview", null, null, "v1.2", "1.2", "1.3-preview.{height}")]
+    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Minor, "preview", "rc", null, "v1.2", "1.2-rc.{height}", "1.3-preview.{height}")]
     // include build metadata in version
-    [InlineData("1.2-beta+metadata",          null,   ReleaseVersionIncrement.Minor, "alpha", null, null, "release/v1.2", "1.2+metadata",             "1.3-alpha+metadata"          )]    
-    [InlineData("1.2-beta+metadata",          null,   ReleaseVersionIncrement.Minor, "alpha", "rc", null, "release/v1.2", "1.2-rc+metadata",          "1.3-alpha+metadata"          )]
-    [InlineData("1.2-beta.{height}+metadata", null,   ReleaseVersionIncrement.Minor, "alpha", null, null, "release/v1.2", "1.2+metadata",             "1.3-alpha.{height}+metadata" )]   
-    [InlineData("1.2-beta.{height}+metadata", null,   ReleaseVersionIncrement.Minor, "alpha", "rc", null, "release/v1.2", "1.2-rc.{height}+metadata", "1.3-alpha.{height}+metadata" )]
+    [InlineData("1.2-beta+metadata", null, ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2", "1.2+metadata", "1.3-alpha+metadata")]
+    [InlineData("1.2-beta+metadata", null, ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2", "1.2-rc+metadata", "1.3-alpha+metadata")]
+    [InlineData("1.2-beta.{height}+metadata", null, ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2", "1.2+metadata", "1.3-alpha.{height}+metadata")]
+    [InlineData("1.2-beta.{height}+metadata", null, ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2", "1.2-rc.{height}+metadata", "1.3-alpha.{height}+metadata")]
     // versions without prerelease tags
-    [InlineData("1.2", null,   ReleaseVersionIncrement.Minor, "alpha", null, null, "release/v1.2", "1.2",  "1.3-alpha")]       
-    [InlineData("1.2", null,   ReleaseVersionIncrement.Major, "alpha", null, null, "release/v1.2", "1.2",  "2.0-alpha")]    
+    [InlineData("1.2", null, ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2", "1.2", "1.3-alpha")]
+    [InlineData("1.2", null, ReleaseVersionIncrement.Major, "alpha", null, null, "v1.2", "1.2", "2.0-alpha")]
     // explicitly set next version (firstUnstableTag setting will be ignored)
-    [InlineData("1.2-beta",          null, null, null, null, "4.5",              "release/v1.2", "1.2", "4.5"              )]    
-    [InlineData("1.2-beta",          null, null, null, null, "4.5-pre",          "release/v1.2", "1.2", "4.5-pre"          )]
-    [InlineData("1.2-beta.{height}", null, null, null, null, "4.5-pre.{height}", "release/v1.2", "1.2", "4.5-pre.{height}" )]       
+    [InlineData("1.2-beta", null, null, null, null, "4.5", "v1.2", "1.2", "4.5")]
+    [InlineData("1.2-beta", null, null, null, null, "4.5-pre", "v1.2", "1.2", "4.5-pre")]
+    [InlineData("1.2-beta.{height}", null, null, null, null, "4.5-pre.{height}", "v1.2", "1.2", "4.5-pre.{height}")]
     public void PrepareRelease_Master(
         // data for initial setup (version and release options configured in version.json)
         string initialVersion,
@@ -284,7 +284,7 @@ public class ReleaseManagerTests : RepoTestBase
                 FirstUnstableTag = releaseOptionsFirstUnstableTag
             }
         };
-        
+
         var initialBranchName = this.Repo.Head.FriendlyName;
         var tipBeforePrepareRelease = this.Repo.Head.Tip;
 
@@ -298,7 +298,7 @@ public class ReleaseManagerTests : RepoTestBase
         // PrepareRelease should switch back to the initial branch
         Assert.Equal(initialBranchName, this.Repo.Head.FriendlyName);
 
-        // check if release branch contains a new commit 
+        // check if release branch contains a new commit
         // parent of new commit must be the commit before preparing the release
         var releaseBranch = this.Repo.Branches[expectedBranchName];
         {
@@ -308,7 +308,7 @@ public class ReleaseManagerTests : RepoTestBase
 
         // check if current branch contains new commits
         // - one commit that updates the version (parent must be the commit before preparing the release)
-        // - one commit merging the release branch back to master and resolving the conflict        
+        // - one commit merging the release branch back to master and resolving the conflict
         {
             var mergeCommit = this.Repo.Head.Tip;
             Assert.Equal(2, mergeCommit.Parents.Count());
@@ -348,21 +348,16 @@ public class ReleaseManagerTests : RepoTestBase
         var versionOptions = new VersionOptions() { Version = SemanticVersion.Parse(initialVersion) };
         this.WriteVersionFile(versionOptions);
 
-        // running PrepareRelease should result in an error 
-        // because we're trying to add a prerelease tag to a version without prerelease tag        
+        // running PrepareRelease should result in an error
+        // because we're trying to add a prerelease tag to a version without prerelease tag
         this.AssertError(
-            () => new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag, (nextVersion == null ? null : SemanticVersion.Parse(nextVersion))), 
+            () => new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag, (nextVersion == null ? null : SemanticVersion.Parse(nextVersion))),
             ReleasePreparationError.VersionDecrement);
     }
 
-
     private void AssertError(Action testCode, ReleasePreparationError expectedError)
     {
-        var exception = Record.Exception(testCode);
-
-        Assert.NotNull(exception);
-        Assert.IsType<ReleasePreparationException>(exception);
-
-        Assert.Equal(expectedError, ((ReleasePreparationException)exception).Error);
+        var ex = Assert.Throws<ReleasePreparationException>(testCode);
+        Assert.Equal(expectedError, ex.Error);
     }
 }

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -46,6 +46,26 @@ public class ReleaseManagerTests : RepoTestBase
         this.AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath), ReleasePreparationError.UncommittedChanges);
     }
 
+    [Fact]
+    public void PrepareRelease_InvalidBranchNameSetting()
+    {
+        this.InitializeSourceControl();
+
+        // create version.json
+        var versionOptions = new VersionOptions()
+        {
+            Version = SemanticVersion.Parse("1.2-pre"),
+            Release = new ReleaseOptions()
+            {
+                BranchName = "nameWithoutPlaceholder",
+            }
+        };
+        this.WriteVersionFile(versionOptions);
+
+
+        AssertError(() => ReleaseManager.PrepareRelease(this.RepoPath), ReleasePreparationError.InvalidBranchNameSetting);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("v{0}")]

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -96,7 +96,7 @@ public class ReleaseManagerTests : RepoTestBase
             Version = SemanticVersion.Parse("1.2-pre"),
             Release = new ReleaseOptions()
             {
-                BranchName = "release/v{0}",
+                BranchName = "release/v{version}",
             }
         };
 
@@ -116,10 +116,10 @@ public class ReleaseManagerTests : RepoTestBase
     [InlineData("1.2-beta",          null, "rc", "release/v1.2", "1.2-rc"         )]
     [InlineData("1.2-beta.{height}", null, "rc", "release/v1.2", "1.2-rc.{height}")]
     // modify release.branchName
-    [InlineData("1.2-beta",          "v{0}release", null, "v1.2release", "1.2"            )]
-    [InlineData("1.2-beta.{height}", "v{0}release", null, "v1.2release", "1.2"            )]
-    [InlineData("1.2-beta",          "v{0}release", "rc", "v1.2release", "1.2-rc"         )]
-    [InlineData("1.2-beta.{height}", "v{0}release", "rc", "v1.2release", "1.2-rc.{height}")]    
+    [InlineData("1.2-beta",          "v{version}release", null, "v1.2release", "1.2"            )]
+    [InlineData("1.2-beta.{height}", "v{version}release", null, "v1.2release", "1.2"            )]
+    [InlineData("1.2-beta",          "v{version}release", "rc", "v1.2release", "1.2-rc"         )]
+    [InlineData("1.2-beta.{height}", "v{version}release", "rc", "v1.2release", "1.2-rc.{height}")]    
     public void PrepareRelease_ReleaseBranch(string initialVersion, string releaseOptionsBranchName, string releaseUnstableTag, string releaseBranchName, string resultingVersion)
     {
         releaseOptionsBranchName = releaseOptionsBranchName ?? new ReleaseOptions().BranchNameOrDefault;
@@ -176,9 +176,9 @@ public class ReleaseManagerTests : RepoTestBase
     }
 
     [Theory]
-    [InlineData("1.2", "rc")]
-    [InlineData("1.2+metadata", "rc")]
-    public void PrepeareRelease_ReleaseBranchWithVersionDecrement(string initialVersion, string releaseUnstableTag)
+    [InlineData("1.2",          "rc", "release/v{version}", "release/v1.2")]
+    [InlineData("1.2+metadata", "rc", "release/v{version}", "release/v1.2")]
+    public void PrepeareRelease_ReleaseBranchWithVersionDecrement(string initialVersion, string releaseUnstableTag, string releaseOptionsBranchName, string branchName)
     {
         // create and configure repository
         this.InitializeSourceControl();
@@ -190,7 +190,6 @@ public class ReleaseManagerTests : RepoTestBase
         this.WriteVersionFile(versionOptions);
 
         // switch to release branch
-        var branchName = string.Format(versionOptions.ReleaseOrDefault.BranchNameOrDefault, versionOptions.Version.Version);
         Commands.Checkout(this.Repo, this.Repo.CreateBranch(branchName));
 
         // running PrepareRelease should result in an error 
@@ -206,10 +205,10 @@ public class ReleaseManagerTests : RepoTestBase
     [InlineData("1.2-beta.{height}", null, null, null, null, null, "release/v1.2", "1.2",             "1.3-alpha.{height}" )]   
     [InlineData("1.2-beta.{height}", null, null, null, "rc", null, "release/v1.2", "1.2-rc.{height}", "1.3-alpha.{height}" )]
     // modify release.branchName
-    [InlineData("1.2-beta",          "v{0}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha"          )]    
-    [InlineData("1.2-beta",          "v{0}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc",          "1.3-alpha"          )]
-    [InlineData("1.2-beta.{height}", "v{0}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha.{height}" )]   
-    [InlineData("1.2-beta.{height}", "v{0}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc.{height}", "1.3-alpha.{height}" )]
+    [InlineData("1.2-beta",          "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha"          )]    
+    [InlineData("1.2-beta",          "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc",          "1.3-alpha"          )]
+    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2",             "1.3-alpha.{height}" )]   
+    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc.{height}", "1.3-alpha.{height}" )]
     // modify release.versionIncrement
     [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Major, "alpha", null, null, "release/v1.2", "1.2",             "2.0-alpha"          )]    
     [InlineData("1.2-beta",          null,   ReleaseVersionIncrement.Major, "alpha", "rc", null, "release/v1.2", "1.2-rc",          "2.0-alpha"          )]

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using LibGit2Sharp;
+using Nerdbank.GitVersioning;
+using Nerdbank.GitVersioning.Tests;
+using Xunit;
+using Xunit.Abstractions;
+using static Nerdbank.GitVersioning.ReleaseManager;
+
+public class ReleaseManagerTests : RepoTestBase
+{
+    public ReleaseManagerTests(ITestOutputHelper logger) : base(logger)
+    {
+    }
+
+    [Fact]
+    public void PrepareRelease_NoGitRepo()
+    {
+        this.AssertError(
+            () => ReleaseManager.PrepareRelease(this.RepoPath),
+            ReleasePreparationError.NoGitRepo
+        );        
+    }
+
+    [Fact]
+    public void PrepareRelease_DirtyWorkingDirecotory()
+    {       
+        this.InitializeSourceControl();
+
+        File.WriteAllText(Path.Combine(this.RepoPath, "file1.txt"), "");
+
+        this.AssertError(
+            () => ReleaseManager.PrepareRelease(this.RepoPath),
+            ReleasePreparationError.UncommittedChanges
+        );  
+    }
+
+    [Fact]
+    public void PrepareRelease_DirtyIndex()
+    {
+        this.InitializeSourceControl();
+
+        var filePath = Path.Combine(this.RepoPath, "file1.txt");
+        File.WriteAllText(filePath, "");
+
+        Commands.Stage(this.Repo, filePath);
+
+
+        this.AssertError(
+            () => ReleaseManager.PrepareRelease(this.RepoPath),
+            ReleasePreparationError.UncommittedChanges
+        );
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("v{0}")]
+    public void PrepareRelease_OnReleaseBranch(string releaseBranchFormat)
+    {
+        var version = "1.2";
+        releaseBranchFormat = releaseBranchFormat ?? new VersionOptions.ReleaseOptions().BranchNameOrDefault;
+
+        this.InitializeSourceControl();
+        this.WriteVersionFile(new VersionOptions()
+        {
+            Version = new SemanticVersion(version),
+            Release = new VersionOptions.ReleaseOptions()
+            {
+                BranchName = releaseBranchFormat
+            }
+        });
+        
+
+        var branch = this.Repo.CreateBranch(String.Format(releaseBranchFormat, version));
+        Commands.Checkout(this.Repo, branch);
+
+
+        this.AssertError(
+            () => ReleaseManager.PrepareRelease(this.RepoPath),
+            ReleasePreparationError.OnReleaseBranch
+        );
+
+    }
+
+    [Fact]
+    //TODO: more test cases (different release settings)
+    public void PrepareRelease_OnMaster()
+    {
+        var version = SemanticVersion.Parse("1.2-pre");
+
+        // create and configure repository
+        this.InitializeSourceControl();
+        this.Repo.Config.Set("user.name", this.Signer.Name, ConfigurationLevel.Local);
+        this.Repo.Config.Set("user.email", this.Signer.Email, ConfigurationLevel.Local);
+        
+        // cretae version.json
+        var versionOptions = new VersionOptions()
+        {
+            Version = version,
+            Release = new VersionOptions.ReleaseOptions()
+        };
+        this.WriteVersionFile(versionOptions);
+
+        var expectedBranchName = String.Format(versionOptions.ReleaseOrDefault.BranchNameOrDefault, version.Version);
+
+        // prepare release
+        ReleaseManager.PrepareRelease(this.RepoPath);
+
+        // check if a branch was created
+        Assert.Contains(this.Repo.Branches, branch => branch.FriendlyName == expectedBranchName);
+        var masterBranch = this.Repo.Branches.Single(branch => branch.FriendlyName == "master");
+        var releaseBranch = this.Repo.Branches.Single(branch => branch.FriendlyName == expectedBranchName);
+
+        // check if if release branch contains a new commit
+        Assert.NotEqual(releaseBranch.Tip.Sha, masterBranch.Tip.Sha);
+
+        // check version on release branch
+        var releaseBranchVersion = VersionFile.GetVersion(releaseBranch.Tip);
+        Assert.Equal(version.Version.ToString(), releaseBranchVersion.Version.ToString());
+    }
+
+
+    private void AssertError(Action testCode, ReleasePreparationError expectedError)
+    {
+        var exception = Record.Exception(testCode);
+
+        Assert.NotNull(exception);
+        Assert.IsType<ReleasePreparationException>(exception);
+
+        Assert.Equal(expectedError, ((ReleasePreparationException)exception).Error);
+    }
+}

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -85,6 +85,30 @@ public class ReleaseManagerTests : RepoTestBase
         this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.InvalidBranchNameSetting);
     }
 
+    [Fact]
+    public void PrepareRelease_ReleaseBranchAlreadyExists()
+    {
+        this.InitializeSourceControl();
+
+        // create version.json
+        var versionOptions = new VersionOptions()
+        {
+            Version = SemanticVersion.Parse("1.2-pre"),
+            Release = new ReleaseOptions()
+            {
+                BranchName = "release/v{0}",
+            }
+        };
+
+        this.WriteVersionFile(versionOptions);
+
+        this.Repo.CreateBranch("release/v1.2");
+
+        // running PrepareRelease should result in an error 
+        // because the branchName does not have a placeholder for the version
+        this.AssertError(() => new ReleaseManager().PrepareRelease(this.RepoPath), ReleasePreparationError.BranchAlreadyExists);
+    }
+
     [Theory]
     // base test cases
     [InlineData("1.2-beta",          null, null, "release/v1.2", "1.2"            )]

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -370,6 +370,16 @@ public class ReleaseManagerTests : RepoTestBase
             ReleasePreparationError.VersionDecrement);
     }
 
+    [Fact]
+    public void PrepareRelease_DetachedHead()
+    {
+        this.InitializeSourceControl();
+        this.WriteVersionFile("1.0", "-alpha");
+        Commands.Checkout(this.Repo, this.Repo.Head.Commits.First());
+        var ex = Assert.Throws<ReleasePreparationException>(() => new ReleaseManager().PrepareRelease(this.RepoPath));
+        Assert.Equal(ReleasePreparationError.DetachedHead, ex.Error);
+    }
+
     private void AssertError(Action testCode, ReleasePreparationError expectedError)
     {
         var ex = Assert.Throws<ReleasePreparationException>(testCode);

--- a/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
+++ b/src/NerdBank.GitVersioning.Tests/RepoTestBase.cs
@@ -133,7 +133,7 @@
             {
                 Assumes.True(versionFilePath.StartsWith(this.RepoPath, StringComparison.OrdinalIgnoreCase));
                 var relativeFilePath = versionFilePath.Substring(this.RepoPath.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-                this.Repo.Index.Add(relativeFilePath);
+                Commands.Stage(this.Repo, relativeFilePath);
                 if (Path.GetExtension(relativeFilePath) == ".json")
                 {
                     string txtFilePath = relativeFilePath.Substring(0, relativeFilePath.Length - 4) + "txt";

--- a/src/NerdBank.GitVersioning.Tests/SemanticVersionExtensionsTest.cs
+++ b/src/NerdBank.GitVersioning.Tests/SemanticVersionExtensionsTest.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Nerdbank.GitVersioning;
+using Xunit;
+using Xunit.Sdk;
+
+using static Nerdbank.GitVersioning.VersionOptions;
+
+/// <summary>
+/// Tests for <see cref=""/>
+/// </summary>
+public class SemanticVersionExtensionsTest
+{
+    /// <summary>
+    /// Provides testcases (original version, incremented version) in all supported version formats for
+    /// testing <see cref="SemanticVersionExtensions.Increment(SemanticVersion, ReleaseVersionIncrement)"/>
+    /// </summary>
+    public class TestDataAttribute : DataAttribute
+    {            
+        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+        {
+            // prefix: none or "v"
+            foreach (var prefix in new[] { "", "v" })
+            // version has either 2, 3 or 4 components
+            foreach (var precision in new[] { VersionPrecision.Minor, VersionPrecision.Build, VersionPrecision.Revision })
+            // version can have a prerelease tag
+            foreach (var prereleaseTag in new[] { "", "-pre", "-pre.{height}", "-{height}", "-{height}.build" }) 
+            // version can have build metadata
+            foreach (var buildMetadata in new[] { "", "+build", "+build.{height}", "+{height}", "+{height}.build" }) 
+            // either major or minor version can be incremented
+            foreach (var increment in new[] { ReleaseVersionIncrement.Major, ReleaseVersionIncrement.Minor }) 
+            {
+                var major = 1;
+                var minor = 2;
+                var build = 3;
+                var revision = 4;
+
+                var majorIncrement = increment == ReleaseVersionIncrement.Major ? 1 : 0;
+                var minorIncrement = increment == ReleaseVersionIncrement.Minor ? 1 : 0;
+
+                var current = $"{prefix}{major}.{minor}";
+                var next = $"{prefix}{major + majorIncrement}.{minor + minorIncrement}";
+
+                // append third and/or fourth version component
+                switch (precision)
+                {
+                    case VersionPrecision.Build:
+                        current += $".{build}";
+                        next += $".{build}";
+                        break;
+                    case VersionPrecision.Revision:
+                        current += $".{build}.{revision}";
+                        next += $".{build}.{revision}";
+                        break;
+                }
+
+                // append prerelease tag
+                current += prereleaseTag;
+                next += prereleaseTag;
+                
+                // append build metadata
+                current += buildMetadata;
+                next += buildMetadata;
+
+                yield return new object[]
+                {
+                    current,
+                    increment,
+                    next
+                };
+            }
+        }
+    }
+
+    [Theory]
+    [TestData]
+    public void IncrementVersion(string currentVersionString, ReleaseVersionIncrement increment, string expectedVersionString)
+    {
+        var currentVersion = SemanticVersion.Parse(currentVersionString);
+        var expectedVersion = SemanticVersion.Parse(expectedVersionString);
+
+        var actualVersion = currentVersion.Increment(increment);
+
+        Assert.Equal(expectedVersion, actualVersion);
+    }
+}
+

--- a/src/NerdBank.GitVersioning.Tests/SemanticVersionExtensionsTest.cs
+++ b/src/NerdBank.GitVersioning.Tests/SemanticVersionExtensionsTest.cs
@@ -11,69 +11,19 @@ using static Nerdbank.GitVersioning.VersionOptions;
 /// </summary>
 public class SemanticVersionExtensionsTest
 {
-    /// <summary>
-    /// Provides testcases (original version, incremented version) in all supported version formats for
-    /// testing <see cref="SemanticVersionExtensions.Increment(SemanticVersion, ReleaseVersionIncrement)"/>
-    /// </summary>
-    public class TestDataAttribute : DataAttribute
-    {            
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            // prefix: none or "v"
-            foreach (var prefix in new[] { "", "v" })
-            // version has either 2, 3 or 4 components
-            foreach (var precision in new[] { VersionPrecision.Minor, VersionPrecision.Build, VersionPrecision.Revision })
-            // version can have a prerelease tag
-            foreach (var prereleaseTag in new[] { "", "-pre", "-pre.{height}", "-{height}", "-{height}.build" }) 
-            // version can have build metadata
-            foreach (var buildMetadata in new[] { "", "+build", "+build.{height}", "+{height}", "+{height}.build" }) 
-            // either major or minor version can be incremented
-            foreach (var increment in new[] { ReleaseVersionIncrement.Major, ReleaseVersionIncrement.Minor }) 
-            {
-                var major = 1;
-                var minor = 2;
-                var build = 3;
-                var revision = 4;
-
-                var majorIncrement = increment == ReleaseVersionIncrement.Major ? 1 : 0;
-                var minorIncrement = increment == ReleaseVersionIncrement.Minor ? 1 : 0;
-
-                var current = $"{prefix}{major}.{minor}";
-                var next = $"{prefix}{major + majorIncrement}.{minor + minorIncrement}";
-
-                // append third and/or fourth version component
-                switch (precision)
-                {
-                    case VersionPrecision.Build:
-                        current += $".{build}";
-                        next += $".{build}";
-                        break;
-                    case VersionPrecision.Revision:
-                        current += $".{build}.{revision}";
-                        next += $".{build}.{revision}";
-                        break;
-                }
-
-                // append prerelease tag
-                current += prereleaseTag;
-                next += prereleaseTag;
-                
-                // append build metadata
-                current += buildMetadata;
-                next += buildMetadata;
-
-                yield return new object[]
-                {
-                    current,
-                    increment,
-                    next
-                };
-            }
-        }
-    }
-
     [Theory]
-    [TestData]
+    [InlineData("1.0", ReleaseVersionIncrement.Minor, "1.1")]
+    [InlineData("1.0", ReleaseVersionIncrement.Major, "2.0")]
+    [InlineData("1.0-tag", ReleaseVersionIncrement.Minor, "1.1-tag")]
+    [InlineData("1.0-tag", ReleaseVersionIncrement.Major, "2.0-tag")]
+    [InlineData("1.0+metadata", ReleaseVersionIncrement.Minor, "1.1+metadata")]
+    [InlineData("1.0+metadata", ReleaseVersionIncrement.Major, "2.0+metadata")]
+    [InlineData("1.0-tag+metadata", ReleaseVersionIncrement.Minor, "1.1-tag+metadata")]
+    [InlineData("1.0-tag+metadata", ReleaseVersionIncrement.Major, "2.0-tag+metadata")]
+    [InlineData("1.2.3", ReleaseVersionIncrement.Minor, "1.3.3")]
+    [InlineData("1.2.3", ReleaseVersionIncrement.Major, "2.2.3")]
+    [InlineData("1.2.3.4", ReleaseVersionIncrement.Minor, "1.3.3.4")]
+    [InlineData("1.2.3.4", ReleaseVersionIncrement.Major, "2.2.3.4")]
     public void IncrementVersion(string currentVersionString, ReleaseVersionIncrement increment, string expectedVersionString)
     {
         var currentVersion = SemanticVersion.Parse(currentVersionString);

--- a/src/NerdBank.GitVersioning.Tests/SemanticVersionExtensionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/SemanticVersionExtensionsTests.cs
@@ -13,17 +13,19 @@ public class SemanticVersionExtensionsTests
 {
     [Theory]
     [InlineData("1.0", ReleaseVersionIncrement.Minor, "1.1")]
+    [InlineData("1.1", ReleaseVersionIncrement.Minor, "1.2")]
     [InlineData("1.0", ReleaseVersionIncrement.Major, "2.0")]
+    [InlineData("1.1", ReleaseVersionIncrement.Major, "2.0")]
     [InlineData("1.0-tag", ReleaseVersionIncrement.Minor, "1.1-tag")]
     [InlineData("1.0-tag", ReleaseVersionIncrement.Major, "2.0-tag")]
     [InlineData("1.0+metadata", ReleaseVersionIncrement.Minor, "1.1+metadata")]
     [InlineData("1.0+metadata", ReleaseVersionIncrement.Major, "2.0+metadata")]
     [InlineData("1.0-tag+metadata", ReleaseVersionIncrement.Minor, "1.1-tag+metadata")]
     [InlineData("1.0-tag+metadata", ReleaseVersionIncrement.Major, "2.0-tag+metadata")]
-    [InlineData("1.2.3", ReleaseVersionIncrement.Minor, "1.3.3")]
-    [InlineData("1.2.3", ReleaseVersionIncrement.Major, "2.2.3")]
-    [InlineData("1.2.3.4", ReleaseVersionIncrement.Minor, "1.3.3.4")]
-    [InlineData("1.2.3.4", ReleaseVersionIncrement.Major, "2.2.3.4")]
+    [InlineData("1.2.3", ReleaseVersionIncrement.Minor, "1.3.0")]
+    [InlineData("1.2.3", ReleaseVersionIncrement.Major, "2.0.0")]
+    [InlineData("1.2.3.4", ReleaseVersionIncrement.Minor, "1.3.0.0")]
+    [InlineData("1.2.3.4", ReleaseVersionIncrement.Major, "2.0.0.0")]
     public void IncrementVersion(string currentVersionString, ReleaseVersionIncrement increment, string expectedVersionString)
     {
         var currentVersion = SemanticVersion.Parse(currentVersionString);

--- a/src/NerdBank.GitVersioning.Tests/SemanticVersionExtensionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/SemanticVersionExtensionsTests.cs
@@ -9,7 +9,7 @@ using static Nerdbank.GitVersioning.VersionOptions;
 /// <summary>
 /// Tests for <see cref=""/>
 /// </summary>
-public class SemanticVersionExtensionsTest
+public class SemanticVersionExtensionsTests
 {
     [Theory]
     [InlineData("1.0", ReleaseVersionIncrement.Minor, "1.1")]
@@ -30,6 +30,36 @@ public class SemanticVersionExtensionsTest
         var expectedVersion = SemanticVersion.Parse(expectedVersionString);
 
         var actualVersion = currentVersion.Increment(increment);
+
+        Assert.Equal(expectedVersion, actualVersion);
+    }
+
+    [Theory]
+    // no prerelease tag in input version
+    [InlineData("1.2", "pre", "1.2-pre")]
+    [InlineData("1.2", "-pre", "1.2-pre")]
+    [InlineData("1.2+build", "pre", "1.2-pre+build")]
+    [InlineData("1.2.3", "pre", "1.2.3-pre")]
+    [InlineData("1.2.3+build", "pre", "1.2.3-pre+build")]
+    // single prerelease tag in input version
+    [InlineData("1.2-alpha", "beta", "1.2-beta")]
+    [InlineData("1.2-alpha", "-beta", "1.2-beta")]
+    [InlineData("1.2.3-alpha", "beta", "1.2.3-beta")]
+    [InlineData("1.2-alpha+metadata", "-beta", "1.2-beta+metadata")]
+    // multiple prerelease tags
+    [InlineData("1.2-alpha.preview", "beta", "1.2-beta.preview")]
+    [InlineData("1.2-alpha.preview", "-beta", "1.2-beta.preview")]
+    [InlineData("1.2-alpha.preview+metadata", "beta", "1.2-beta.preview+metadata")]    
+    [InlineData("1.2.3-alpha.preview", "beta", "1.2.3-beta.preview")]
+    [InlineData("1.2-alpha.{height}", "beta", "1.2-beta.{height}")]
+    // remove tag
+    [InlineData("1.2-pre", "", "1.2")]
+    public void SetFirstPrereleaseTag(string currentVersionString, string newTag, string expectedVersionString)
+    {
+        var currentVersion = SemanticVersion.Parse(currentVersionString);
+        var expectedVersion = SemanticVersion.Parse(expectedVersionString);
+
+        var actualVersion = currentVersion.SetFirstPrereleaseTag(newTag);
 
         Assert.Equal(expectedVersion, actualVersion);
     }

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -143,6 +143,12 @@ public class VersionFileTests : RepoTestBase
     [InlineData(@"{""cloudBuild"":{""buildNumber"":{""enabled"":true,""includeCommitId"":{""when"":""nonPublicReleaseOnly"",""where"":""fourthVersionComponent""}}}}", @"{""cloudBuild"":{""buildNumber"":{""enabled"":true,""includeCommitId"":{""where"":""fourthVersionComponent""}}}}")]
     [InlineData(@"{""cloudBuild"":{""setVersionVariables"":true}}", @"{}")]
     [InlineData(@"{""cloudBuild"":{""setAllVariables"":false}}", @"{}")]
+    [InlineData(@"{""release"":{""increment"":""minor""}}", @"{}")]
+    [InlineData(@"{""release"":{""branchName"":""release/v{0}""}}", @"{}")]
+    [InlineData(@"{""release"":{""branchName"":""release/v{0}"",""versionIncrement"":""minor""}}", @"{}")]
+    [InlineData(@"{""release"":{""versionIncrement"":""major""}}", @"{""release"":{""versionIncrement"":""major""}}")]
+    [InlineData(@"{""release"":{""branchName"":""someName""}}", @"{""release"":{""branchName"":""someName""}}")]
+    [InlineData(@"{""release"":{""branchName"":""someName"",""versionIncrement"":""major""}}", @"{""release"":{""branchName"":""someName"",""versionIncrement"":""major""}}")]
     public void JsonMinification(string full, string minimal)
     {
         var settings = VersionOptions.GetJsonSettings();

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -318,7 +318,7 @@ public class VersionFileTests : RepoTestBase
 
         Assert.NotNull(versionOptions.Release);
         Assert.NotNull(versionOptions.Release.BranchName);
-        Assert.Equal("someValue{0}", versionOptions.Release.BranchName);
+        Assert.Equal("someValue{version}", versionOptions.Release.BranchName);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -278,6 +278,49 @@ public class VersionFileTests : RepoTestBase
         this.AssertPathHasVersion(commit, this.RepoPath, rootVersionSpec);
     }
 
+
+    [Fact]
+    public void GetVersion_ReadReleaseSettings_VersionIncrement()
+    {
+        var json = @"{ ""version"" : ""1.2"", ""release"" : { ""versionIncrement"" : ""major""  } }";
+        var path = Path.Combine(this.RepoPath, "version.json");
+        File.WriteAllText(path, json);
+
+        var versionOptions = VersionFile.GetVersion(this.RepoPath);
+
+        Assert.NotNull(versionOptions.Release);        
+        Assert.NotNull(versionOptions.Release.VersionIncrement);        
+        Assert.Equal(VersionOptions.ReleaseVersionIncrement.Major, versionOptions.Release.VersionIncrement);
+    }
+
+    [Fact]
+    public void GetVersion_ReadReleaseSettings_FirstUnstableTag()
+    {
+        var json = @"{ ""version"" : ""1.2"", ""release"" : { ""firstUnstableTag"" : ""preview""  } }";
+        var path = Path.Combine(this.RepoPath, "version.json");
+        File.WriteAllText(path, json);
+
+        var versionOptions = VersionFile.GetVersion(this.RepoPath);
+
+        Assert.NotNull(versionOptions.Release);
+        Assert.NotNull(versionOptions.Release.FirstUnstableTag);
+        Assert.Equal("preview", versionOptions.Release.FirstUnstableTag);
+    }
+
+    [Fact]
+    public void GetVersion_ReadReleaseSettings_BranchName()
+    {
+        var json = @"{ ""version"" : ""1.2"", ""release"" : { ""branchName"" : ""someValue{0}""  } }";
+        var path = Path.Combine(this.RepoPath, "version.json");
+        File.WriteAllText(path, json);
+
+        var versionOptions = VersionFile.GetVersion(this.RepoPath);
+
+        Assert.NotNull(versionOptions.Release);
+        Assert.NotNull(versionOptions.Release.BranchName);
+        Assert.Equal("someValue{0}", versionOptions.Release.BranchName);
+    }
+
     [Fact]
     public void GetVersion_String_MissingFile()
     {

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -144,10 +144,10 @@ public class VersionFileTests : RepoTestBase
     [InlineData(@"{""cloudBuild"":{""setVersionVariables"":true}}", @"{}")]
     [InlineData(@"{""cloudBuild"":{""setAllVariables"":false}}", @"{}")]
     [InlineData(@"{""release"":{""increment"":""minor""}}", @"{}")]
-    [InlineData(@"{""release"":{""branchName"":""release/v{0}""}}", @"{}")]
+    [InlineData(@"{""release"":{""branchName"":""release/v{version}""}}", @"{}")]
     [InlineData(@"{""release"":{""firstUnstableTag"":""alpha""}}", @"{}")]
     [InlineData(@"{""release"":{""firstUnstableTag"":""tag""}}", @"{""release"":{""firstUnstableTag"":""tag""}}")]
-    [InlineData(@"{""release"":{""branchName"":""release/v{0}"",""versionIncrement"":""minor"",""firstUnstableTag"":""alpha""}}", @"{}")]
+    [InlineData(@"{""release"":{""branchName"":""release/v{version}"",""versionIncrement"":""minor"",""firstUnstableTag"":""alpha""}}", @"{}")]
     [InlineData(@"{""release"":{""versionIncrement"":""major""}}", @"{""release"":{""versionIncrement"":""major""}}")]
     [InlineData(@"{""release"":{""branchName"":""someName""}}", @"{""release"":{""branchName"":""someName""}}")]
     [InlineData(@"{""release"":{""branchName"":""someName"",""versionIncrement"":""major""}}", @"{""release"":{""branchName"":""someName"",""versionIncrement"":""major""}}")]
@@ -310,7 +310,7 @@ public class VersionFileTests : RepoTestBase
     [Fact]
     public void GetVersion_ReadReleaseSettings_BranchName()
     {
-        var json = @"{ ""version"" : ""1.2"", ""release"" : { ""branchName"" : ""someValue{0}""  } }";
+        var json = @"{ ""version"" : ""1.2"", ""release"" : { ""branchName"" : ""someValue{version}""  } }";
         var path = Path.Combine(this.RepoPath, "version.json");
         File.WriteAllText(path, json);
 

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -144,10 +144,10 @@ public class VersionFileTests : RepoTestBase
     [InlineData(@"{""cloudBuild"":{""setVersionVariables"":true}}", @"{}")]
     [InlineData(@"{""cloudBuild"":{""setAllVariables"":false}}", @"{}")]
     [InlineData(@"{""release"":{""increment"":""minor""}}", @"{}")]
-    [InlineData(@"{""release"":{""branchName"":""release/v{version}""}}", @"{}")]
+    [InlineData(@"{""release"":{""branchName"":""v{version}""}}", @"{}")]
     [InlineData(@"{""release"":{""firstUnstableTag"":""alpha""}}", @"{}")]
     [InlineData(@"{""release"":{""firstUnstableTag"":""tag""}}", @"{""release"":{""firstUnstableTag"":""tag""}}")]
-    [InlineData(@"{""release"":{""branchName"":""release/v{version}"",""versionIncrement"":""minor"",""firstUnstableTag"":""alpha""}}", @"{}")]
+    [InlineData(@"{""release"":{""branchName"":""v{version}"",""versionIncrement"":""minor"",""firstUnstableTag"":""alpha""}}", @"{}")]
     [InlineData(@"{""release"":{""versionIncrement"":""major""}}", @"{""release"":{""versionIncrement"":""major""}}")]
     [InlineData(@"{""release"":{""branchName"":""someName""}}", @"{""release"":{""branchName"":""someName""}}")]
     [InlineData(@"{""release"":{""branchName"":""someName"",""versionIncrement"":""major""}}", @"{""release"":{""branchName"":""someName"",""versionIncrement"":""major""}}")]
@@ -288,8 +288,8 @@ public class VersionFileTests : RepoTestBase
 
         var versionOptions = VersionFile.GetVersion(this.RepoPath);
 
-        Assert.NotNull(versionOptions.Release);        
-        Assert.NotNull(versionOptions.Release.VersionIncrement);        
+        Assert.NotNull(versionOptions.Release);
+        Assert.NotNull(versionOptions.Release.VersionIncrement);
         Assert.Equal(VersionOptions.ReleaseVersionIncrement.Major, versionOptions.Release.VersionIncrement);
     }
 

--- a/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionFileTests.cs
@@ -145,10 +145,14 @@ public class VersionFileTests : RepoTestBase
     [InlineData(@"{""cloudBuild"":{""setAllVariables"":false}}", @"{}")]
     [InlineData(@"{""release"":{""increment"":""minor""}}", @"{}")]
     [InlineData(@"{""release"":{""branchName"":""release/v{0}""}}", @"{}")]
-    [InlineData(@"{""release"":{""branchName"":""release/v{0}"",""versionIncrement"":""minor""}}", @"{}")]
+    [InlineData(@"{""release"":{""firstUnstableTag"":""alpha""}}", @"{}")]
+    [InlineData(@"{""release"":{""firstUnstableTag"":""tag""}}", @"{""release"":{""firstUnstableTag"":""tag""}}")]
+    [InlineData(@"{""release"":{""branchName"":""release/v{0}"",""versionIncrement"":""minor"",""firstUnstableTag"":""alpha""}}", @"{}")]
     [InlineData(@"{""release"":{""versionIncrement"":""major""}}", @"{""release"":{""versionIncrement"":""major""}}")]
     [InlineData(@"{""release"":{""branchName"":""someName""}}", @"{""release"":{""branchName"":""someName""}}")]
     [InlineData(@"{""release"":{""branchName"":""someName"",""versionIncrement"":""major""}}", @"{""release"":{""branchName"":""someName"",""versionIncrement"":""major""}}")]
+    [InlineData(@"{""release"":{""branchName"":""someName"",""versionIncrement"":""major"",""firstUnstableTag"":""alpha""}}", @"{""release"":{""branchName"":""someName"",""versionIncrement"":""major""}}")]
+    [InlineData(@"{""release"":{""branchName"":""someName"",""versionIncrement"":""major"",""firstUnstableTag"":""pre""}}", @"{""release"":{""branchName"":""someName"",""versionIncrement"":""major"",""firstUnstableTag"":""pre""}}")]
     public void JsonMinification(string full, string minimal)
     {
         var settings = VersionOptions.GetJsonSettings();

--- a/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
@@ -180,35 +180,50 @@ public class VersionOptionsTests
         Assert.Throws<InvalidOperationException>(() => options.NuGetPackageVersionOrDefault.SemVer = 2);
         Assert.Throws<InvalidOperationException>(() => options.ReleaseOrDefault.BranchName = "BranchName");
         Assert.Throws<InvalidOperationException>(() => options.ReleaseOrDefault.VersionIncrement = VersionOptions.ReleaseVersionIncrement.Major);
+        Assert.Throws<InvalidOperationException>(() => options.ReleaseOrDefault.FirstUnstableTag = "-tag");
     }
 
 
     [Fact]
     public void ReleaseOptions_Equality()
     {
-        var releaseOptions1 = new VersionOptions.ReleaseOptions() { };
-        var releaseOptions2 = new VersionOptions.ReleaseOptions() { };
-        var releaseOptions3 = new VersionOptions.ReleaseOptions()
+        var ro1 = new VersionOptions.ReleaseOptions() { };
+        var ro2 = new VersionOptions.ReleaseOptions() { };
+        var ro3 = new VersionOptions.ReleaseOptions()
         {
             BranchName = "branchName",
             VersionIncrement = VersionOptions.ReleaseVersionIncrement.Major
         };
-        var releaseOptions4 = new VersionOptions.ReleaseOptions()
+        var ro4 = new VersionOptions.ReleaseOptions()
         {
             BranchName = "branchName",
             VersionIncrement = VersionOptions.ReleaseVersionIncrement.Major
         };
-        var releaseOptions5 = new VersionOptions.ReleaseOptions()
+        var ro5 = new VersionOptions.ReleaseOptions()
         {
             BranchName = "branchName",
-            VersionIncrement = VersionOptions.ReleaseVersionIncrement.Minor
+            VersionIncrement = VersionOptions.ReleaseVersionIncrement.Minor,            
+        };
+        var ro6 = new VersionOptions.ReleaseOptions()
+        {
+            BranchName = "branchName",
+            VersionIncrement = VersionOptions.ReleaseVersionIncrement.Minor,
+            FirstUnstableTag = "tag"
+        };
+        var ro7 = new VersionOptions.ReleaseOptions()
+        {
+            BranchName = "branchName",
+            VersionIncrement = VersionOptions.ReleaseVersionIncrement.Minor,
+            FirstUnstableTag = "tag"
         };
 
-        Assert.Equal(releaseOptions1, releaseOptions2);
-        Assert.Equal(releaseOptions3, releaseOptions4);
+        Assert.Equal(ro1, ro2);
+        Assert.Equal(ro3, ro4);
+        Assert.Equal(ro3, ro4);
 
-        Assert.NotEqual(releaseOptions1, releaseOptions3);
-        Assert.NotEqual(releaseOptions1, releaseOptions5);
-        Assert.NotEqual(releaseOptions3, releaseOptions5);
+        Assert.NotEqual(ro1, ro3);
+        Assert.NotEqual(ro1, ro5);
+        Assert.NotEqual(ro3, ro5);
+        Assert.NotEqual(ro5, ro6);
     }
 }

--- a/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
@@ -178,5 +178,36 @@ public class VersionOptionsTests
         Assert.Throws<InvalidOperationException>(() => options.CloudBuildOrDefault.BuildNumberOrDefault.IncludeCommitIdOrDefault.Where = VersionOptions.CloudBuildNumberCommitWhere.BuildMetadata);
         Assert.Throws<InvalidOperationException>(() => options.CloudBuildOrDefault.SetVersionVariables = true);
         Assert.Throws<InvalidOperationException>(() => options.NuGetPackageVersionOrDefault.SemVer = 2);
+        //TODO
+    }
+
+
+    [Fact]
+    public void ReleaseOptions_Equality()
+    {
+        var releaseOptions1 = new VersionOptions.ReleaseOptions() { };
+        var releaseOptions2 = new VersionOptions.ReleaseOptions() { };
+        var releaseOptions3 = new VersionOptions.ReleaseOptions()
+        {
+            BranchName = "branchName",
+            VersionIncrement = VersionOptions.ReleaseVersionIncrement.Major
+        };
+        var releaseOptions4 = new VersionOptions.ReleaseOptions()
+        {
+            BranchName = "branchName",
+            VersionIncrement = VersionOptions.ReleaseVersionIncrement.Major
+        };
+        var releaseOptions5 = new VersionOptions.ReleaseOptions()
+        {
+            BranchName = "branchName",
+            VersionIncrement = VersionOptions.ReleaseVersionIncrement.Minor
+        };
+
+        Assert.Equal(releaseOptions1, releaseOptions2);
+        Assert.Equal(releaseOptions3, releaseOptions4);
+
+        Assert.NotEqual(releaseOptions1, releaseOptions3);
+        Assert.NotEqual(releaseOptions1, releaseOptions5);
+        Assert.NotEqual(releaseOptions3, releaseOptions5);
     }
 }

--- a/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOptionsTests.cs
@@ -178,7 +178,8 @@ public class VersionOptionsTests
         Assert.Throws<InvalidOperationException>(() => options.CloudBuildOrDefault.BuildNumberOrDefault.IncludeCommitIdOrDefault.Where = VersionOptions.CloudBuildNumberCommitWhere.BuildMetadata);
         Assert.Throws<InvalidOperationException>(() => options.CloudBuildOrDefault.SetVersionVariables = true);
         Assert.Throws<InvalidOperationException>(() => options.NuGetPackageVersionOrDefault.SemVer = 2);
-        //TODO
+        Assert.Throws<InvalidOperationException>(() => options.ReleaseOrDefault.BranchName = "BranchName");
+        Assert.Throws<InvalidOperationException>(() => options.ReleaseOrDefault.VersionIncrement = VersionOptions.ReleaseVersionIncrement.Major);
     }
 
 

--- a/src/NerdBank.GitVersioning.Tests/VersionSchemaTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionSchemaTests.cs
@@ -92,6 +92,7 @@ public class VersionSchemaTests
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""prefix{0}suffix"" } }")]
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"", ""versionIncrement"" : ""major"" } }")]
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"", ""versionIncrement"" : ""minor"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""firstUnstableTag"" : ""pre"" } }")]
     public void ReleaseProperty_ValidJson(string json)
     {
         this.json = JObject.Parse(json);

--- a/src/NerdBank.GitVersioning.Tests/VersionSchemaTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionSchemaTests.cs
@@ -84,4 +84,27 @@ public class VersionSchemaTests
         this.json = JObject.Parse(@"{ ""inherit"": true }");
         Assert.True(this.json.IsValid(this.schema));
     }
+
+    [Theory]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""release/v{0}"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""prefix{0}suffix"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"", ""versionIncrement"" : ""major"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"", ""versionIncrement"" : ""minor"" } }")]
+    public void ReleaseProperty_ValidJson(string json)
+    {
+        this.json = JObject.Parse(json);
+        Assert.True(this.json.IsValid(this.schema));      
+    }
+
+    [Theory]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""versionIncrement"" : ""build"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""formatWithoutPlaceholder"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""unknownProperty"" : ""value"" } }")]
+    public void ReleaseProperty_InvalidJson(string json)
+    {
+        this.json = JObject.Parse(json);
+        Assert.False(this.json.IsValid(this.schema));
+    }
 }

--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -387,7 +387,7 @@
             Requires.NotNullOrEmpty(pathUnderGitRepo, nameof(pathUnderGitRepo));
             var gitDir = FindGitDir(pathUnderGitRepo);
 
-            if(useDefaultConfigSearchPaths)
+            if (useDefaultConfigSearchPaths)
             {
                 // pass null to reset to defaults
                 GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, null);
@@ -399,7 +399,7 @@
                 GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, string.Empty);
                 GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.System, string.Empty);
             }
-            
+
             return gitDir == null ? null : new Repository(gitDir);
         }
 

--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -380,16 +380,26 @@
         /// Opens a <see cref="Repository"/> found at or above a specified path.
         /// </summary>
         /// <param name="pathUnderGitRepo">The path at or beneath the git repo root.</param>
+        /// <param name="useDefaultConfigSearchPaths">Specifies whether to use default settings for looking up global and system settings.</param>
         /// <returns>The <see cref="Repository"/> found for the specified path, or <c>null</c> if no git repo is found.</returns>
-        public static Repository OpenGitRepo(string pathUnderGitRepo)
+        public static Repository OpenGitRepo(string pathUnderGitRepo, bool useDefaultConfigSearchPaths = false)
         {
             Requires.NotNullOrEmpty(pathUnderGitRepo, nameof(pathUnderGitRepo));
             var gitDir = FindGitDir(pathUnderGitRepo);
 
-            // Override Config Search paths to empty path to avoid new Repository instance to lookup for Global\System .gitconfig file
-            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, string.Empty);
-            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.System, string.Empty);
-
+            if(useDefaultConfigSearchPaths)
+            {
+                // pass null to reset to defaults
+                GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, null);
+                GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.System, null);
+            }
+            else
+            {
+                // Override Config Search paths to empty path to avoid new Repository instance to lookup for Global\System .gitconfig file
+                GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, string.Empty);
+                GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.System, string.Empty);
+            }
+            
             return gitDir == null ? null : new Repository(gitDir);
         }
 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -24,17 +24,13 @@
             /// </summary>
             UncommittedChanges,
             /// <summary>
-            /// The current branch is already a release branch
-            /// </summary>
-            OnReleaseBranch,
-            /// <summary>
             /// The "branchName" setting in "version.json" is invalid
             /// </summary>
             InvalidBranchNameSetting,
             /// <summary>
             /// version.json/version.txt not found
             /// </summary>
-            NoVersionFile
+            NoVersionFile            
         }
 
         /// <summary>
@@ -83,8 +79,13 @@
             // check if the current branch is the release branch
             if (mainBranchName.FriendlyName.Equals(releaseBranchName, StringComparison.OrdinalIgnoreCase))
             {
-                //TODO: only update the version. For now, this is an error
-                throw new ReleasePreparationException(ReleasePreparationError.OnReleaseBranch);
+                UpdateVersion(projectDirectory, repository,
+                    version =>
+                        string.IsNullOrEmpty(releaseUnstableTag)
+                            ? version.WithoutPrepreleaseTags()
+                            : version.SetFirstPrereleaseTag(releaseUnstableTag)
+                );
+                return;
             }
 
             // create release branch            
@@ -95,7 +96,7 @@
             UpdateVersion(projectDirectory, repository,
                 version =>
                     string.IsNullOrEmpty(releaseUnstableTag)
-                        ? new SemanticVersion(version.Version)
+                        ? version.WithoutPrepreleaseTags()
                         : version.SetFirstPrereleaseTag(releaseUnstableTag)
             );
             

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -70,6 +70,7 @@
         }
 
 
+        //TODO: Parameter to explicitly specify the next version
         /// <summary>
         /// Prepares a release for the specified directory by creating a release branch and incrementing the version in the current branch.
         /// </summary>
@@ -161,7 +162,7 @@
             var filePath = VersionFile.SetVersion(projectDirectory, versionOptions);
             
             Commands.Stage(repository, filePath);
-            repository.Commit($"Set version to '{versionOptions.Version}'", signature, signature);
+            repository.Commit($"Set version to '{versionOptions.Version}'", signature, signature, new CommitOptions() { AllowEmptyCommit = true } );
         }
 
         private static Signature GetSignature(Repository repository)

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -1,6 +1,7 @@
 ﻿namespace Nerdbank.GitVersioning
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using LibGit2Sharp;
@@ -203,17 +204,24 @@
                 throw new ReleasePreparationException(ReleasePreparationError.VersionDecrement);
             }
 
-            this.stdout.WriteLine($"Setting version to {newVersion}.");
-
-            versionOptions.Version = newVersion;
-            var filePath = VersionFile.SetVersion(projectDirectory, versionOptions, includeSchemaProperty: true);
-
-            Commands.Stage(repository, filePath);
-
-            // Author a commit only if we effectively changed something.
-            if (!repository.Head.Tip.Tree.Equals(repository.Index.WriteToTree()))
+            if (EqualityComparer<SemanticVersion>.Default.Equals(versionOptions.Version, newVersion))
             {
-                repository.Commit($"Set version to '{versionOptions.Version}'", signature, signature, new CommitOptions() { AllowEmptyCommit = false });
+                this.stdout.WriteLine($"Version already set to {newVersion}.");
+            }
+            else
+            {
+                this.stdout.WriteLine($"Setting version to {newVersion}...");
+
+                versionOptions.Version = newVersion;
+                var filePath = VersionFile.SetVersion(projectDirectory, versionOptions, includeSchemaProperty: true);
+
+                Commands.Stage(repository, filePath);
+
+                // Author a commit only if we effectively changed something.
+                if (!repository.Head.Tip.Tree.Equals(repository.Index.WriteToTree()))
+                {
+                    repository.Commit($"Set version to '{versionOptions.Version}'", signature, signature, new CommitOptions() { AllowEmptyCommit = false });
+                }
             }
         }
 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -59,8 +59,7 @@
         /// Prepares a release for the specified directory by creating a release branch and incrementing the version in the current branch.
         /// </summary>
         /// <exception cref="ReleasePreparationException">Thrown when the release could not be created.</exception>
-        //TODO: prerelease tag parameter
-        public static void PrepareRelease(string projectDirectory, TextWriter stdout = null, TextWriter stderr = null)
+        public static void PrepareRelease(string projectDirectory, string releaseUnstableTag = null, TextWriter stdout = null, TextWriter stderr = null)
         {
             stdout = stdout ?? Console.Out;
             stderr = stderr ?? Console.Error;
@@ -93,7 +92,12 @@
 
             // update version in release branch    
             Commands.Checkout(repository, releaseBranch);
-            UpdateVersion(projectDirectory, repository, version => new SemanticVersion(version.Version));
+            UpdateVersion(projectDirectory, repository,
+                version =>
+                    string.IsNullOrEmpty(releaseUnstableTag)
+                        ? new SemanticVersion(version.Version)
+                        : version.SetFirstPrereleaseTag(releaseUnstableTag)
+            );
             
             // update version on main branch
             Commands.Checkout(repository, mainBranchName);

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -26,7 +26,11 @@
             /// <summary>
             /// The current branch is already a release branch
             /// </summary>
-            OnReleaseBranch
+            OnReleaseBranch,
+            /// <summary>
+            /// The "branchName" setting in "version.json" is invalid
+            /// </summary>
+            InvalidBranchNameSetting
         }
 
         /// <summary>
@@ -131,9 +135,14 @@
 
         private static string GetReleaseBranchName(VersionOptions versionOptions)
         {
-            //TODO: Check format
-            return String.Format(versionOptions.ReleaseOrDefault.BranchNameOrDefault, versionOptions.Version.Version);                        
-        }
+            var branchNameFormat = versionOptions.ReleaseOrDefault.BranchNameOrDefault;
 
+            if(string.IsNullOrEmpty(branchNameFormat) || !branchNameFormat.Contains("{0}"))
+            {
+                throw new ReleasePreparationException(ReleasePreparationError.InvalidBranchNameSetting);
+            }
+            
+            return string.Format(branchNameFormat, versionOptions.Version.Version);                        
+        }
     }
 }

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -75,7 +75,18 @@
         /// Prepares a release for the specified directory by creating a release branch and incrementing the version in the current branch.
         /// </summary>
         /// <exception cref="ReleasePreparationException">Thrown when the release could not be created.</exception>
-        public void PrepareRelease(string projectDirectory, string releaseUnstableTag = null)
+        /// <param name="projectDirectory">
+        /// The path to the directory which may (or its ancestors may) define the version file.
+        /// </param>
+        /// <param name="releaseUnstableTag">
+        /// The prerelease tag to add to the version on the release branch. Pass <c>null</c> to omit/remove the prerelease tag.
+        /// </param>
+        /// <param name="nextVersion">
+        /// The next version to save to the version file on the current branch. Pass <c>null</c> to automatically determine the next
+        /// version based on the current version and the <c>versionIncrement</c> setting in <c>version.json</c>.
+        /// Parameter will be ignored if the current branch is a release branch.
+        /// </param>
+        public void PrepareRelease(string projectDirectory, string releaseUnstableTag = null, SemanticVersion nextVersion = null)
         {
             // open the git repository
             var repository = this.GetRepository(projectDirectory);
@@ -118,9 +129,11 @@
             // update version on main branch
             Commands.Checkout(repository, mainBranchName);
             this.UpdateVersion(projectDirectory, repository,
-                version => version
-                    .Increment(releaseOptions.VersionIncrementOrDefault)
-                    .SetFirstPrereleaseTag(releaseOptions.FirstUnstableTagOrDefault));
+                version => 
+                    nextVersion ?? 
+                    version
+                        .Increment(releaseOptions.VersionIncrementOrDefault)
+                        .SetFirstPrereleaseTag(releaseOptions.FirstUnstableTagOrDefault));
             
             // Merge release branch back to main branch
             var mergeOptions = new MergeOptions()

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -1,0 +1,122 @@
+﻿namespace Nerdbank.GitVersioning
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using LibGit2Sharp;
+
+    /// <summary>
+    /// Methods for creating releases 
+    /// </summary>
+    public class ReleaseManager
+    {
+        /// <summary>
+        /// Defines the possible errors that can occur when preparing a release
+        /// </summary>
+        public enum ReleasePreparationError
+        {
+            /// <summary>
+            /// The project directory is not a git repository
+            /// </summary>
+            NoGitRepo,
+            /// <summary>
+            /// There are pending changes in the proejct directory
+            /// </summary>
+            UncommittedChanges,
+            /// <summary>
+            /// The current branch is already a release branch
+            /// </summary>
+            OnReleaseBranch
+        }
+
+        /// <summary>
+        /// Exception indicating an error during preparation of a release
+        /// </summary>
+        public class ReleasePreparationException : Exception
+        {
+            /// <summary>
+            /// Gets the error that occurred.
+            /// </summary>
+            public ReleasePreparationError Error { get; }
+
+            /// <summary>
+            /// Initializes a new instance ogf <see cref="ReleasePreparationException"/>
+            /// </summary>
+            /// <param name="error">The error that occurred.</param>
+            public ReleasePreparationException(ReleasePreparationError error) => this.Error = error;
+        }
+
+
+        /// <summary>
+        /// Prepares a release for the specified directory by creating a release branch and incrementing the version in the current branch.
+        /// </summary>
+        /// <exception cref="ReleasePreparationException">Thrown when the release could not be created.</exception>
+        //TODO: prerelease tag parameter
+        public static void PrepareRelease(string projectDirectory, TextWriter stdout = null, TextWriter stderr = null)
+        {
+            stdout = stdout ?? Console.Out;
+            stderr = stderr ?? Console.Error;
+            
+            // get the current version
+            var currentVersionOptions = VersionFile.GetVersion(projectDirectory);
+
+            // open the git repository
+            var repository = GitExtensions.OpenGitRepo(projectDirectory);
+            if(repository == null)
+            {
+                stderr.WriteLine($"No git repository found above directory '{projectDirectory}'");
+                throw new ReleasePreparationException(ReleasePreparationError.NoGitRepo);
+            }
+            
+            // abort if there are any pending changes
+            if(repository.RetrieveStatus().IsDirty)
+            {
+                stderr.WriteLine($"Uncommited changes in directory '{projectDirectory}'");
+                throw new ReleasePreparationException(ReleasePreparationError.UncommittedChanges);
+            }
+
+            var releaseBranchName = GetReleaseBranchName(currentVersionOptions);
+            var currentBranch = repository.Branches.Single(x => x.IsCurrentRepositoryHead);
+
+            // check if the current branch is the release branch
+            if (currentBranch.FriendlyName.Equals(releaseBranchName, StringComparison.OrdinalIgnoreCase))
+            {
+                //TODO: only update the version. For now, this is an error
+                throw new ReleasePreparationException(ReleasePreparationError.OnReleaseBranch);
+            }
+
+            // create release branch
+            
+            var releaseBranch = repository.CreateBranch(releaseBranchName);
+
+            // update version in release branch    
+            var releaseVersion = VersionFile.GetVersion(projectDirectory);
+            releaseVersion.Version = new SemanticVersion(releaseVersion.Version.Version);
+            Commands.Checkout(repository, releaseBranch);
+            var filePath = VersionFile.SetVersion(projectDirectory, releaseVersion);
+            Commands.Stage(repository, filePath);
+
+            var signature = repository.Config.BuildSignature(DateTimeOffset.Now);
+            if(signature == null)
+            {
+                //TODO
+            }
+            repository.Commit($"Create release branch for version '{releaseVersion.Version}'", signature, signature);
+
+            // switch back to previous branch
+            Commands.Checkout(repository, currentBranch);
+
+            //TODO: edit version on master current branch
+
+            //TODO: Merge back release branch 
+        }
+
+
+        private static string GetReleaseBranchName(VersionOptions versionOptions)
+        {
+            //TODO: Check format
+            return String.Format(versionOptions.ReleaseOrDefault.BranchNameOrDefault, versionOptions.Version.Version);                        
+        }
+
+    }
+}

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -106,10 +106,10 @@
             var releaseOptions = versionOptions.ReleaseOrDefault;
 
             var releaseBranchName = this.GetReleaseBranchName(versionOptions);
-            var mainBranchName = repository.Branches.Single(x => x.IsCurrentRepositoryHead);
+            var mainBranchName = repository.Branches.Single(x => x.IsCurrentRepositoryHead).FriendlyName;
 
             // check if the current branch is the release branch
-            if (mainBranchName.FriendlyName.Equals(releaseBranchName, StringComparison.OrdinalIgnoreCase))
+            if (mainBranchName.Equals(releaseBranchName, StringComparison.OrdinalIgnoreCase))
             {
                 this.stdout.WriteLine($"Current branch '{releaseBranchName}' is a release branch. Updating version");
                 this.UpdateVersion(projectDirectory, repository,

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -113,8 +113,15 @@
             Commands.Stage(repository, filePath);
             repository.Commit($"Set version to {newVersion.Version}", signature, signature);
 
-
-            //TODO: Merge back release branch 
+            // Merge release branch back to initial branch
+            var mergeResult = repository.Merge(
+                releaseBranch, 
+                signature, 
+                new MergeOptions()
+                {
+                    CommitOnSuccess = true,
+                    MergeFileFavor = MergeFileFavor.Ours
+                });
         }
 
 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -206,7 +206,7 @@
             this.stdout.WriteLine($"Setting version to {newVersion}.");
 
             versionOptions.Version = newVersion;
-            var filePath = VersionFile.SetVersion(projectDirectory, versionOptions);
+            var filePath = VersionFile.SetVersion(projectDirectory, versionOptions, includeSchemaProperty: true);
 
             Commands.Stage(repository, filePath);
 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -57,7 +57,7 @@
             /// <param name="error">The error that occurred.</param>
             public ReleasePreparationException(ReleasePreparationError error) => this.Error = error;
         }
-
+        
 
         private readonly TextWriter stdout;
         private readonly TextWriter stderr;
@@ -197,7 +197,7 @@
         }
 
         private static Signature GetSignature(Repository repository)
-        {
+        {   
             var signature = repository.Config.BuildSignature(DateTimeOffset.Now);
             if (signature == null)
             {
@@ -208,7 +208,9 @@
 
         private Repository GetRepository(string projectDirectory)
         {
-            var repository = GitExtensions.OpenGitRepo(projectDirectory);
+            // open git repo and use default configuration (in order to commit we need a configured user name and email
+            // which is most likely configured on a user/system level rather than the repo level
+            var repository = GitExtensions.OpenGitRepo(projectDirectory, useDefaultConfigSearchPaths: true);
             if (repository == null)
             {
                 this.stderr.WriteLine($"No git repository found above directory '{projectDirectory}'");

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -51,6 +51,11 @@
             /// Cannot create a commit because user name and user email are not configured (either at the repo or global level)
             /// </summary>
             UserNotConfigured,
+
+            /// <summary>
+            /// HEAD is detached. A branch must be checked out first.
+            /// </summary>
+            DetachedHead,
         }
 
         /// <summary>
@@ -106,6 +111,12 @@
 
             // open the git repository
             var repository = this.GetRepository(projectDirectory);
+
+            if (repository.Info.IsHeadDetached)
+            {
+                this.stderr.WriteLine("Detached head. Check out a branch first.");
+                throw new ReleasePreparationException(ReleasePreparationError.DetachedHead);
+            }
 
             // get the current version
             var versionOptions = VersionFile.GetVersion(projectDirectory);

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -20,7 +20,7 @@
             /// </summary>
             NoGitRepo,
             /// <summary>
-            /// There are pending changes in the proejct directory
+            /// There are pending changes in the project directory
             /// </summary>
             UncommittedChanges,
             /// <summary>
@@ -40,7 +40,7 @@
             public ReleasePreparationError Error { get; }
 
             /// <summary>
-            /// Initializes a new instance ogf <see cref="ReleasePreparationException"/>
+            /// Initializes a new instance of <see cref="ReleasePreparationException"/>
             /// </summary>
             /// <param name="error">The error that occurred.</param>
             public ReleasePreparationException(ReleasePreparationError error) => this.Error = error;
@@ -71,7 +71,7 @@
             // abort if there are any pending changes
             if(repository.RetrieveStatus().IsDirty)
             {
-                stderr.WriteLine($"Uncommited changes in directory '{projectDirectory}'");
+                stderr.WriteLine($"Uncommitted changes in directory '{projectDirectory}'");
                 throw new ReleasePreparationException(ReleasePreparationError.UncommittedChanges);
             }
 
@@ -106,7 +106,13 @@
             // switch back to previous branch
             Commands.Checkout(repository, currentBranch);
 
-            //TODO: edit version on master current branch
+            // edit version on master current branch
+            var newVersion = VersionFile.GetVersion(projectDirectory);
+            newVersion.Version = newVersion.Version.Increment(currentVersionOptions.ReleaseOrDefault.VersionIncrementOrDefault);
+            filePath = VersionFile.SetVersion(projectDirectory, newVersion);
+            Commands.Stage(repository, filePath);
+            repository.Commit($"Set version to {newVersion.Version}", signature, signature);
+
 
             //TODO: Merge back release branch 
         }

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -229,6 +229,9 @@
                 throw new ReleasePreparationException(ReleasePreparationError.UncommittedChanges);
             }
 
+            // check if repo is configured so we can create commits
+            _ = this.GetSignature(repository);
+
             return repository;
         }
 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -106,9 +106,13 @@
             // switch back to previous branch
             Commands.Checkout(repository, currentBranch);
 
-            // edit version on master current branch
+            // edit version on current branch
             var newVersion = VersionFile.GetVersion(projectDirectory);
-            newVersion.Version = newVersion.Version.Increment(currentVersionOptions.ReleaseOrDefault.VersionIncrementOrDefault);
+            newVersion.Version = newVersion
+                .Version
+                .Increment(currentVersionOptions.ReleaseOrDefault.VersionIncrementOrDefault)
+                .SetFirstPrereleaseTag(currentVersionOptions.ReleaseOrDefault.FirstUnstableTagOrDefault);
+
             filePath = VersionFile.SetVersion(projectDirectory, newVersion);
             Commands.Stage(repository, filePath);
             repository.Commit($"Set version to {newVersion.Version}", signature, signature);

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -4,6 +4,7 @@
     using System.IO;
     using System.Linq;
     using LibGit2Sharp;
+    using Validation;
 
     /// <summary>
     /// Methods for creating releases
@@ -19,30 +20,36 @@
             /// The project directory is not a git repository
             /// </summary>
             NoGitRepo,
+
             /// <summary>
             /// There are pending changes in the project directory
             /// </summary>
             UncommittedChanges,
+
             /// <summary>
             /// The "branchName" setting in "version.json" is invalid
             /// </summary>
             InvalidBranchNameSetting,
+
             /// <summary>
             /// version.json/version.txt not found
             /// </summary>
             NoVersionFile,
+
             /// <summary>
             /// Updating the version would result in a version lower than the previous version
             /// </summary>
             VersionDecrement,
+
             /// <summary>
             /// Cannot create a branch because it already exists
             /// </summary>
             BranchAlreadyExists,
+
             /// <summary>
             /// Cannot create a commit because user name and user email are not configured (either at the repo or global level)
             /// </summary>
-            UserNotConfigured
+            UserNotConfigured,
         }
 
         /// <summary>
@@ -62,21 +69,19 @@
             public ReleasePreparationException(ReleasePreparationError error) => this.Error = error;
         }
 
-
         private readonly TextWriter stdout;
         private readonly TextWriter stderr;
 
         /// <summary>
         /// Initializes a new instance of <see cref="ReleaseManager"/>
         /// </summary>
-        /// <param name="stdout">The <see cref="TextWriter"/> to write output to.</param>
-        /// <param name="stderr">The <see cref="TextWriter"/> to write error messages to to.</param>
-        public ReleaseManager(TextWriter stdout = null, TextWriter stderr = null)
+        /// <param name="outputWriter">The <see cref="TextWriter"/> to write output to (e.g. <see cref="Console.Out" />).</param>
+        /// <param name="errorWriter">The <see cref="TextWriter"/> to write error messages to (e.g. <see cref="Console.Error" />).</param>
+        public ReleaseManager(TextWriter outputWriter = null, TextWriter errorWriter = null)
         {
-            this.stdout = stdout ?? Console.Out;
-            this.stderr = stderr ?? Console.Error;
+            this.stdout = outputWriter ?? TextWriter.Null;
+            this.stderr = errorWriter ?? TextWriter.Null;
         }
-
 
         /// <summary>
         /// Prepares a release for the specified directory by creating a release branch and incrementing the version in the current branch.
@@ -87,6 +92,7 @@
         /// </param>
         /// <param name="releaseUnstableTag">
         /// The prerelease tag to add to the version on the release branch. Pass <c>null</c> to omit/remove the prerelease tag.
+        /// The leading hyphen may be specified or omitted.
         /// </param>
         /// <param name="nextVersion">
         /// The next version to save to the version file on the current branch. Pass <c>null</c> to automatically determine the next
@@ -95,26 +101,28 @@
         /// </param>
         public void PrepareRelease(string projectDirectory, string releaseUnstableTag = null, SemanticVersion nextVersion = null)
         {
+            Requires.NotNull(projectDirectory, nameof(projectDirectory));
+
             // open the git repository
             var repository = this.GetRepository(projectDirectory);
 
             // get the current version
             var versionOptions = VersionFile.GetVersion(projectDirectory);
-            if(versionOptions == null)
+            if (versionOptions == null)
             {
-                this.stderr.WriteLine($"Failed to load version file for directory '{projectDirectory}'");
+                this.stderr.WriteLine($"Failed to load version file for directory '{projectDirectory}'.");
                 throw new ReleasePreparationException(ReleasePreparationError.NoVersionFile);
             }
 
             var releaseOptions = versionOptions.ReleaseOrDefault;
 
             var releaseBranchName = this.GetReleaseBranchName(versionOptions);
-            var mainBranchName = repository.Branches.Single(x => x.IsCurrentRepositoryHead).FriendlyName;
+            var originalBranchName = repository.Head.FriendlyName;
 
             // check if the current branch is the release branch
-            if (mainBranchName.Equals(releaseBranchName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(originalBranchName, releaseBranchName, StringComparison.OrdinalIgnoreCase))
             {
-                this.stdout.WriteLine($"Current branch '{releaseBranchName}' is a release branch. Updating version");
+                this.stdout.WriteLine($"Current branch '{releaseBranchName}' is a release branch. Updating version...");
                 this.UpdateVersion(projectDirectory, repository,
                     version =>
                         string.IsNullOrEmpty(releaseUnstableTag)
@@ -124,14 +132,14 @@
             }
 
             // check if the release branch already exists
-            if(repository.Branches[releaseBranchName] != null)
+            if (repository.Branches[releaseBranchName] != null)
             {
-                this.stderr.WriteLine($"Cannot create branch '{releaseBranchName}' because it already exists");
+                this.stderr.WriteLine($"Cannot create branch '{releaseBranchName}' because it already exists.");
                 throw new ReleasePreparationException(ReleasePreparationError.BranchAlreadyExists);
             }
 
             // create release branch and update version
-            this.stdout.WriteLine($"Creating release branch '{releaseBranchName}'");
+            this.stdout.WriteLine($"Creating release branch '{releaseBranchName}'...");
             var releaseBranch = repository.CreateBranch(releaseBranchName);
             Commands.Checkout(repository, releaseBranch);
             this.UpdateVersion(projectDirectory, repository,
@@ -141,8 +149,8 @@
                         : version.SetFirstPrereleaseTag(releaseUnstableTag));
 
             // update version on main branch
-            this.stdout.WriteLine($"Updating version on branch '{mainBranchName}'");
-            Commands.Checkout(repository, mainBranchName);
+            this.stdout.WriteLine($"Updating version on branch '{originalBranchName}'...");
+            Commands.Checkout(repository, originalBranchName);
             this.UpdateVersion(projectDirectory, repository,
                 version =>
                     nextVersion ??
@@ -151,24 +159,25 @@
                         .SetFirstPrereleaseTag(releaseOptions.FirstUnstableTagOrDefault));
 
             // Merge release branch back to main branch
-            this.stdout.WriteLine($"Merging branch '{releaseBranchName}' into '{mainBranchName}' ");
+            this.stdout.WriteLine($"Merging branch '{releaseBranchName}' into '{originalBranchName}'...");
             var mergeOptions = new MergeOptions()
             {
                 CommitOnSuccess = true,
                 MergeFileFavor = MergeFileFavor.Ours
             };
-            repository.Merge(releaseBranch, GetSignature(repository), mergeOptions);
+            repository.Merge(releaseBranch, this.GetSignature(repository), mergeOptions);
         }
-
 
         private string GetReleaseBranchName(VersionOptions versionOptions)
         {
+            Requires.NotNull(versionOptions, nameof(versionOptions));
+
             var branchNameFormat = versionOptions.ReleaseOrDefault.BranchNameOrDefault;
 
             // ensure there is a '{version}' placeholder in the branch name
-            if(string.IsNullOrEmpty(branchNameFormat) || !branchNameFormat.Contains("{version}"))
+            if (string.IsNullOrEmpty(branchNameFormat) || !branchNameFormat.Contains("{version}"))
             {
-                this.stderr.WriteLine($"Invalid 'branchName' setting '{branchNameFormat}'. Missing version placeholder '{{version}}'");
+                this.stderr.WriteLine($"Invalid 'branchName' setting '{branchNameFormat}'. Missing version placeholder '{{version}}'.");
                 throw new ReleasePreparationException(ReleasePreparationError.InvalidBranchNameSetting);
             }
 
@@ -178,25 +187,29 @@
 
         private void UpdateVersion(string projectDirectory, Repository repository, Func<SemanticVersion, SemanticVersion> updateAction)
         {
+            Requires.NotNull(projectDirectory, nameof(projectDirectory));
+            Requires.NotNull(repository, nameof(repository));
+            Requires.NotNull(updateAction, nameof(updateAction));
+
             var signature = this.GetSignature(repository);
 
             var versionOptions = VersionFile.GetVersion(projectDirectory);
             var oldVersion = versionOptions.Version;
             var newVersion = updateAction(oldVersion);
 
-            if(IsVersionDecrement(oldVersion, newVersion))
+            if (IsVersionDecrement(oldVersion, newVersion))
             {
-                this.stderr.WriteLine($"Cannot change version from {oldVersion} to {newVersion} because {newVersion} is older than {oldVersion}");
+                this.stderr.WriteLine($"Cannot change version from {oldVersion} to {newVersion} because {newVersion} is older than {oldVersion}.");
                 throw new ReleasePreparationException(ReleasePreparationError.VersionDecrement);
             }
 
-            this.stdout.WriteLine($"Setting version to {newVersion}");
+            this.stdout.WriteLine($"Setting version to {newVersion}.");
 
             versionOptions.Version = newVersion;
             var filePath = VersionFile.SetVersion(projectDirectory, versionOptions);
 
             Commands.Stage(repository, filePath);
-            repository.Commit($"Set version to '{versionOptions.Version}'", signature, signature, new CommitOptions() { AllowEmptyCommit = true } );
+            repository.Commit($"Set version to '{versionOptions.Version}'", signature, signature, new CommitOptions() { AllowEmptyCommit = true });
         }
 
         private Signature GetSignature(Repository repository)
@@ -207,6 +220,7 @@
                 this.stderr.WriteLine("Cannot create commits in this repo because git user name and email are not configured.");
                 throw new ReleasePreparationException(ReleasePreparationError.UserNotConfigured);
             }
+
             return signature;
         }
 
@@ -217,14 +231,14 @@
             var repository = GitExtensions.OpenGitRepo(projectDirectory, useDefaultConfigSearchPaths: true);
             if (repository == null)
             {
-                this.stderr.WriteLine($"No git repository found above directory '{projectDirectory}'");
+                this.stderr.WriteLine($"No git repository found above directory '{projectDirectory}'.");
                 throw new ReleasePreparationException(ReleasePreparationError.NoGitRepo);
             }
 
             // abort if there are any pending changes
             if (repository.RetrieveStatus().IsDirty)
             {
-                this.stderr.WriteLine($"Uncommitted changes in directory '{projectDirectory}'");
+                this.stderr.WriteLine($"Uncommitted changes in directory '{projectDirectory}'.");
                 throw new ReleasePreparationException(ReleasePreparationError.UncommittedChanges);
             }
 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -34,7 +34,11 @@
             /// <summary>
             /// Updating the version would result in a version lower than the previous version
             /// </summary>
-            VersionDecrement
+            VersionDecrement,
+            /// <summary>
+            /// Cannot create a branch because it already exists
+            /// </summary>
+            BranchAlreadyExists
         }
 
         /// <summary>
@@ -114,6 +118,13 @@
                             ? version.WithoutPrepreleaseTags()
                             : version.SetFirstPrereleaseTag(releaseUnstableTag));
                 return;
+            }
+
+            // check if the release branch already exists
+            if(repository.Branches[releaseBranchName] != null)
+            {
+                this.stderr.WriteLine($"Cannot create branch '{releaseBranchName}' because it already exists");
+                throw new ReleasePreparationException(ReleasePreparationError.BranchAlreadyExists);
             }
 
             // create release branch and update version 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -6,7 +6,7 @@
     using LibGit2Sharp;
 
     /// <summary>
-    /// Methods for creating releases 
+    /// Methods for creating releases
     /// </summary>
     public class ReleaseManager
     {
@@ -61,7 +61,7 @@
             /// <param name="error">The error that occurred.</param>
             public ReleasePreparationException(ReleasePreparationError error) => this.Error = error;
         }
-        
+
 
         private readonly TextWriter stdout;
         private readonly TextWriter stderr;
@@ -97,7 +97,7 @@
         {
             // open the git repository
             var repository = this.GetRepository(projectDirectory);
-            
+
             // get the current version
             var versionOptions = VersionFile.GetVersion(projectDirectory);
             if(versionOptions == null)
@@ -130,7 +130,7 @@
                 throw new ReleasePreparationException(ReleasePreparationError.BranchAlreadyExists);
             }
 
-            // create release branch and update version 
+            // create release branch and update version
             this.stdout.WriteLine($"Creating release branch '{releaseBranchName}'");
             var releaseBranch = repository.CreateBranch(releaseBranchName);
             Commands.Checkout(repository, releaseBranch);
@@ -144,8 +144,8 @@
             this.stdout.WriteLine($"Updating version on branch '{mainBranchName}'");
             Commands.Checkout(repository, mainBranchName);
             this.UpdateVersion(projectDirectory, repository,
-                version => 
-                    nextVersion ?? 
+                version =>
+                    nextVersion ??
                     version
                         .Increment(releaseOptions.VersionIncrementOrDefault)
                         .SetFirstPrereleaseTag(releaseOptions.FirstUnstableTagOrDefault));
@@ -194,13 +194,13 @@
 
             versionOptions.Version = newVersion;
             var filePath = VersionFile.SetVersion(projectDirectory, versionOptions);
-            
+
             Commands.Stage(repository, filePath);
             repository.Commit($"Set version to '{versionOptions.Version}'", signature, signature, new CommitOptions() { AllowEmptyCommit = true } );
         }
 
         private Signature GetSignature(Repository repository)
-        {   
+        {
             var signature = repository.Config.BuildSignature(DateTimeOffset.Now);
             if (signature == null)
             {

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -162,13 +162,15 @@
         {
             var branchNameFormat = versionOptions.ReleaseOrDefault.BranchNameOrDefault;
 
-            if(string.IsNullOrEmpty(branchNameFormat) || !branchNameFormat.Contains("{0}"))
+            // ensure there is a '{version}' placeholder in the branch name
+            if(string.IsNullOrEmpty(branchNameFormat) || !branchNameFormat.Contains("{version}"))
             {
-                this.stderr.WriteLine($"Invalid 'branchName' setting '{branchNameFormat}'. Missing version placeholder '{{0}}'");
+                this.stderr.WriteLine($"Invalid 'branchName' setting '{branchNameFormat}'. Missing version placeholder '{{version}}'");
                 throw new ReleasePreparationException(ReleasePreparationError.InvalidBranchNameSetting);
             }
-            
-            return string.Format(branchNameFormat, versionOptions.Version.Version);                        
+
+            // replace the "{version}" placeholder with the actual version
+            return branchNameFormat.Replace("{version}", versionOptions.Version.Version.ToString());
         }
 
         private void UpdateVersion(string projectDirectory, Repository repository, Func<SemanticVersion, SemanticVersion> updateAction)

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -163,7 +163,7 @@
             var mergeOptions = new MergeOptions()
             {
                 CommitOnSuccess = true,
-                MergeFileFavor = MergeFileFavor.Ours
+                MergeFileFavor = MergeFileFavor.Ours,
             };
             repository.Merge(releaseBranch, this.GetSignature(repository), mergeOptions);
         }
@@ -209,7 +209,12 @@
             var filePath = VersionFile.SetVersion(projectDirectory, versionOptions);
 
             Commands.Stage(repository, filePath);
-            repository.Commit($"Set version to '{versionOptions.Version}'", signature, signature, new CommitOptions() { AllowEmptyCommit = true });
+
+            // Author a commit only if we effectively changed something.
+            if (!repository.Head.Tip.Tree.Equals(repository.Index.WriteToTree()))
+            {
+                repository.Commit($"Set version to '{versionOptions.Version}'", signature, signature, new CommitOptions() { AllowEmptyCommit = false });
+            }
         }
 
         private Signature GetSignature(Repository repository)

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -78,7 +78,6 @@
         }
 
 
-        //TODO: Parameter to explicitly specify the next version
         /// <summary>
         /// Prepares a release for the specified directory by creating a release branch and incrementing the version in the current branch.
         /// </summary>

--- a/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
@@ -51,5 +51,34 @@
             
             return new SemanticVersion(newVersion, currentVersion.Prerelease, currentVersion.BuildMetadata);
         }
+        
+        /// <summary>
+        /// Sets the first prerelease tag of the specified semantic version to the specified value.
+        /// </summary>
+        /// <param name="version">The version which's prerelease tag to modify.</param>
+        /// <param name="newFirstTag">The new prerelease tag.</param>
+        /// <returns>Returns a new instance of <see cref="SemanticVersion"/> with the updated prerelease tag</returns>
+        public static SemanticVersion SetFirstPrereleaseTag(this SemanticVersion version, string newFirstTag)
+        {
+            string preRelease;
+            if(string.IsNullOrEmpty(version.Prerelease))
+            {
+                preRelease = newFirstTag; 
+            }
+            else if(version.Prerelease.Contains("."))
+            {
+                preRelease = newFirstTag + version.Prerelease.Substring(version.Prerelease.IndexOf("."));
+            }
+            else
+            {
+                preRelease = newFirstTag;
+            }        
+
+            if (!string.IsNullOrEmpty(preRelease) && !preRelease.StartsWith("-"))
+                preRelease = "-" + preRelease;
+
+            return new SemanticVersion(version.Version, preRelease, version.BuildMetadata);            
+        }
+
     }
 }

--- a/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+namespace Nerdbank.GitVersioning
+{
+    /// <summary>
+    /// Extension methods for <see cref="SemanticVersion"/>
+    /// </summary>
+    public static class SemanticVersionExtensions
+    {
+        /// <summary>
+        /// Gets a new semantic with the specified version component (major/minor) incremented.
+        /// </summary>
+        /// <param name="currentVersion">The version to increment.</param>
+        /// <param name="increment">Specifies whether to increment the major or minor version.</param>
+        /// <returns>Returns a new <see cref="SemanticVersion"/> object with either the major or minor version incremented by 1.</returns>
+        public static SemanticVersion Increment(this SemanticVersion currentVersion, VersionOptions.ReleaseVersionIncrement increment)
+        {
+            if (increment != VersionOptions.ReleaseVersionIncrement.Major && increment != VersionOptions.ReleaseVersionIncrement.Minor)
+                throw new ArgumentException($"Unexpected increment value '{increment}'", nameof(increment));
+
+            var majorIncrement = increment == VersionOptions.ReleaseVersionIncrement.Major ? 1 : 0;
+            var minorIncrement = increment == VersionOptions.ReleaseVersionIncrement.Minor ? 1 : 0;
+            
+            // use the appropriate constructor for the new version object
+            // dependening on whether the current versions has 2, 3 or 4 segements
+            Version newVersion;
+            if (currentVersion.Version.Build >= 0 && currentVersion.Version.Revision > 0)
+            {
+                // 4 segement version
+                newVersion = new Version(
+                    currentVersion.Version.Major + majorIncrement,
+                    currentVersion.Version.Minor + minorIncrement,
+                    currentVersion.Version.Build,
+                    currentVersion.Version.Revision);
+            }
+            else if (currentVersion.Version.Build >= 0)
+            {
+                // 3 segement version
+                newVersion = new Version(
+                    currentVersion.Version.Major + majorIncrement,
+                    currentVersion.Version.Minor + minorIncrement,
+                    currentVersion.Version.Build);
+            }
+            else
+            {
+                // 2 segment version
+                newVersion = new Version(
+                    currentVersion.Version.Major + majorIncrement,
+                    currentVersion.Version.Minor + minorIncrement);
+            }
+            
+            return new SemanticVersion(newVersion, currentVersion.Prerelease, currentVersion.BuildMetadata);
+        }
+    }
+}

--- a/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace Nerdbank.GitVersioning
+﻿namespace Nerdbank.GitVersioning
 {
+    using System;
+
     /// <summary>
     /// Extension methods for <see cref="SemanticVersion"/>
     /// </summary>

--- a/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
@@ -18,35 +18,36 @@
             if (increment != VersionOptions.ReleaseVersionIncrement.Major && increment != VersionOptions.ReleaseVersionIncrement.Minor)
                 throw new ArgumentException($"Unexpected increment value '{increment}'", nameof(increment));
 
-            var majorIncrement = increment == VersionOptions.ReleaseVersionIncrement.Major ? 1 : 0;
-            var minorIncrement = increment == VersionOptions.ReleaseVersionIncrement.Minor ? 1 : 0;
+            var major = currentVersion.Version.Major;
+            var minor = currentVersion.Version.Minor;
+
+            if(increment == VersionOptions.ReleaseVersionIncrement.Major)
+            {
+                major += 1;
+                minor = 0;
+            }
+            else
+            {
+                minor += 1;
+            }
             
             // use the appropriate constructor for the new version object
             // depending on whether the current versions has 2, 3 or 4 segments
             Version newVersion;
             if (currentVersion.Version.Build >= 0 && currentVersion.Version.Revision > 0)
-            {
+            {                
                 // 4 segment version
-                newVersion = new Version(
-                    currentVersion.Version.Major + majorIncrement,
-                    currentVersion.Version.Minor + minorIncrement,
-                    currentVersion.Version.Build,
-                    currentVersion.Version.Revision);
+                newVersion = new Version(major, minor, 0, 0);
             }
             else if (currentVersion.Version.Build >= 0)
             {
                 // 3 segment version
-                newVersion = new Version(
-                    currentVersion.Version.Major + majorIncrement,
-                    currentVersion.Version.Minor + minorIncrement,
-                    currentVersion.Version.Build);
+                newVersion = new Version(major, minor, 0);
             }
             else
             {
                 // 2 segment version
-                newVersion = new Version(
-                    currentVersion.Version.Major + majorIncrement,
-                    currentVersion.Version.Minor + minorIncrement);
+                newVersion = new Version(major, minor);
             }
             
             return new SemanticVersion(newVersion, currentVersion.Prerelease, currentVersion.BuildMetadata);

--- a/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
@@ -22,11 +22,11 @@
             var minorIncrement = increment == VersionOptions.ReleaseVersionIncrement.Minor ? 1 : 0;
             
             // use the appropriate constructor for the new version object
-            // dependening on whether the current versions has 2, 3 or 4 segements
+            // depending on whether the current versions has 2, 3 or 4 segments
             Version newVersion;
             if (currentVersion.Version.Build >= 0 && currentVersion.Version.Revision > 0)
             {
-                // 4 segement version
+                // 4 segment version
                 newVersion = new Version(
                     currentVersion.Version.Major + majorIncrement,
                     currentVersion.Version.Minor + minorIncrement,
@@ -35,7 +35,7 @@
             }
             else if (currentVersion.Version.Build >= 0)
             {
-                // 3 segement version
+                // 3 segment version
                 newVersion = new Version(
                     currentVersion.Version.Major + majorIncrement,
                     currentVersion.Version.Minor + minorIncrement,

--- a/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
@@ -60,6 +60,8 @@
         /// <returns>Returns a new instance of <see cref="SemanticVersion"/> with the updated prerelease tag</returns>
         public static SemanticVersion SetFirstPrereleaseTag(this SemanticVersion version, string newFirstTag)
         {
+            newFirstTag = newFirstTag ?? "";
+
             string preRelease;
             if(string.IsNullOrEmpty(version.Prerelease))
             {
@@ -80,5 +82,14 @@
             return new SemanticVersion(version.Version, preRelease, version.BuildMetadata);            
         }
 
+        /// <summary>
+        /// Removes all prerelease tags from the semantic version.
+        /// </summary>
+        /// <param name="version">The version to remove the prerelease tags from.</param>
+        /// <returns>Returns a new instance <see cref="SemanticVersion"/> which does not contain any prerelease tags.</returns>
+        public static SemanticVersion WithoutPrepreleaseTags(this SemanticVersion version)
+        {
+            return new SemanticVersion(version.Version, null, version.BuildMetadata);
+        }
     }
 }

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -997,7 +997,8 @@
             /// <summary>
             /// Initializes a new instance of the <see cref="ReleaseOptions"/> class
             /// </summary>
-            public ReleaseOptions() : this(isReadOnly: false)
+            public ReleaseOptions()
+                : this(isReadOnly: false)
             {
             }
 
@@ -1025,7 +1026,6 @@
             [JsonIgnore]
             public string BranchNameOrDefault => this.BranchName ?? DefaultInstance.BranchName;
 
-
             /// <summary>
             /// Gets or sets the setting specifying how to increment the version when creating a release
             /// </summary>
@@ -1037,13 +1037,13 @@
             }
 
             /// <summary>
-            /// Gets or sets the setting specifying how to increment the version when creating a release
+            /// Gets or sets the setting specifying how to increment the version when creating a release.
             /// </summary>
             [JsonIgnore]
             public ReleaseVersionIncrement VersionIncrementOrDefault => this.VersionIncrement ?? DefaultInstance.VersionIncrement.Value;
 
             /// <summary>
-            /// Gets or sets the first/default prerelease tag for new versions
+            /// Gets or sets the first/default prerelease tag for new versions.
             /// </summary>
             [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
             public string FirstUnstableTag
@@ -1053,7 +1053,7 @@
             }
 
             /// <summary>
-            /// Gets or sets the first/default prerelease tag for new versions
+            /// Gets or sets the first/default prerelease tag for new versions.
             /// </summary>
             [JsonIgnore]
             public string FirstUnstableTagOrDefault => this.FirstUnstableTag ?? DefaultInstance.FirstUnstableTag;

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -126,6 +126,18 @@
         public CloudBuildOptions CloudBuildOrDefault => this.CloudBuild ?? CloudBuildOptions.DefaultInstance;
 
         /// <summary>
+        /// Gets or sets the options for the prepare-release command
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ReleaseOptions Release { get; set; }
+
+        /// <summary>
+        /// Gets the options for the prepare-release command
+        /// </summary>
+        [JsonIgnore]
+        public ReleaseOptions ReleaseOrDefault => this.Release ?? ReleaseOptions.DefaultInstance;
+
+        /// <summary>
         /// Gets or sets a value indicating whether this options object should inherit from an ancestor any settings that are not explicitly set in this one.
         /// </summary>
         /// <remarks>
@@ -1024,7 +1036,7 @@
             /// </summary>
             [JsonIgnore]
             public ReleaseVersionIncrement VersionIncrementOrDefault => this.VersionIncrement ?? DefaultInstance.VersionIncrement.Value;
-
+            
             /// <inheritdoc />
             public override bool Equals(object obj) => this.Equals(obj as ReleaseOptions);
 
@@ -1070,15 +1082,15 @@
                         return true;
                     }
 
-                    return StringComparer.Ordinal.Equals(x.BranchName, y.BranchName) &&
-                           x.VersionIncrement == y.VersionIncrement;
+                    return StringComparer.Ordinal.Equals(x.BranchNameOrDefault, y.BranchNameOrDefault) &&
+                           x.VersionIncrementOrDefault == y.VersionIncrementOrDefault;
                 }
 
                 /// <inheritdoc />
                 public int GetHashCode(ReleaseOptions obj)
                 {
                     return obj != null
-                        ? (StringComparer.Ordinal.GetHashCode(obj.BranchName) + (int)obj.VersionIncrement)
+                        ? (StringComparer.Ordinal.GetHashCode(obj.BranchNameOrDefault) + (int)obj.VersionIncrementOrDefault)
                         : 0;
                 }
             }

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -893,6 +893,7 @@
                     && AssemblyVersionOptions.EqualWithDefaultsComparer.Singleton.Equals(x.AssemblyVersionOrDefault, y.AssemblyVersionOrDefault)
                     && NuGetPackageVersionOptions.EqualWithDefaultsComparer.Singleton.Equals(x.NuGetPackageVersionOrDefault, y.NuGetPackageVersionOrDefault)
                     && CloudBuildOptions.EqualWithDefaultsComparer.Singleton.Equals(x.CloudBuildOrDefault, y.CloudBuildOrDefault)
+                    && ReleaseOptions.EqualWithDefaultsComparer.Singleton.Equals(x.ReleaseOrDefault, y.ReleaseOrDefault)
                     && x.BuildNumberOffset == y.BuildNumberOffset;
             }
 

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -977,7 +977,7 @@
             /// </summary>
             internal static readonly ReleaseOptions DefaultInstance = new ReleaseOptions(isReadOnly: true)
             {
-                branchName = "release/v{version}", 
+                branchName = "v{version}",
                 versionIncrement = ReleaseVersionIncrement.Minor,
                 firstUnstableTag = "alpha"
             };
@@ -1020,7 +1020,7 @@
             }
 
             /// <summary>
-            /// Gets the set branch name template for release branches 
+            /// Gets the set branch name template for release branches
             /// </summary>
             [JsonIgnore]
             public string BranchNameOrDefault => this.BranchName ?? DefaultInstance.BranchName;
@@ -1120,7 +1120,7 @@
                         hash ^= (int)obj.VersionIncrementOrDefault;
                         hash ^= StringComparer.Ordinal.GetHashCode(obj.FirstUnstableTagOrDefault);
                         return hash;
-                    }                    
+                    }
                 }
             }
         }

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -977,7 +977,8 @@
             internal static readonly ReleaseOptions DefaultInstance = new ReleaseOptions(isReadOnly: true)
             {
                 branchName = "release/v{0}", //TODO: Use something like {version} instead of {0} which would be more consistent with the {height} in the version
-                versionIncrement = ReleaseVersionIncrement.Minor
+                versionIncrement = ReleaseVersionIncrement.Minor,
+                firstUnstableTag = "alpha"
             };
 
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -988,6 +989,9 @@
 
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             private ReleaseVersionIncrement? versionIncrement;
+
+            [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+            private string firstUnstableTag;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="ReleaseOptions"/> class
@@ -1036,7 +1040,23 @@
             /// </summary>
             [JsonIgnore]
             public ReleaseVersionIncrement VersionIncrementOrDefault => this.VersionIncrement ?? DefaultInstance.VersionIncrement.Value;
-            
+
+            /// <summary>
+            /// Gets or sets the first/default prerelease tag for new versions
+            /// </summary>
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string FirstUnstableTag
+            {
+                get => this.firstUnstableTag;
+                set => this.SetIfNotReadOnly(ref this.firstUnstableTag, value);
+            }
+
+            /// <summary>
+            /// Gets or sets the first/default prerelease tag for new versions
+            /// </summary>
+            [JsonIgnore]
+            public string FirstUnstableTagOrDefault => this.FirstUnstableTag ?? DefaultInstance.FirstUnstableTag;
+
             /// <inheritdoc />
             public override bool Equals(object obj) => this.Equals(obj as ReleaseOptions);
 
@@ -1083,15 +1103,23 @@
                     }
 
                     return StringComparer.Ordinal.Equals(x.BranchNameOrDefault, y.BranchNameOrDefault) &&
-                           x.VersionIncrementOrDefault == y.VersionIncrementOrDefault;
+                           x.VersionIncrementOrDefault == y.VersionIncrementOrDefault &&
+                           StringComparer.Ordinal.Equals(x.FirstUnstableTagOrDefault, y.FirstUnstableTagOrDefault);
                 }
 
                 /// <inheritdoc />
                 public int GetHashCode(ReleaseOptions obj)
                 {
-                    return obj != null
-                        ? (StringComparer.Ordinal.GetHashCode(obj.BranchNameOrDefault) + (int)obj.VersionIncrementOrDefault)
-                        : 0;
+                    if (obj == null)
+                        return 0;
+
+                    unchecked
+                    {
+                        var hash = StringComparer.Ordinal.GetHashCode(obj.BranchNameOrDefault) * 397;
+                        hash ^= (int)obj.VersionIncrementOrDefault;
+                        hash ^= StringComparer.Ordinal.GetHashCode(obj.FirstUnstableTagOrDefault);
+                        return hash;
+                    }                    
                 }
             }
         }

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -977,7 +977,7 @@
             /// </summary>
             internal static readonly ReleaseOptions DefaultInstance = new ReleaseOptions(isReadOnly: true)
             {
-                branchName = "release/v{0}", //TODO: Use something like {version} instead of {0} which would be more consistent with the {height} in the version
+                branchName = "release/v{version}", 
                 versionIncrement = ReleaseVersionIncrement.Minor,
                 firstUnstableTag = "alpha"
             };

--- a/src/NerdBank.GitVersioning/VersionOptionsContractResolver.cs
+++ b/src/NerdBank.GitVersioning/VersionOptionsContractResolver.cs
@@ -129,6 +129,11 @@
                 {
                     property.ShouldSerialize = instance => ((VersionOptions.ReleaseOptions)instance).VersionIncrementOrDefault != VersionOptions.ReleaseOptions.DefaultInstance.VersionIncrement.Value;
                 }
+
+                if (property.DeclaringType == typeof(VersionOptions.ReleaseOptions) && member.Name == nameof(VersionOptions.ReleaseOptions.FirstUnstableTag))
+                {
+                    property.ShouldSerialize = instance => ((VersionOptions.ReleaseOptions)instance).FirstUnstableTagOrDefault != VersionOptions.ReleaseOptions.DefaultInstance.FirstUnstableTag;
+                }
             }
 
             return property;

--- a/src/NerdBank.GitVersioning/VersionOptionsContractResolver.cs
+++ b/src/NerdBank.GitVersioning/VersionOptionsContractResolver.cs
@@ -114,6 +114,21 @@
                 {
                     property.ShouldSerialize = instance => ((VersionOptions.CloudBuildNumberCommitIdOptions)instance).WhereOrDefault != VersionOptions.CloudBuildNumberCommitIdOptions.DefaultInstance.Where.Value;
                 }
+                
+                if (property.DeclaringType == typeof(VersionOptions) && member.Name == nameof(VersionOptions.Release))
+                {
+                    property.ShouldSerialize = instance => !((VersionOptions)instance).ReleaseOrDefault.IsDefault;
+                }
+                
+                if (property.DeclaringType == typeof(VersionOptions.ReleaseOptions) && member.Name == nameof(VersionOptions.ReleaseOptions.BranchName))
+                {
+                    property.ShouldSerialize = instance => ((VersionOptions.ReleaseOptions)instance).BranchNameOrDefault != VersionOptions.ReleaseOptions.DefaultInstance.BranchName;
+                }
+
+                if (property.DeclaringType == typeof(VersionOptions.ReleaseOptions) && member.Name == nameof(VersionOptions.ReleaseOptions.VersionIncrement))
+                {
+                    property.ShouldSerialize = instance => ((VersionOptions.ReleaseOptions)instance).VersionIncrementOrDefault != VersionOptions.ReleaseOptions.DefaultInstance.VersionIncrement.Value;
+                }
             }
 
             return property;

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -143,7 +143,7 @@
               "description": "Defines the format of release branch names. Format must include a placeholder '{version}' for the version",
               "type": "string",
               "pattern": ".*\\{0\\}.*",
-              "default": "release/v{0}"
+              "default": "v{version}"
             },
             "versionIncrement": {
               "description": "Specifies which part of the version on the current branch is incremented when preparing a release.",

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -134,6 +134,24 @@
               }
             }
           }
+        },
+        "release": {
+          "description": "Settings for the prepare-release command",
+          "type": "object",
+          "properties": {
+            "branchName": {
+              "description": "Defines the format of release branch names. Format must incluse a placeholder '{0}' for the version",
+              "type": "string",
+              "pattern": ".*\\{0\\}.*"
+            },
+            "versionIncrement": {
+              "type": "string",
+              "description": "Specifies how the version on the current branch is updated when creating a release branch",
+              "enum": [ "major", "minor" ],
+              "default": "minor"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -140,13 +140,13 @@
           "type": "object",
           "properties": {
             "branchName": {
-              "description": "Defines the format of release branch names. Format must incluse a placeholder '{0}' for the version",
+              "description": "Defines the format of release branch names. Format must include a placeholder '{version}' for the version",
               "type": "string",
               "pattern": ".*\\{0\\}.*",
               "default": "release/v{0}"
             },
             "versionIncrement": {
-              "description": "Specifies how the version on the current branch is updated when creating a release branch",
+              "description": "Specifies which part of the version on the current branch is incremented when preparing a release.",
               "type": "string",
               "enum": [ "major", "minor" ],
               "default": "minor"

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -142,13 +142,19 @@
             "branchName": {
               "description": "Defines the format of release branch names. Format must incluse a placeholder '{0}' for the version",
               "type": "string",
-              "pattern": ".*\\{0\\}.*"
+              "pattern": ".*\\{0\\}.*",
+              "default": "release/v{0}"
             },
             "versionIncrement": {
-              "type": "string",
               "description": "Specifies how the version on the current branch is updated when creating a release branch",
+              "type": "string",
               "enum": [ "major", "minor" ],
               "default": "minor"
+            },
+            "firstUnstableTag": {
+              "description": "Specifies the first/default prerelease tag for new versions",
+              "type": "string",
+              "default": "alpha"
             }
           },
           "additionalProperties": false

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -40,7 +40,8 @@ namespace Nerdbank.GitVersioning.Tool
             NoCloudBuildProviderMatch,
             BadVariable,
             UncommittedChanges,
-            InvalidBranchNameSetting
+            InvalidBranchNameSetting,
+            BranchAlreadyExists
         }
 
         private static ExitCodes exitCode;
@@ -596,7 +597,9 @@ namespace Nerdbank.GitVersioning.Tool
                     case ReleaseManager.ReleasePreparationError.NoVersionFile:
                         return ExitCodes.NoVersionJsonFound;
                     case ReleaseManager.ReleasePreparationError.VersionDecrement:
-                        return ExitCodes.InvalidVersionSpec;                        
+                        return ExitCodes.InvalidVersionSpec;
+                    case ReleaseManager.ReleasePreparationError.BranchAlreadyExists:
+                        return ExitCodes.BranchAlreadyExists;                        
                     default:
                         throw new InvalidOperationException($"Unimplemented case in switch statement: ReleasePreparationError.{ex.Error}");
                 }

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -14,6 +14,7 @@ namespace Nerdbank.GitVersioning.Tool
     using NuGet.Protocol;
     using NuGet.Protocol.Core.Types;
     using NuGet.Resolver;
+    using Validation;
     using MSBuild = Microsoft.Build.Evaluation;
 
     internal class Program
@@ -43,6 +44,7 @@ namespace Nerdbank.GitVersioning.Tool
             InvalidBranchNameSetting,
             BranchAlreadyExists,
             UserNotConfigured,
+            DetachedHead,
         }
 
         private static ExitCodes exitCode;
@@ -603,8 +605,11 @@ namespace Nerdbank.GitVersioning.Tool
                         return ExitCodes.BranchAlreadyExists;
                     case ReleaseManager.ReleasePreparationError.UserNotConfigured:
                         return ExitCodes.UserNotConfigured;
+                    case ReleaseManager.ReleasePreparationError.DetachedHead:
+                        return ExitCodes.DetachedHead;
                     default:
-                        throw new InvalidOperationException($"Unimplemented case in switch statement. ReleasePreparationError: {ex.Error}");
+                        Report.Fail($"{nameof(ReleaseManager.ReleasePreparationError)}: {ex.Error}");
+                        return (ExitCodes)(-1);
                 }
             }
         }

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -41,7 +41,8 @@ namespace Nerdbank.GitVersioning.Tool
             BadVariable,
             UncommittedChanges,
             InvalidBranchNameSetting,
-            BranchAlreadyExists
+            BranchAlreadyExists,
+            UserNotConfigured
         }
 
         private static ExitCodes exitCode;
@@ -599,7 +600,9 @@ namespace Nerdbank.GitVersioning.Tool
                     case ReleaseManager.ReleasePreparationError.VersionDecrement:
                         return ExitCodes.InvalidVersionSpec;
                     case ReleaseManager.ReleasePreparationError.BranchAlreadyExists:
-                        return ExitCodes.BranchAlreadyExists;                        
+                        return ExitCodes.BranchAlreadyExists;
+                    case ReleaseManager.ReleasePreparationError.UserNotConfigured:
+                        return ExitCodes.UserNotConfigured;
                     default:
                         throw new InvalidOperationException($"Unimplemented case in switch statement: ReleasePreparationError.{ex.Error}");
                 }

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -42,7 +42,7 @@ namespace Nerdbank.GitVersioning.Tool
             UncommittedChanges,
             InvalidBranchNameSetting,
             BranchAlreadyExists,
-            UserNotConfigured
+            UserNotConfigured,
         }
 
         private static ExitCodes exitCode;
@@ -60,7 +60,7 @@ namespace Nerdbank.GitVersioning.Tool
             var cisystem = string.Empty;
             bool cloudBuildCommonVars = false;
             bool cloudBuildAllVars = false;
-            string releasePreReleasetag = null;
+            string releasePreReleaseTag = null;
             string releaseNextVersion = null;
 
             ArgumentCommand<string> install = null;
@@ -107,7 +107,7 @@ namespace Nerdbank.GitVersioning.Tool
                 prepareRelease = syntax.DefineCommand("prepare-release", ref commandText, "Prepares a release by creating a release branch for the current version and adjusting the version on the current branch.");
                 syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the current directory.");
                 syntax.DefineOption("nextVersion", ref releaseNextVersion, "The version to set for the current branch. If omitted, the next version is determined automatically by incrementing the current version.");
-                syntax.DefineParameter("tag", ref releasePreReleasetag, "The prerelease to use on the release branch. Omit to not use any prerelease tags on the release branch.");
+                syntax.DefineParameter("tag", ref releasePreReleaseTag, "The prerelease tag to apply on the release branch (if any). If not specified, any existing prerelease tag will be removed. The preceding hyphen may be omitted.");
 
                 if (syntax.ActiveCommand == null)
                 {
@@ -140,9 +140,9 @@ namespace Nerdbank.GitVersioning.Tool
             {
                 exitCode = OnCloudCommand(projectPath, version, cisystem, cloudBuildAllVars, cloudBuildCommonVars, cloudVariables);
             }
-            else if(prepareRelease.IsActive)
+            else if (prepareRelease.IsActive)
             {
-                exitCode = OnPrepareReleaseCommand(projectPath, releasePreReleasetag, releaseNextVersion);
+                exitCode = OnPrepareReleaseCommand(projectPath, releasePreReleaseTag, releaseNextVersion);
             }
 
             return (int)exitCode;
@@ -568,9 +568,9 @@ namespace Nerdbank.GitVersioning.Tool
 
             // parse nextVersion if parameter was specified
             SemanticVersion nextVersionParsed = default;
-            if(!string.IsNullOrEmpty(nextVersion))
+            if (!string.IsNullOrEmpty(nextVersion))
             {
-                if(!SemanticVersion.TryParse(nextVersion, out nextVersionParsed))
+                if (!SemanticVersion.TryParse(nextVersion, out nextVersionParsed))
                 {
                     Console.Error.WriteLine($"\"{nextVersion}\" is not a semver-compliant version spec.");
                     return ExitCodes.InvalidVersionSpec;
@@ -590,7 +590,7 @@ namespace Nerdbank.GitVersioning.Tool
                 switch (ex.Error)
                 {
                     case ReleaseManager.ReleasePreparationError.NoGitRepo:
-                        return ExitCodes.NoGitRepo;                        
+                        return ExitCodes.NoGitRepo;
                     case ReleaseManager.ReleasePreparationError.UncommittedChanges:
                         return ExitCodes.UncommittedChanges;
                     case ReleaseManager.ReleasePreparationError.InvalidBranchNameSetting:
@@ -604,7 +604,7 @@ namespace Nerdbank.GitVersioning.Tool
                     case ReleaseManager.ReleasePreparationError.UserNotConfigured:
                         return ExitCodes.UserNotConfigured;
                     default:
-                        throw new InvalidOperationException($"Unimplemented case in switch statement: ReleasePreparationError.{ex.Error}");
+                        throw new InvalidOperationException($"Unimplemented case in switch statement. ReleasePreparationError: {ex.Error}");
                 }
             }
         }


### PR DESCRIPTION
This PR adds the `prepare-release` command as discussed in #287 

I made a minor modification to the feature compared to what was discussed in the issue. The setting to control the name of release branches does not use `{0}` as a placeholder for the version but `{version}`. I think this makes it more consistent with the version setting which uses `{height}`

Closes #287