### PR TITLE
Allow incrementing the "build" of the version in the prepare-release command

### DIFF
--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -103,11 +103,11 @@ The behaviour of the `prepare-release` command can be customized in
 }
 ```
 
-| Property         | Default value        | Description                                                                                                                                |
-|------------------|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| branchName       | `v{version}`         | Defines the format of release branch names. The value must include a `{version}` placeholder.                                              |
-| versionIncremnt  | `minor`              | Specifies which part of the version on the current branch is incremented when preparing a release. Allowed values are `minor` and `major`. |
-| firstUnstableTag | `alpha`              | Specified the unstable tag to use for the main branch.                                                                                     |
+| Property         | Default value        | Description                                                                                                                                         |
+|------------------|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| branchName       | `v{version}`         | Defines the format of release branch names. The value must include a `{version}` placeholder.                                                       |
+| versionIncremnt  | `minor`              | Specifies which part of the version on the current branch is incremented when preparing a release. Allowed values are `major`, `minor` and `build`. |
+| firstUnstableTag | `alpha`              | Specified the unstable tag to use for the main branch.                                                                                              |
 
 ## Learn more
 

--- a/src/NerdBank.GitVersioning.Tests/SemanticVersionExtensionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/SemanticVersionExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Nerdbank.GitVersioning;
 using Xunit;
@@ -26,7 +27,13 @@ public class SemanticVersionExtensionsTests
     [InlineData("1.2.3", ReleaseVersionIncrement.Major, "2.0.0")]
     [InlineData("1.2.3.4", ReleaseVersionIncrement.Minor, "1.3.0.0")]
     [InlineData("1.2.3.4", ReleaseVersionIncrement.Major, "2.0.0.0")]
-    public void IncrementVersion(string currentVersionString, ReleaseVersionIncrement increment, string expectedVersionString)
+    [InlineData("1.2.3", ReleaseVersionIncrement.Build, "1.2.4")]
+    [InlineData("1.2.3.4", ReleaseVersionIncrement.Build, "1.2.4.0")]
+    [InlineData("1.2.3-tag", ReleaseVersionIncrement.Build, "1.2.4-tag")]
+    [InlineData("1.2.3-tag+metadata", ReleaseVersionIncrement.Build, "1.2.4-tag+metadata")]
+    [InlineData("1.2.3.4-tag", ReleaseVersionIncrement.Build, "1.2.4.0-tag")]
+    [InlineData("1.2.3.4-tag+metadata", ReleaseVersionIncrement.Build, "1.2.4.0-tag+metadata")]
+    public void Increment(string currentVersionString, ReleaseVersionIncrement increment, string expectedVersionString)
     {
         var currentVersion = SemanticVersion.Parse(currentVersionString);
         var expectedVersion = SemanticVersion.Parse(expectedVersionString);
@@ -34,6 +41,15 @@ public class SemanticVersionExtensionsTests
         var actualVersion = currentVersion.Increment(increment);
 
         Assert.Equal(expectedVersion, actualVersion);
+    }
+
+    [Theory]
+    [InlineData("1.0", ReleaseVersionIncrement.Build)]
+    public void Increment_InvalidIncrement(string currentVersionString, ReleaseVersionIncrement increment)
+    {
+        var currentVersion = SemanticVersion.Parse(currentVersionString);
+
+        Assert.Throws<ArgumentException>(() => currentVersion.Increment(increment));
     }
 
     [Theory]

--- a/src/NerdBank.GitVersioning.Tests/VersionSchemaTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionSchemaTests.cs
@@ -92,6 +92,7 @@ public class VersionSchemaTests
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""prefix{0}suffix"" } }")]
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"", ""versionIncrement"" : ""major"" } }")]
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"", ""versionIncrement"" : ""minor"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"", ""versionIncrement"" : ""build"" } }")]
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""firstUnstableTag"" : ""pre"" } }")]
     public void ReleaseProperty_ValidJson(string json)
     {
@@ -100,7 +101,7 @@ public class VersionSchemaTests
     }
 
     [Theory]
-    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""versionIncrement"" : ""build"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""versionIncrement"" : ""revision"" } }")]
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""formatWithoutPlaceholder"" } }")]
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""unknownProperty"" : ""value"" } }")]
     public void ReleaseProperty_InvalidJson(string json)

--- a/src/NerdBank.GitVersioning.Tests/VersionSchemaTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionSchemaTests.cs
@@ -87,12 +87,12 @@ public class VersionSchemaTests
 
     [Theory]
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { } }")]
-    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"" } }")]
-    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""release/v{0}"" } }")]
-    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""prefix{0}suffix"" } }")]
-    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"", ""versionIncrement"" : ""major"" } }")]
-    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"", ""versionIncrement"" : ""minor"" } }")]
-    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{0}"", ""versionIncrement"" : ""build"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{version}"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""release/v{version}"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""prefix{version}suffix"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{version}"", ""versionIncrement"" : ""major"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{version}"", ""versionIncrement"" : ""minor"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""{version}"", ""versionIncrement"" : ""build"" } }")]
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""firstUnstableTag"" : ""pre"" } }")]
     public void ReleaseProperty_ValidJson(string json)
     {
@@ -103,7 +103,8 @@ public class VersionSchemaTests
     [Theory]
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""versionIncrement"" : ""revision"" } }")]
     [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""formatWithoutPlaceholder"" } }")]
-    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""unknownProperty"" : ""value"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""branchName"" : ""formatWithoutPlaceholder{0}"" } }")]
+    [InlineData(@"{ ""version"": ""2.3"", ""release"":  { ""unknownProperty"" : ""value"" } }")]    
     public void ReleaseProperty_InvalidJson(string json)
     {
         this.json = JObject.Parse(json);

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -58,7 +58,7 @@
             DetachedHead,
 
             /// <summary>
-            /// The versionIncrement setting cannot be applied to the current version
+            /// The versionIncrement setting cannot be applied to the current version.
             /// </summary>
             InvalidVersionIncrementSetting,
         }

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -56,6 +56,11 @@
             /// HEAD is detached. A branch must be checked out first.
             /// </summary>
             DetachedHead,
+
+            /// <summary>
+            /// The versionIncrement setting cannot be applied to the current version
+            /// </summary>
+            InvalidVersionIncrementSetting,
         }
 
         /// <summary>
@@ -126,13 +131,13 @@
                 throw new ReleasePreparationException(ReleasePreparationError.NoVersionFile);
             }
 
-            var releaseOptions = versionOptions.ReleaseOrDefault;
-
+            
             var releaseBranchName = this.GetReleaseBranchName(versionOptions);
             var originalBranchName = repository.Head.FriendlyName;
             var releaseVersion = string.IsNullOrEmpty(releaseUnstableTag)
                 ? versionOptions.Version.WithoutPrepreleaseTags()
                 : versionOptions.Version.SetFirstPrereleaseTag(releaseUnstableTag);
+            var nextDevVersion = this.GetNextDevVersion(versionOptions, nextVersion);
 
             // check if the current branch is the release branch
             if (string.Equals(originalBranchName, releaseBranchName, StringComparison.OrdinalIgnoreCase))
@@ -157,10 +162,6 @@
 
             // update version on main branch
             Commands.Checkout(repository, originalBranchName);
-            var nextDevVersion = nextVersion ??
-                    versionOptions.Version
-                        .Increment(releaseOptions.VersionIncrementOrDefault)
-                        .SetFirstPrereleaseTag(releaseOptions.FirstUnstableTagOrDefault);
             this.UpdateVersion(projectDirectory, repository, versionOptions.Version, nextDevVersion);
             this.stdout.WriteLine($"{originalBranchName} branch now tracks v{nextDevVersion} development.");
 
@@ -271,6 +272,31 @@
                 // newVersion.Version < oldVersion.Version
                 return true;
             }
+        }
+
+        private SemanticVersion GetNextDevVersion(VersionOptions versionOptions, SemanticVersion nextVersion)
+        {
+            if (nextVersion != null)
+                return nextVersion;
+
+            var releaseOptions = versionOptions.ReleaseOrDefault;
+
+            // the increment is only valid if the current version has the required precision
+            // increment settings "Major" and "Minor" are always valid
+            // increment setting "Build" is only valid if the version has at lease three segments
+            var isValidIncrement = releaseOptions.VersionIncrementOrDefault != VersionOptions.ReleaseVersionIncrement.Build ||
+                                   versionOptions.Version.Version.Build >= 0;
+
+            // increment is ignored when the next version was specified explicitly
+            if (!isValidIncrement)
+            {
+                this.stderr.WriteLine($"Cannot increment build in version '{versionOptions.Version}' because it only has major and minor segments");
+                throw new ReleasePreparationException(ReleasePreparationError.InvalidVersionIncrementSetting);
+            }
+
+            return versionOptions.Version
+                        .Increment(releaseOptions.VersionIncrementOrDefault)
+                        .SetFirstPrereleaseTag(releaseOptions.FirstUnstableTagOrDefault);
         }
     }
 }

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -289,7 +289,7 @@
             // increment is ignored when the next version was specified explicitly
             if (!isValidIncrement)
             {
-                this.stderr.WriteLine($"Cannot use version increment 'build' in version '{versionOptions.Version}' because it only has major and minor segments");
+                this.stderr.WriteLine($"Cannot apply version increment 'build' to version '{versionOptions.Version}' because it only has major and minor segments");
                 throw new ReleasePreparationException(ReleasePreparationError.InvalidVersionIncrementSetting);
             }
 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -289,7 +289,7 @@
             // increment is ignored when the next version was specified explicitly
             if (!isValidIncrement)
             {
-                this.stderr.WriteLine($"Cannot increment build in version '{versionOptions.Version}' because it only has major and minor segments");
+                this.stderr.WriteLine($"Cannot use version increment 'build' in version '{versionOptions.Version}' because it only has major and minor segments");
                 throw new ReleasePreparationException(ReleasePreparationError.InvalidVersionIncrementSetting);
             }
 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -130,7 +130,6 @@
                 this.stderr.WriteLine($"Failed to load version file for directory '{projectDirectory}'.");
                 throw new ReleasePreparationException(ReleasePreparationError.NoVersionFile);
             }
-
             
             var releaseBranchName = this.GetReleaseBranchName(versionOptions);
             var originalBranchName = repository.Head.FriendlyName;

--- a/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
@@ -106,6 +106,6 @@
         internal static SemanticVersion WithoutPrepreleaseTags(this SemanticVersion version)
         {
             return new SemanticVersion(version.Version, null, version.BuildMetadata);
-        }      
+        }
     }
 }

--- a/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
@@ -18,7 +18,7 @@
         {
             Requires.NotNull(currentVersion, nameof(currentVersion));
             Requires.That(increment != VersionOptions.ReleaseVersionIncrement.Build || currentVersion.Version.Build >= 0, nameof(increment), 
-                          "Cannot use increment '{0}' with higher precision than the version being incremented", increment);
+                          "Cannot apply version increment '{0}' to version '{1}'", increment, currentVersion);
 
             var major = currentVersion.Version.Major;
             var minor = currentVersion.Version.Minor;

--- a/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
@@ -17,19 +17,29 @@
         internal static SemanticVersion Increment(this SemanticVersion currentVersion, VersionOptions.ReleaseVersionIncrement increment)
         {
             Requires.NotNull(currentVersion, nameof(currentVersion));
+            Requires.That(increment != VersionOptions.ReleaseVersionIncrement.Build || currentVersion.Version.Build > 0, nameof(increment), 
+                          "Cannot use increment '{0}' with higher precision than the version being incremented", increment);
 
             var major = currentVersion.Version.Major;
             var minor = currentVersion.Version.Minor;
+            var build = currentVersion.Version.Build;
 
             switch (increment)
             {
                 case VersionOptions.ReleaseVersionIncrement.Major:
                     major += 1;
                     minor = 0;
+                    build = 0;
                     break;
                 case VersionOptions.ReleaseVersionIncrement.Minor:
                     minor += 1;
+                    build = 0;
                     break;
+
+                case VersionOptions.ReleaseVersionIncrement.Build:
+                    build += 1;
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(increment));
             }
@@ -40,12 +50,12 @@
             if (currentVersion.Version.Build >= 0 && currentVersion.Version.Revision > 0)
             {
                 // 4 segment version
-                newVersion = new Version(major, minor, 0, 0);
+                newVersion = new Version(major, minor, build, 0);
             }
             else if (currentVersion.Version.Build >= 0)
             {
                 // 3 segment version
-                newVersion = new Version(major, minor, 0);
+                newVersion = new Version(major, minor, build);
             }
             else
             {
@@ -96,6 +106,6 @@
         internal static SemanticVersion WithoutPrepreleaseTags(this SemanticVersion version)
         {
             return new SemanticVersion(version.Version, null, version.BuildMetadata);
-        }
+        }      
     }
 }

--- a/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersionExtensions.cs
@@ -17,7 +17,7 @@
         internal static SemanticVersion Increment(this SemanticVersion currentVersion, VersionOptions.ReleaseVersionIncrement increment)
         {
             Requires.NotNull(currentVersion, nameof(currentVersion));
-            Requires.That(increment != VersionOptions.ReleaseVersionIncrement.Build || currentVersion.Version.Build > 0, nameof(increment), 
+            Requires.That(increment != VersionOptions.ReleaseVersionIncrement.Build || currentVersion.Version.Build >= 0, nameof(increment), 
                           "Cannot use increment '{0}' with higher precision than the version being incremented", increment);
 
             var major = currentVersion.Version.Major;

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -1142,7 +1142,7 @@
             Minor,
 
             /// <summary>
-            /// Inrementn the build number (the third number in a version) after creating a release branch
+            /// Increment the build number (the third number in a version) after creating a release branch.
             /// </summary>
             Build,
         }

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -1139,7 +1139,12 @@
             /// <summary>
             /// Increment the minor version after creating a release branch
             /// </summary>
-            Minor
+            Minor,
+
+            /// <summary>
+            /// Inrementn the build number (the third number in a version) after creating a release branch
+            /// </summary>
+            Build,
         }
     }
 }

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -148,7 +148,7 @@
             "versionIncrement": {
               "description": "Specifies which part of the version on the current branch is incremented when preparing a release.",
               "type": "string",
-              "enum": [ "major", "minor" ],
+              "enum": [ "major", "minor", "build" ],
               "default": "minor"
             },
             "firstUnstableTag": {

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -142,7 +142,7 @@
             "branchName": {
               "description": "Defines the format of release branch names. Format must include a placeholder '{version}' for the version",
               "type": "string",
-              "pattern": ".*\\{0\\}.*",
+              "pattern": ".*\\{version\\}.*",
               "default": "v{version}"
             },
             "versionIncrement": {

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -45,6 +45,7 @@ namespace Nerdbank.GitVersioning.Tool
             BranchAlreadyExists,
             UserNotConfigured,
             DetachedHead,
+            InvalidVersionIncrementSetting,
         }
 
         private static ExitCodes exitCode;
@@ -606,6 +607,8 @@ namespace Nerdbank.GitVersioning.Tool
                         return ExitCodes.UserNotConfigured;
                     case ReleaseManager.ReleasePreparationError.DetachedHead:
                         return ExitCodes.DetachedHead;
+                    case ReleaseManager.ReleasePreparationError.InvalidVersionIncrementSetting:
+                        return ExitCodes.InvalidVersionIncrementSetting;
                     default:
                         Report.Fail($"{nameof(ReleaseManager.ReleasePreparationError)}: {ex.Error}");
                         return (ExitCodes)(-1);


### PR DESCRIPTION
As discussed in #300, this PR add support for incrementing the "build" of a version when running `prepare-release`.

This can be achieved by setting the `versionIncrement` setting in `version.json` to `build`. 
The command will abort with an error if the current version only has a major and minor version.