### PR TITLE
Improved commandline options for prepare-release command

### DIFF
--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -87,7 +87,7 @@ or override the version increment setting.
 To explicitly set the next version, run
 
 ```ps1
-nbgv prepare-release --nextVersion 2.0-beta
+nbgv prepare-release --nextVersion 2.0
 ```
 
 To override the `versionIncrement` setting from `version.json`, run

--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -77,15 +77,27 @@ nbgv prepare-release rc
 no new branch will be created. Instead the tool will just update the version
 in the current branch by replacing or removing the prerelease tag.
 
-### Explicitly setting the next version
+### Customizing the next version
 
-If you want to explicitly set the next version of the main branch instead of
-automatically determining it by incrementing the current version, you
-can set the version as commandline parameter:
+By default, the next version of the main branch is determined from the current
+version and the `versionIncrement` setting in `version.json`.
+To customize this behaviour, you can either explicitly set the next version
+or override the version increment setting.
+
+To explicitly set the next version, run
 
 ```ps1
 nbgv prepare-release --nextVersion 2.0-beta
 ```
+
+To override the `versionIncrement` setting from `version.json`, run
+
+```ps1
+nbgv prepare-release --versionIncrement Major
+```
+
+**Note:** The parameters `nextVersion` and `versionIncrement` cannot
+be combined.
 
 ### Customizing the behaviour of `prepare-release`
 

--- a/doc/nbgv-cli.md
+++ b/doc/nbgv-cli.md
@@ -84,13 +84,13 @@ version and the `versionIncrement` setting in `version.json`.
 To customize this behaviour, you can either explicitly set the next version
 or override the version increment setting.
 
-To explicitly set the next version, run
+To explicitly set the next version, run:
 
 ```ps1
 nbgv prepare-release --nextVersion 2.0
 ```
 
-To override the `versionIncrement` setting from `version.json`, run
+To override the `versionIncrement` setting from `version.json`, run:
 
 ```ps1
 nbgv prepare-release --versionIncrement Major

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -200,42 +200,45 @@ public class ReleaseManagerTests : RepoTestBase
 
     [Theory]
     // base test cases
-    [InlineData("1.2-beta", null, null, null, null, null, "v1.2", "1.2", "1.3-alpha")]
-    [InlineData("1.2-beta", null, null, null, "rc", null, "v1.2", "1.2-rc", "1.3-alpha")]
-    [InlineData("1.2-beta.{height}", null, null, null, null, null, "v1.2", "1.2", "1.3-alpha.{height}")]
-    [InlineData("1.2-beta.{height}", null, null, null, "rc", null, "v1.2", "1.2-rc.{height}", "1.3-alpha.{height}")]
+    [InlineData("1.2-beta", null, null, null, null, null, null, "v1.2", "1.2", "1.3-alpha")]
+    [InlineData("1.2-beta", null, null, null, "rc", null, null, "v1.2", "1.2-rc", "1.3-alpha")]
+    [InlineData("1.2-beta.{height}", null, null, null, null, null, null, "v1.2", "1.2", "1.3-alpha.{height}")]
+    [InlineData("1.2-beta.{height}", null, null, null, "rc", null, null, "v1.2", "1.2-rc.{height}", "1.3-alpha.{height}")]
     // modify release.branchName
-    [InlineData("1.2-beta", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2", "1.3-alpha")]
-    [InlineData("1.2-beta", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc", "1.3-alpha")]
-    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2release", "1.2", "1.3-alpha.{height}")]
-    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2release", "1.2-rc.{height}", "1.3-alpha.{height}")]
+    [InlineData("1.2-beta", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, null, "v1.2release", "1.2", "1.3-alpha")]
+    [InlineData("1.2-beta", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, null, "v1.2release", "1.2-rc", "1.3-alpha")]
+    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", null, null, null, "v1.2release", "1.2", "1.3-alpha.{height}")]
+    [InlineData("1.2-beta.{height}", "v{version}release", ReleaseVersionIncrement.Minor, "alpha", "rc", null, null, "v1.2release", "1.2-rc.{height}", "1.3-alpha.{height}")]
     // modify release.versionIncrement: "Major"
-    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Major, "alpha", null, null, "v1.2", "1.2", "2.0-alpha")]
-    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Major, "alpha", "rc", null, "v1.2", "1.2-rc", "2.0-alpha")]
-    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Major, "alpha", null, null, "v1.2", "1.2", "2.0-alpha.{height}")]
-    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Major, "alpha", "rc", null, "v1.2", "1.2-rc.{height}", "2.0-alpha.{height}")]
+    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Major, "alpha", null, null, null, "v1.2", "1.2", "2.0-alpha")]
+    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Major, "alpha", "rc", null, null, "v1.2", "1.2-rc", "2.0-alpha")]
+    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Major, "alpha", null, null, null, "v1.2", "1.2", "2.0-alpha.{height}")]
+    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Major, "alpha", "rc", null, null, "v1.2", "1.2-rc.{height}", "2.0-alpha.{height}")]
     // modify release.versionIncrement: "Build"
-    [InlineData("1.2.3-beta", null, ReleaseVersionIncrement.Build, "alpha", null, null, "v1.2.3", "1.2.3", "1.2.4-alpha")]
-    [InlineData("1.2.3-beta", null, ReleaseVersionIncrement.Build, "alpha", "rc", null, "v1.2.3", "1.2.3-rc", "1.2.4-alpha")]
-    [InlineData("1.2.3-beta.{height}", null, ReleaseVersionIncrement.Build, "alpha", null, null, "v1.2.3", "1.2.3", "1.2.4-alpha.{height}")]
-    [InlineData("1.2.3-beta.{height}", null, ReleaseVersionIncrement.Build, "alpha", "rc", null, "v1.2.3", "1.2.3-rc.{height}", "1.2.4-alpha.{height}")]
+    [InlineData("1.2.3-beta", null, ReleaseVersionIncrement.Build, "alpha", null, null, null, "v1.2.3", "1.2.3", "1.2.4-alpha")]
+    [InlineData("1.2.3-beta", null, ReleaseVersionIncrement.Build, "alpha", "rc", null, null, "v1.2.3", "1.2.3-rc", "1.2.4-alpha")]
+    [InlineData("1.2.3-beta.{height}", null, ReleaseVersionIncrement.Build, "alpha", null, null, null, "v1.2.3", "1.2.3", "1.2.4-alpha.{height}")]
+    [InlineData("1.2.3-beta.{height}", null, ReleaseVersionIncrement.Build, "alpha", "rc", null, null, "v1.2.3", "1.2.3-rc.{height}", "1.2.4-alpha.{height}")]
     // modify release.firstUnstableTag
-    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Minor, "preview", null, null, "v1.2", "1.2", "1.3-preview")]
-    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Minor, "preview", "rc", null, "v1.2", "1.2-rc", "1.3-preview")]
-    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Minor, "preview", null, null, "v1.2", "1.2", "1.3-preview.{height}")]
-    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Minor, "preview", "rc", null, "v1.2", "1.2-rc.{height}", "1.3-preview.{height}")]
+    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Minor, "preview", null, null, null, "v1.2", "1.2", "1.3-preview")]
+    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Minor, "preview", "rc", null, null, "v1.2", "1.2-rc", "1.3-preview")]
+    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Minor, "preview", null, null, null, "v1.2", "1.2", "1.3-preview.{height}")]
+    [InlineData("1.2-beta.{height}", null, ReleaseVersionIncrement.Minor, "preview", "rc", null, null, "v1.2", "1.2-rc.{height}", "1.3-preview.{height}")]
     // include build metadata in version
-    [InlineData("1.2-beta+metadata", null, ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2", "1.2+metadata", "1.3-alpha+metadata")]
-    [InlineData("1.2-beta+metadata", null, ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2", "1.2-rc+metadata", "1.3-alpha+metadata")]
-    [InlineData("1.2-beta.{height}+metadata", null, ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2", "1.2+metadata", "1.3-alpha.{height}+metadata")]
-    [InlineData("1.2-beta.{height}+metadata", null, ReleaseVersionIncrement.Minor, "alpha", "rc", null, "v1.2", "1.2-rc.{height}+metadata", "1.3-alpha.{height}+metadata")]
+    [InlineData("1.2-beta+metadata", null, ReleaseVersionIncrement.Minor, "alpha", null, null, null, "v1.2", "1.2+metadata", "1.3-alpha+metadata")]
+    [InlineData("1.2-beta+metadata", null, ReleaseVersionIncrement.Minor, "alpha", "rc", null, null, "v1.2", "1.2-rc+metadata", "1.3-alpha+metadata")]
+    [InlineData("1.2-beta.{height}+metadata", null, ReleaseVersionIncrement.Minor, "alpha", null, null, null, "v1.2", "1.2+metadata", "1.3-alpha.{height}+metadata")]
+    [InlineData("1.2-beta.{height}+metadata", null, ReleaseVersionIncrement.Minor, "alpha", "rc", null, null, "v1.2", "1.2-rc.{height}+metadata", "1.3-alpha.{height}+metadata")]
     // versions without prerelease tags
-    [InlineData("1.2", null, ReleaseVersionIncrement.Minor, "alpha", null, null, "v1.2", "1.2", "1.3-alpha")]
-    [InlineData("1.2", null, ReleaseVersionIncrement.Major, "alpha", null, null, "v1.2", "1.2", "2.0-alpha")]
+    [InlineData("1.2", null, ReleaseVersionIncrement.Minor, "alpha", null, null, null, "v1.2", "1.2", "1.3-alpha")]
+    [InlineData("1.2", null, ReleaseVersionIncrement.Major, "alpha", null, null, null, "v1.2", "1.2", "2.0-alpha")]
     // explicitly set next version (firstUnstableTag setting will be ignored)
-    [InlineData("1.2-beta", null, null, null, null, "4.5", "v1.2", "1.2", "4.5")]
-    [InlineData("1.2-beta", null, null, null, null, "4.5-pre", "v1.2", "1.2", "4.5-pre")]
-    [InlineData("1.2-beta.{height}", null, null, null, null, "4.5-pre.{height}", "v1.2", "1.2", "4.5-pre.{height}")]
+    [InlineData("1.2-beta", null, null, null, null, "4.5", null, "v1.2", "1.2", "4.5")]
+    [InlineData("1.2-beta", null, null, null, null, "4.5-pre", null, "v1.2", "1.2", "4.5-pre")]
+    [InlineData("1.2-beta.{height}", null, null, null, null, "4.5-pre.{height}", null, "v1.2", "1.2", "4.5-pre.{height}")]
+    // explicitly set version increment overriding the setting from version.json    
+    [InlineData("1.2-beta", null, ReleaseVersionIncrement.Minor, null, null, null, ReleaseVersionIncrement.Major, "v1.2", "1.2", "2.0-alpha")]
+    [InlineData("1.2.3-beta", null, ReleaseVersionIncrement.Minor, null, null, null, ReleaseVersionIncrement.Build, "v1.2.3", "1.2.3", "1.2.4-alpha")]
     public void PrepareRelease_Master(
         // data for initial setup (version and release options configured in version.json)
         string initialVersion,
@@ -245,6 +248,7 @@ public class ReleaseManagerTests : RepoTestBase
         // arguments passed to PrepareRelease()
         string releaseUnstableTag,
         string nextVersion,
+        ReleaseVersionIncrement? parameterVersionIncrement,
         // expected versions and branch name after running PrepareRelease()
         string expectedBranchName,
         string resultingReleaseVersion,
@@ -295,7 +299,7 @@ public class ReleaseManagerTests : RepoTestBase
 
         // prepare release
         var releaseManager = new ReleaseManager();
-        releaseManager.PrepareRelease(this.RepoPath, releaseUnstableTag, (nextVersion == null ? null : SemanticVersion.Parse(nextVersion)));
+        releaseManager.PrepareRelease(this.RepoPath, releaseUnstableTag, (nextVersion == null ? null : SemanticVersion.Parse(nextVersion)), parameterVersionIncrement);
 
         // check if a branch was created
         Assert.Contains(this.Repo.Branches, branch => branch.FriendlyName == expectedBranchName);

--- a/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -11,6 +11,7 @@ using ReleaseOptions = Nerdbank.GitVersioning.VersionOptions.ReleaseOptions;
 using ReleasePreparationError = Nerdbank.GitVersioning.ReleaseManager.ReleasePreparationError;
 using ReleasePreparationException = Nerdbank.GitVersioning.ReleaseManager.ReleasePreparationException;
 using ReleaseVersionIncrement = Nerdbank.GitVersioning.VersionOptions.ReleaseVersionIncrement;
+using Version = System.Version;
 
 public class ReleaseManagerTests : RepoTestBase
 {
@@ -232,11 +233,11 @@ public class ReleaseManagerTests : RepoTestBase
     // versions without prerelease tags
     [InlineData("1.2", null, ReleaseVersionIncrement.Minor, "alpha", null, null, null, "v1.2", "1.2", "1.3-alpha")]
     [InlineData("1.2", null, ReleaseVersionIncrement.Major, "alpha", null, null, null, "v1.2", "1.2", "2.0-alpha")]
-    // explicitly set next version (firstUnstableTag setting will be ignored)
-    [InlineData("1.2-beta", null, null, null, null, "4.5", null, "v1.2", "1.2", "4.5")]
-    [InlineData("1.2-beta", null, null, null, null, "4.5-pre", null, "v1.2", "1.2", "4.5-pre")]
-    [InlineData("1.2-beta.{height}", null, null, null, null, "4.5-pre.{height}", null, "v1.2", "1.2", "4.5-pre.{height}")]
-    // explicitly set version increment overriding the setting from version.json    
+    // explicitly set next version
+    [InlineData("1.2-beta", null, null, null, null, "4.5", null, "v1.2", "1.2", "4.5-alpha")]
+    [InlineData("1.2-beta.{height}", null, null, null, null, "4.5", null, "v1.2", "1.2", "4.5-alpha.{height}")]
+    [InlineData("1.2-beta.{height}", null, null, "pre", null, "4.5.6", null, "v1.2", "1.2", "4.5.6-pre.{height}")]
+    // explicitly set version increment overriding the setting from ReleaseOptions 
     [InlineData("1.2-beta", null, ReleaseVersionIncrement.Minor, null, null, null, ReleaseVersionIncrement.Major, "v1.2", "1.2", "2.0-alpha")]
     [InlineData("1.2.3-beta", null, ReleaseVersionIncrement.Minor, null, null, null, ReleaseVersionIncrement.Build, "v1.2.3", "1.2.3", "1.2.4-alpha")]
     public void PrepareRelease_Master(
@@ -299,7 +300,7 @@ public class ReleaseManagerTests : RepoTestBase
 
         // prepare release
         var releaseManager = new ReleaseManager();
-        releaseManager.PrepareRelease(this.RepoPath, releaseUnstableTag, (nextVersion == null ? null : SemanticVersion.Parse(nextVersion)), parameterVersionIncrement);
+        releaseManager.PrepareRelease(this.RepoPath, releaseUnstableTag, (nextVersion == null ? null : Version.Parse(nextVersion)), parameterVersionIncrement);
 
         // check if a branch was created
         Assert.Contains(this.Repo.Branches, branch => branch.FriendlyName == expectedBranchName);
@@ -375,7 +376,7 @@ public class ReleaseManagerTests : RepoTestBase
         // running PrepareRelease should result in an error
         // because we're trying to add a prerelease tag to a version without prerelease tag
         this.AssertError(
-            () => new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag, (nextVersion == null ? null : SemanticVersion.Parse(nextVersion))),
+            () => new ReleaseManager().PrepareRelease(this.RepoPath, releaseUnstableTag, (nextVersion == null ? null : Version.Parse(nextVersion))),
             ReleasePreparationError.VersionDecrement);
     }
 

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -6,7 +6,6 @@
     using LibGit2Sharp;
     using Validation;
     using Version = System.Version;
-    using static Nerdbank.GitVersioning.VersionOptions;
 
     /// <summary>
     /// Methods for creating releases
@@ -116,9 +115,9 @@
         /// If specified, value will be used instead of the increment specified in <c>version.json</c>.
         /// Parameter will be ignored if the current branch is a release branch.
         /// </param>
-        public void PrepareRelease(string projectDirectory, string releaseUnstableTag = null, Version nextVersion = null, ReleaseVersionIncrement? versionIncrement = null)
+        public void PrepareRelease(string projectDirectory, string releaseUnstableTag = null, Version nextVersion = null, VersionOptions.ReleaseVersionIncrement? versionIncrement = null)
         {
-            Requires.NotNull(projectDirectory, nameof(projectDirectory));            
+            Requires.NotNull(projectDirectory, nameof(projectDirectory));
 
             // open the git repository
             var repository = this.GetRepository(projectDirectory);
@@ -280,7 +279,7 @@
             }
         }
 
-        private SemanticVersion GetNextDevVersion(VersionOptions versionOptions, Version nextVersionOverride, ReleaseVersionIncrement? versionIncrementOverride)
+        private SemanticVersion GetNextDevVersion(VersionOptions versionOptions, Version nextVersionOverride, VersionOptions.ReleaseVersionIncrement? versionIncrementOverride)
         {
             var currentVersion = versionOptions.Version;
 
@@ -291,26 +290,26 @@
             }
             else
             {
-                // determine the increment to use. 
-                // Use parameter if it has a value, otherwise use setting from version.json
+                // Determine the increment to use:
+                // Use parameter versionIncrementOverride if it has a value, otherwise use setting from version.json.
                 var versionIncrement = versionIncrementOverride ?? versionOptions.ReleaseOrDefault.VersionIncrementOrDefault;
 
-                // the increment is only valid if the current version has the required precision
-                // increment settings "Major" and "Minor" are always valid
-                // increment setting "Build" is only valid if the version has at lease three segments
-                var isValidIncrement = versionIncrement != ReleaseVersionIncrement.Build ||
+                // The increment is only valid if the current version has the required precision:
+                //  - increment settings "Major" and "Minor" are always valid.
+                //  - increment setting "Build" is only valid if the version has at lease three segments.
+                var isValidIncrement = versionIncrement != VersionOptions.ReleaseVersionIncrement.Build ||
                                        versionOptions.Version.Version.Build >= 0;
 
-                // increment is ignored when the next version was specified explicitly
                 if (!isValidIncrement)
                 {
-                    this.stderr.WriteLine($"Cannot apply version increment 'build' to version '{versionOptions.Version}' because it only has major and minor segments");
+                    this.stderr.WriteLine($"Cannot apply version increment 'build' to version '{versionOptions.Version}' because it only has major and minor segments.");
                     throw new ReleasePreparationException(ReleasePreparationError.InvalidVersionIncrementSetting);
                 }
 
                 nextDevVersion = currentVersion.Increment(versionIncrement);
             }
 
+            // return next version with prerelease tag specified in version.json
             return nextDevVersion.SetFirstPrereleaseTag(versionOptions.ReleaseOrDefault.FirstUnstableTagOrDefault);
         }
     }

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -606,7 +606,7 @@ namespace Nerdbank.GitVersioning.Tool
             try
             {
                 var releaseManager = new ReleaseManager(Console.Out, Console.Error);
-                releaseManager.PrepareRelease(searchPath, prereleaseTag, nextVersionParsed);
+                releaseManager.PrepareRelease(searchPath, prereleaseTag, nextVersionParsed, versionIncrementParsed);
                 return ExitCodes.OK;
             }
             catch (ReleaseManager.ReleasePreparationException ex)

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -113,7 +113,7 @@ namespace Nerdbank.GitVersioning.Tool
                 prepareRelease = syntax.DefineCommand("prepare-release", ref commandText, "Prepares a release by creating a release branch for the current version and adjusting the version on the current branch.");
                 syntax.DefineOption("p|project", ref projectPath, "The path to the project or project directory. The default is the current directory.");
                 syntax.DefineOption("nextVersion", ref releaseNextVersion, "The version to set for the current branch. If omitted, the next version is determined automatically by incrementing the current version.");
-                syntax.DefineOption("versionIncrement", ref releaseVersionIncrement, "Specifies how the next version for the current branch is determined overriding the 'versionIncrement' setting in version.json");
+                syntax.DefineOption("versionIncrement", ref releaseVersionIncrement, "Overrides the 'versionIncrement' setting set in version.json for determining the next version of the current branch.");
                 syntax.DefineParameter("tag", ref releasePreReleaseTag, "The prerelease tag to apply on the release branch (if any). If not specified, any existing prerelease tag will be removed. The preceding hyphen may be omitted.");
 
                 if (syntax.ActiveCommand == null)
@@ -579,7 +579,7 @@ namespace Nerdbank.GitVersioning.Tool
                 return ExitCodes.InvalidParameters;
             }
 
-            // parse versionIncrement is parameter was specified
+            // parse versionIncrement if parameter was specified
             VersionOptions.ReleaseVersionIncrement? versionIncrementParsed = default;
             if (!string.IsNullOrEmpty(versionIncrement))
             {

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -592,12 +592,12 @@ namespace Nerdbank.GitVersioning.Tool
             }
 
             // parse nextVersion if parameter was specified
-            SemanticVersion nextVersionParsed = default;
+            Version nextVersionParsed = default;
             if (!string.IsNullOrEmpty(nextVersion))
             {
-                if (!SemanticVersion.TryParse(nextVersion, out nextVersionParsed))
+                if (!Version.TryParse(nextVersion, out nextVersionParsed))
                 {
-                    Console.Error.WriteLine($"\"{nextVersion}\" is not a semver-compliant version spec.");
+                    Console.Error.WriteLine($"\"{nextVersion}\" is not a valid version spec.");
                     return ExitCodes.InvalidVersionSpec;
                 }
             }


### PR DESCRIPTION
This PR improves the command line parameters for the `prepare-release` command (see #300)

- The `nextVersion` parameter no longer accepts a semantic version.   
  Instead of completely overriding the version from `version.json`, it will now retain the prerelease tags of the current version.   
  When the current version is e.g. `1.2-beta.someTag` running `nbgv prepare-release --nextVersion 2.0` will set the version to `2.0-alpha.someTag` (assuming the `firstUnstableTag` setting is `alpha`)
- A new parameter `versionIncrement` allows overriding the `versionIncrement` setting to e.g. increment the major version instead of the minor version.

The parameters are exclusive and cannot be used at the same time.