### PR TITLE
persist msbuild files generated during test before actual execution

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -1005,6 +1005,7 @@ public class BuildIntegrationTests : RepoTestBase
     {
         var eventLogger = new MSBuildLogger { Verbosity = LoggerVerbosity.Minimal };
         var loggers = new ILogger[] { eventLogger };
+        this.testProject.Save(); // persist generated project on disk for analysis
         var buildResult = await this.buildManager.BuildAsync(
             this.Logger,
             this.projectCollection,
@@ -1036,6 +1037,7 @@ public class BuildIntegrationTests : RepoTestBase
             {
                 var targetsFile = ProjectRootElement.Create(XmlReader.Create(stream), this.projectCollection);
                 targetsFile.FullPath = Path.Combine(this.RepoPath, name.Substring(prefix.Length));
+                targetsFile.Save(); // persist files on disk
             }
         }
     }


### PR DESCRIPTION
The testProject and imported targets files were not persisted during testing.

I believe this might be the cause of the unstable tests, as the build engine actually will sometimes error out on missing files during testing like:
`Microsoft.Build.Exceptions.InvalidProjectFileException : The imported project "C:\Users\VssAdministrator\AppData\Local\Temp\b0hpof3h.oba\NerdBank.GitVersioning.targets" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.  C:\Users\VssAdministrator\AppData\Local\Temp\b0hpof3h.oba\projdir\test.prj`