### PR TITLE
get commit short id from git repo

### DIFF
--- a/doc/versionJson.md
+++ b/doc/versionJson.md
@@ -28,7 +28,8 @@ The content of the version.json file is a JSON serialized object with these prop
   "assemblyVersion": "x.y", // optional. Use when x.y for AssemblyVersionAttribute differs from the default version property.
   "buildNumberOffset": "zOffset", // optional. Use when you need to add/subtract a fixed value from the computed build number.
   "semVer1NumericIdentifierPadding": 4, // optional. Use when your -prerelease includes numeric identifiers and need semver1 support.
-  "gitCommitIdShortLength": 10, // optional. Change the commit ID suffix length.
+  "gitCommitIdShortFixedLength": 10, // optional. Set the commit ID abbreviation length.
+  "gitCommitIdShortAutoMinimum": 0, // optional. Set to use the short commit ID abbreviation provided by the git repository.
   "nugetPackageVersion": {
      "semVer": 1 // optional. Set to either 1 or 2 to control how the NuGet package version string is generated. Default is 1.
   },

--- a/doc/versionJson.md
+++ b/doc/versionJson.md
@@ -28,6 +28,7 @@ The content of the version.json file is a JSON serialized object with these prop
   "assemblyVersion": "x.y", // optional. Use when x.y for AssemblyVersionAttribute differs from the default version property.
   "buildNumberOffset": "zOffset", // optional. Use when you need to add/subtract a fixed value from the computed build number.
   "semVer1NumericIdentifierPadding": 4, // optional. Use when your -prerelease includes numeric identifiers and need semver1 support.
+  "gitCommitIdShortLength": 10, // optional. Change the commit ID suffix length.
   "nugetPackageVersion": {
      "semVer": 1 // optional. Set to either 1 or 2 to control how the NuGet package version string is generated. Default is 1.
   },

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -72,7 +72,7 @@ public class BuildIntegrationTests : RepoTestBase
         }
     }
 
-    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, 10);
+    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, 7);
 
     protected override void Dispose(bool disposing)
     {
@@ -176,7 +176,7 @@ public class BuildIntegrationTests : RepoTestBase
         Assumes.True(repo.Index[VersionFile.JsonFileName] == null);
         var buildResult = await this.BuildAsync();
         Assert.Equal("3.4.0." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("3.4.0+" + repo.Head.Commits.First().Id.Sha.Substring(0, 10), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("3.4.0+" + repo.Head.Commits.First().Id.Sha.Substring(0, 7), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]
@@ -201,7 +201,7 @@ public class BuildIntegrationTests : RepoTestBase
         repo.Commit("empty", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
         var buildResult = await this.BuildAsync();
         Assert.Equal("0.0.1." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("0.0.1+" + repo.Head.Commits.First().Id.Sha.Substring(0, 10), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("0.0.1+" + repo.Head.Commits.First().Id.Sha.Substring(0, 7), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -72,7 +72,7 @@ public class BuildIntegrationTests : RepoTestBase
         }
     }
 
-    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, VersionOracle.DefaultGitCommitIdShortLength);
+    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortLength);
 
     protected override void Dispose(bool disposing)
     {
@@ -176,7 +176,7 @@ public class BuildIntegrationTests : RepoTestBase
         Assumes.True(repo.Index[VersionFile.JsonFileName] == null);
         var buildResult = await this.BuildAsync();
         Assert.Equal("3.4.0." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("3.4.0+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOracle.DefaultGitCommitIdShortLength), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("3.4.0+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortLength), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]
@@ -201,7 +201,7 @@ public class BuildIntegrationTests : RepoTestBase
         repo.Commit("empty", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
         var buildResult = await this.BuildAsync();
         Assert.Equal("0.0.1." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("0.0.1+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOracle.DefaultGitCommitIdShortLength), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("0.0.1+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortLength), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -72,7 +72,7 @@ public class BuildIntegrationTests : RepoTestBase
         }
     }
 
-    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, 7);
+    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, VersionOracle.DefaultGitCommitIdShortLength);
 
     protected override void Dispose(bool disposing)
     {
@@ -176,7 +176,7 @@ public class BuildIntegrationTests : RepoTestBase
         Assumes.True(repo.Index[VersionFile.JsonFileName] == null);
         var buildResult = await this.BuildAsync();
         Assert.Equal("3.4.0." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("3.4.0+" + repo.Head.Commits.First().Id.Sha.Substring(0, 7), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("3.4.0+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOracle.DefaultGitCommitIdShortLength), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]
@@ -201,7 +201,7 @@ public class BuildIntegrationTests : RepoTestBase
         repo.Commit("empty", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
         var buildResult = await this.BuildAsync();
         Assert.Equal("0.0.1." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("0.0.1+" + repo.Head.Commits.First().Id.Sha.Substring(0, 7), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("0.0.1+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOracle.DefaultGitCommitIdShortLength), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -72,7 +72,7 @@ public class BuildIntegrationTests : RepoTestBase
         }
     }
 
-    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortLength);
+    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength);
 
     protected override void Dispose(bool disposing)
     {
@@ -176,7 +176,7 @@ public class BuildIntegrationTests : RepoTestBase
         Assumes.True(repo.Index[VersionFile.JsonFileName] == null);
         var buildResult = await this.BuildAsync();
         Assert.Equal("3.4.0." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("3.4.0+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortLength), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("3.4.0+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]
@@ -201,7 +201,7 @@ public class BuildIntegrationTests : RepoTestBase
         repo.Commit("empty", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
         var buildResult = await this.BuildAsync();
         Assert.Equal("0.0.1." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("0.0.1+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortLength), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("0.0.1+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -34,11 +34,11 @@ public class VersionOracleTests : RepoTestBase
 
             var oracleA = VersionOracle.Create(Path.Combine(expandedRepo.RepoPath, "a"));
             Assert.Equal("1.3.1", oracleA.SimpleVersion.ToString());
-            Assert.Equal("e238b03", oracleA.GitCommitIdShort);
+            Assert.Equal("e238b03e75", oracleA.GitCommitIdShort);
 
             var oracleB = VersionOracle.Create(Path.Combine(expandedRepo.RepoPath, "b", "projB"));
             Assert.Equal("2.5.2", oracleB.SimpleVersion.ToString());
-            Assert.Equal("3ea7f01", oracleB.GitCommitIdShort);
+            Assert.Equal("3ea7f010c3", oracleB.GitCommitIdShort);
         }
     }
 
@@ -174,10 +174,10 @@ public class VersionOracleTests : RepoTestBase
         this.InitializeSourceControl();
         var oracle = VersionOracle.Create(this.RepoPath);
         oracle.PublicRelease = false;
-        Assert.Matches(@"^2.3.1-[^g]{7}$", oracle.SemVer1);
-        Assert.Matches(@"^2.3.1-[^g]{7}$", oracle.SemVer2);
-        Assert.Matches(@"^2.3.1-g[a-f0-9]{7}$", oracle.NuGetPackageVersion);
-        Assert.Matches(@"^2.3.1-g[a-f0-9]{7}$", oracle.ChocolateyPackageVersion);
+        Assert.Matches(@"^2.3.1-[^g]{"+ VersionOracle.DefaultGitCommitIdShortLength + "}$", oracle.SemVer1);
+        Assert.Matches(@"^2.3.1-[^g]{" + VersionOracle.DefaultGitCommitIdShortLength + "}$", oracle.SemVer2);
+        Assert.Matches(@"^2.3.1-g[a-f0-9]{" + VersionOracle.DefaultGitCommitIdShortLength + "}$", oracle.NuGetPackageVersion);
+        Assert.Matches(@"^2.3.1-g[a-f0-9]{" + VersionOracle.DefaultGitCommitIdShortLength + "}$", oracle.ChocolateyPackageVersion);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -15,7 +15,7 @@ public class VersionOracleTests : RepoTestBase
     {
     }
 
-    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortLength);
+    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength);
 
     [Fact]
     public void NotRepo()
@@ -186,7 +186,7 @@ public class VersionOracleTests : RepoTestBase
         var workingCopyVersion = new VersionOptions
         {
             Version = SemanticVersion.Parse("2.3"),
-            GitCommitIdShortLength = 7
+            GitCommitIdShortFixedLength = 7
         };
         this.WriteVersionFile(workingCopyVersion);
         this.InitializeSourceControl();

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -15,7 +15,7 @@ public class VersionOracleTests : RepoTestBase
     {
     }
 
-    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, 10);
+    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, 7);
 
     [Fact]
     public void NotRepo()
@@ -34,11 +34,11 @@ public class VersionOracleTests : RepoTestBase
 
             var oracleA = VersionOracle.Create(Path.Combine(expandedRepo.RepoPath, "a"));
             Assert.Equal("1.3.1", oracleA.SimpleVersion.ToString());
-            Assert.Equal("e238b03e75", oracleA.GitCommitIdShort);
+            Assert.Equal("e238b03", oracleA.GitCommitIdShort);
 
             var oracleB = VersionOracle.Create(Path.Combine(expandedRepo.RepoPath, "b", "projB"));
             Assert.Equal("2.5.2", oracleB.SimpleVersion.ToString());
-            Assert.Equal("3ea7f010c3", oracleB.GitCommitIdShort);
+            Assert.Equal("3ea7f01", oracleB.GitCommitIdShort);
         }
     }
 
@@ -174,10 +174,10 @@ public class VersionOracleTests : RepoTestBase
         this.InitializeSourceControl();
         var oracle = VersionOracle.Create(this.RepoPath);
         oracle.PublicRelease = false;
-        Assert.Matches(@"^2.3.1-[^g]{10}$", oracle.SemVer1);
-        Assert.Matches(@"^2.3.1-[^g]{10}$", oracle.SemVer2);
-        Assert.Matches(@"^2.3.1-g[a-f0-9]{10}$", oracle.NuGetPackageVersion);
-        Assert.Matches(@"^2.3.1-g[a-f0-9]{10}$", oracle.ChocolateyPackageVersion);
+        Assert.Matches(@"^2.3.1-[^g]{7}$", oracle.SemVer1);
+        Assert.Matches(@"^2.3.1-[^g]{7}$", oracle.SemVer2);
+        Assert.Matches(@"^2.3.1-g[a-f0-9]{7}$", oracle.NuGetPackageVersion);
+        Assert.Matches(@"^2.3.1-g[a-f0-9]{7}$", oracle.ChocolateyPackageVersion);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -15,7 +15,7 @@ public class VersionOracleTests : RepoTestBase
     {
     }
 
-    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, VersionOracle.DefaultGitCommitIdShortLength);
+    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortLength);
 
     [Fact]
     public void NotRepo()
@@ -178,6 +178,24 @@ public class VersionOracleTests : RepoTestBase
         Assert.Matches(@"^2.3.1-[^g]{10}$", oracle.SemVer2);
         Assert.Matches(@"^2.3.1-g[a-f0-9]{10}$", oracle.NuGetPackageVersion);
         Assert.Matches(@"^2.3.1-g[a-f0-9]{10}$", oracle.ChocolateyPackageVersion);
+    }
+
+    [Fact]
+    public void SemVerStableNonPublicVersionShortened()
+    {
+        var workingCopyVersion = new VersionOptions
+        {
+            Version = SemanticVersion.Parse("2.3"),
+            GitCommitIdShortLength = 7
+        };
+        this.WriteVersionFile(workingCopyVersion);
+        this.InitializeSourceControl();
+        var oracle = VersionOracle.Create(this.RepoPath);
+        oracle.PublicRelease = false;
+        Assert.Matches(@"^2.3.1-[^g]{7}$", oracle.SemVer1);
+        Assert.Matches(@"^2.3.1-[^g]{7}$", oracle.SemVer2);
+        Assert.Matches(@"^2.3.1-g[a-f0-9]{7}$", oracle.NuGetPackageVersion);
+        Assert.Matches(@"^2.3.1-g[a-f0-9]{7}$", oracle.ChocolateyPackageVersion);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -15,7 +15,7 @@ public class VersionOracleTests : RepoTestBase
     {
     }
 
-    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, 7);
+    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, VersionOracle.DefaultGitCommitIdShortLength);
 
     [Fact]
     public void NotRepo()
@@ -174,10 +174,10 @@ public class VersionOracleTests : RepoTestBase
         this.InitializeSourceControl();
         var oracle = VersionOracle.Create(this.RepoPath);
         oracle.PublicRelease = false;
-        Assert.Matches(@"^2.3.1-[^g]{"+ VersionOracle.DefaultGitCommitIdShortLength + "}$", oracle.SemVer1);
-        Assert.Matches(@"^2.3.1-[^g]{" + VersionOracle.DefaultGitCommitIdShortLength + "}$", oracle.SemVer2);
-        Assert.Matches(@"^2.3.1-g[a-f0-9]{" + VersionOracle.DefaultGitCommitIdShortLength + "}$", oracle.NuGetPackageVersion);
-        Assert.Matches(@"^2.3.1-g[a-f0-9]{" + VersionOracle.DefaultGitCommitIdShortLength + "}$", oracle.ChocolateyPackageVersion);
+        Assert.Matches(@"^2.3.1-[^g]{10}$", oracle.SemVer1);
+        Assert.Matches(@"^2.3.1-[^g]{10}$", oracle.SemVer2);
+        Assert.Matches(@"^2.3.1-g[a-f0-9]{10}$", oracle.NuGetPackageVersion);
+        Assert.Matches(@"^2.3.1-g[a-f0-9]{10}$", oracle.ChocolateyPackageVersion);
     }
 
     [Fact]

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -27,6 +27,11 @@
         private const int DefaultSemVer1NumericIdentifierPadding = 4;
 
         /// <summary>
+        /// The default value for the <see cref="GitCommitIdShortLengthOrDefault"/> property.
+        /// </summary>
+        public const int DefaultGitCommitIdShortLength = 10;
+
+        /// <summary>
         /// The $schema field that should be serialized when writing
         /// </summary>
         [JsonProperty(PropertyName = "$schema")]
@@ -87,6 +92,18 @@
         /// </summary>
         [JsonIgnore]
         public int SemVer1NumericIdentifierPaddingOrDefault => this.SemVer1NumericIdentifierPadding ?? DefaultSemVer1NumericIdentifierPadding;
+
+        /// <summary>
+        /// Gets or sets the abbreviated git commit hash length.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? GitCommitIdShortLength { get; set; }
+
+        /// <summary>
+        /// Gets the the abbreviated git commit hash length.
+        /// </summary>
+        [JsonIgnore]
+        public int GitCommitIdShortLengthOrDefault => this.GitCommitIdShortLength ?? DefaultGitCommitIdShortLength;
 
         /// <summary>
         /// Gets or sets the options around NuGet version strings

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -27,7 +27,7 @@
         private const int DefaultSemVer1NumericIdentifierPadding = 4;
 
         /// <summary>
-        /// The default value for the <see cref="GitCommitIdShortFixedLengthOrDefault"/> property.
+        /// The default value for the <see cref="GitCommitIdShortFixedLength"/> property.
         /// </summary>
         public const int DefaultGitCommitIdShortFixedLength = 10;
 

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -27,9 +27,9 @@
         private const int DefaultSemVer1NumericIdentifierPadding = 4;
 
         /// <summary>
-        /// The default value for the <see cref="GitCommitIdShortLengthOrDefault"/> property.
+        /// The default value for the <see cref="GitCommitIdShortFixedLengthOrDefault"/> property.
         /// </summary>
-        public const int DefaultGitCommitIdShortLength = 10;
+        public const int DefaultGitCommitIdShortFixedLength = 10;
 
         /// <summary>
         /// The $schema field that should be serialized when writing
@@ -97,13 +97,16 @@
         /// Gets or sets the abbreviated git commit hash length.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int? GitCommitIdShortLength { get; set; }
+        public int? GitCommitIdShortFixedLength { get; set; }
 
         /// <summary>
-        /// Gets the the abbreviated git commit hash length.
+        /// Gets or sets the abbreviated git commit hash length minimum value.
+        /// The git repository provides the value.
+        /// If set to 0 or a git repository is not available, GitCommitIdShortFixedLength is used.
+        /// The value is 0 by default.
         /// </summary>
-        [JsonIgnore]
-        public int GitCommitIdShortLengthOrDefault => this.GitCommitIdShortLength ?? DefaultGitCommitIdShortLength;
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? GitCommitIdShortAutoMinimum { get; set; }
 
         /// <summary>
         /// Gets or sets the options around NuGet version strings

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -102,7 +102,7 @@
         /// <summary>
         /// Gets or sets the abbreviated git commit hash length minimum value.
         /// The git repository provides the value.
-        /// If set to 0 or a git repository is not available, GitCommitIdShortFixedLength is used.
+        /// If set to 0 or a git repository is not available, <see cref="GitCommitIdShortFixedLength"/> is used.
         /// The value is 0 by default.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -96,17 +96,24 @@
                 this.Version = this.VersionOptions?.Version.Version ?? Version0;
             }
 
-            // get the commit short commit sha
-            var gitCommitIdShortFixedLength = this.VersionOptions?.GitCommitIdShortFixedLength ?? VersionOptions.DefaultGitCommitIdShortFixedLength;
-            var gitCommitIdShortAutoMinimum = this.VersionOptions?.GitCommitIdShortAutoMinimum ?? 0;
-            if (repo != null && gitCommitIdShortAutoMinimum > 0)
+            // get the commit id abbreviation only if the commit id is set
+            if (string.IsNullOrEmpty(this.GitCommitId))
             {
-                // get it from the git repo
-                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : repo.ObjectDatabase.ShortenObjectId(commit, gitCommitIdShortAutoMinimum);
+                this.GitCommitIdShort = null;
             }
             else
             {
-                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, gitCommitIdShortFixedLength);
+                var gitCommitIdShortFixedLength = this.VersionOptions?.GitCommitIdShortFixedLength ?? VersionOptions.DefaultGitCommitIdShortFixedLength;
+                var gitCommitIdShortAutoMinimum = this.VersionOptions?.GitCommitIdShortAutoMinimum ?? 0;
+                // get it from the git repository if there is a repository present and it is enabled
+                if (repo != null && gitCommitIdShortAutoMinimum > 0)
+                {
+                    this.GitCommitIdShort = repo.ObjectDatabase.ShortenObjectId(commit, gitCommitIdShortAutoMinimum);
+                }
+                else
+                {
+                    this.GitCommitIdShort = this.GitCommitId.Substring(0, gitCommitIdShortFixedLength);
+                }
             }
 
             this.VersionHeightOffset = this.VersionOptions?.BuildNumberOffsetOrDefault ?? 0;

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -15,6 +15,11 @@
     public class VersionOracle
     {
         /// <summary>
+        /// Default abbreviated git commit hash length.
+        /// </summary>
+        public const int DefaultGitCommitIdShortLength = 10;
+
+        /// <summary>
         /// A regex that matches on numeric identifiers for prerelease or build metadata.
         /// </summary>
         private static readonly Regex NumericIdentifierRegex = new Regex(@"(?<![\w-])(\d+)(?![\w-])");
@@ -104,7 +109,7 @@
             }
             else
             {
-                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, 10);
+                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, VersionOracle.DefaultGitCommitIdShortLength);
             }
 
             this.VersionHeightOffset = this.VersionOptions?.BuildNumberOffsetOrDefault ?? 0;

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -97,14 +97,15 @@
             }
 
             // get the commit short commit sha
+            var gitCommitIdShortLength = this.VersionOptions?.GitCommitIdShortLengthOrDefault ?? VersionOptions.DefaultGitCommitIdShortLength;
             if (repo != null)
             {
                 // get it from the git repo
-                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : repo.ObjectDatabase.ShortenObjectId(commit, this.VersionOptions.GitCommitIdShortLengthOrDefault);
+                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : repo.ObjectDatabase.ShortenObjectId(commit, gitCommitIdShortLength);
             }
             else
             {
-                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, this.VersionOptions.GitCommitIdShortLengthOrDefault);
+                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, gitCommitIdShortLength);
             }
 
             this.VersionHeightOffset = this.VersionOptions?.BuildNumberOffsetOrDefault ?? 0;

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -97,15 +97,16 @@
             }
 
             // get the commit short commit sha
-            var gitCommitIdShortLength = this.VersionOptions?.GitCommitIdShortLengthOrDefault ?? VersionOptions.DefaultGitCommitIdShortLength;
-            if (repo != null)
+            var gitCommitIdShortFixedLength = this.VersionOptions?.GitCommitIdShortFixedLength ?? VersionOptions.DefaultGitCommitIdShortFixedLength;
+            var gitCommitIdShortAutoMinimum = this.VersionOptions?.GitCommitIdShortAutoMinimum ?? 0;
+            if (repo != null && gitCommitIdShortAutoMinimum > 0)
             {
                 // get it from the git repo
-                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : repo.ObjectDatabase.ShortenObjectId(commit, gitCommitIdShortLength);
+                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : repo.ObjectDatabase.ShortenObjectId(commit, gitCommitIdShortAutoMinimum);
             }
             else
             {
-                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, gitCommitIdShortLength);
+                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, gitCommitIdShortFixedLength);
             }
 
             this.VersionHeightOffset = this.VersionOptions?.BuildNumberOffsetOrDefault ?? 0;

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -154,7 +154,7 @@
             {
                 if (!string.IsNullOrEmpty(this.GitCommitId))
                 {
-                    yield return this.GitCommitId.Substring(0, 10);
+                    yield return this.GitCommitIdShort;
                 }
 
                 foreach (string identifier in this.BuildMetadata)

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -96,6 +96,17 @@
                 this.Version = this.VersionOptions?.Version.Version ?? Version0;
             }
 
+            // get the commit short commit sha
+            if (repo != null)
+            {
+                // get it from the git repo
+                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : repo.ObjectDatabase.ShortenObjectId(commit);
+            }
+            else
+            {
+                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, 10);
+            }
+
             this.VersionHeightOffset = this.VersionOptions?.BuildNumberOffsetOrDefault ?? 0;
 
             this.PrereleaseVersion = this.ReplaceMacros(this.VersionOptions?.Version?.Prerelease ?? string.Empty);
@@ -238,7 +249,7 @@
         /// <summary>
         /// Gets the first several characters of the Git revision control commit id for HEAD (the current source code version).
         /// </summary>
-        public string GitCommitIdShort => string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, 10);
+        public string GitCommitIdShort { get; }
 
         /// <summary>
         /// Gets the number of commits in the longest single path between

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -15,11 +15,6 @@
     public class VersionOracle
     {
         /// <summary>
-        /// Default abbreviated git commit hash length.
-        /// </summary>
-        public const int DefaultGitCommitIdShortLength = 10;
-
-        /// <summary>
         /// A regex that matches on numeric identifiers for prerelease or build metadata.
         /// </summary>
         private static readonly Regex NumericIdentifierRegex = new Regex(@"(?<![\w-])(\d+)(?![\w-])");
@@ -32,7 +27,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="VersionOracle"/> class.
         /// </summary>
-        public static VersionOracle Create(string projectDirectory, string gitRepoDirectory = null, ICloudBuild cloudBuild = null, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null, int gitCommitIdShortLength = DefaultGitCommitIdShortLength)
+        public static VersionOracle Create(string projectDirectory, string gitRepoDirectory = null, ICloudBuild cloudBuild = null, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null)
         {
             Requires.NotNull(projectDirectory, nameof(projectDirectory));
             if (string.IsNullOrEmpty(gitRepoDirectory))
@@ -42,22 +37,22 @@
 
             using (var git = GitExtensions.OpenGitRepo(gitRepoDirectory))
             {
-                return new VersionOracle(projectDirectory, git, null, cloudBuild, overrideBuildNumberOffset, projectPathRelativeToGitRepoRoot, gitCommitIdShortLength);
+                return new VersionOracle(projectDirectory, git, null, cloudBuild, overrideBuildNumberOffset, projectPathRelativeToGitRepoRoot);
             }
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VersionOracle"/> class.
         /// </summary>
-        public VersionOracle(string projectDirectory, LibGit2Sharp.Repository repo, ICloudBuild cloudBuild, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null, int gitCommitIdShortLength = DefaultGitCommitIdShortLength)
-            : this(projectDirectory, repo, null, cloudBuild, overrideBuildNumberOffset, projectPathRelativeToGitRepoRoot, gitCommitIdShortLength)
+        public VersionOracle(string projectDirectory, LibGit2Sharp.Repository repo, ICloudBuild cloudBuild, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null)
+            : this(projectDirectory, repo, null, cloudBuild, overrideBuildNumberOffset, projectPathRelativeToGitRepoRoot)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VersionOracle"/> class.
         /// </summary>
-        public VersionOracle(string projectDirectory, LibGit2Sharp.Repository repo, LibGit2Sharp.Commit head, ICloudBuild cloudBuild, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null, int gitCommitIdShortLength = DefaultGitCommitIdShortLength)
+        public VersionOracle(string projectDirectory, LibGit2Sharp.Repository repo, LibGit2Sharp.Commit head, ICloudBuild cloudBuild, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null)
         {
             var repoRoot = repo?.Info?.WorkingDirectory?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             var relativeRepoProjectDirectory = !string.IsNullOrWhiteSpace(repoRoot)
@@ -105,11 +100,11 @@
             if (repo != null)
             {
                 // get it from the git repo
-                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : repo.ObjectDatabase.ShortenObjectId(commit, gitCommitIdShortLength);
+                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : repo.ObjectDatabase.ShortenObjectId(commit, this.VersionOptions.GitCommitIdShortLengthOrDefault);
             }
             else
             {
-                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, gitCommitIdShortLength);
+                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, this.VersionOptions.GitCommitIdShortLengthOrDefault);
             }
 
             this.VersionHeightOffset = this.VersionOptions?.BuildNumberOffsetOrDefault ?? 0;

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -97,11 +97,7 @@
             }
 
             // get the commit id abbreviation only if the commit id is set
-            if (string.IsNullOrEmpty(this.GitCommitId))
-            {
-                this.GitCommitIdShort = null;
-            }
-            else
+            if (!string.IsNullOrEmpty(this.GitCommitId))
             {
                 var gitCommitIdShortFixedLength = this.VersionOptions?.GitCommitIdShortFixedLength ?? VersionOptions.DefaultGitCommitIdShortFixedLength;
                 var gitCommitIdShortAutoMinimum = this.VersionOptions?.GitCommitIdShortAutoMinimum ?? 0;

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -32,7 +32,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="VersionOracle"/> class.
         /// </summary>
-        public static VersionOracle Create(string projectDirectory, string gitRepoDirectory = null, ICloudBuild cloudBuild = null, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null)
+        public static VersionOracle Create(string projectDirectory, string gitRepoDirectory = null, ICloudBuild cloudBuild = null, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null, int gitCommitIdShortLength = DefaultGitCommitIdShortLength)
         {
             Requires.NotNull(projectDirectory, nameof(projectDirectory));
             if (string.IsNullOrEmpty(gitRepoDirectory))
@@ -42,22 +42,22 @@
 
             using (var git = GitExtensions.OpenGitRepo(gitRepoDirectory))
             {
-                return new VersionOracle(projectDirectory, git, null, cloudBuild, overrideBuildNumberOffset, projectPathRelativeToGitRepoRoot);
+                return new VersionOracle(projectDirectory, git, null, cloudBuild, overrideBuildNumberOffset, projectPathRelativeToGitRepoRoot, gitCommitIdShortLength);
             }
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VersionOracle"/> class.
         /// </summary>
-        public VersionOracle(string projectDirectory, LibGit2Sharp.Repository repo, ICloudBuild cloudBuild, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null)
-            : this(projectDirectory, repo, null, cloudBuild, overrideBuildNumberOffset, projectPathRelativeToGitRepoRoot)
+        public VersionOracle(string projectDirectory, LibGit2Sharp.Repository repo, ICloudBuild cloudBuild, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null, int gitCommitIdShortLength = DefaultGitCommitIdShortLength)
+            : this(projectDirectory, repo, null, cloudBuild, overrideBuildNumberOffset, projectPathRelativeToGitRepoRoot, gitCommitIdShortLength)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VersionOracle"/> class.
         /// </summary>
-        public VersionOracle(string projectDirectory, LibGit2Sharp.Repository repo, LibGit2Sharp.Commit head, ICloudBuild cloudBuild, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null)
+        public VersionOracle(string projectDirectory, LibGit2Sharp.Repository repo, LibGit2Sharp.Commit head, ICloudBuild cloudBuild, int? overrideBuildNumberOffset = null, string projectPathRelativeToGitRepoRoot = null, int gitCommitIdShortLength = DefaultGitCommitIdShortLength)
         {
             var repoRoot = repo?.Info?.WorkingDirectory?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             var relativeRepoProjectDirectory = !string.IsNullOrWhiteSpace(repoRoot)
@@ -105,11 +105,11 @@
             if (repo != null)
             {
                 // get it from the git repo
-                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : repo.ObjectDatabase.ShortenObjectId(commit);
+                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : repo.ObjectDatabase.ShortenObjectId(commit, gitCommitIdShortLength);
             }
             else
             {
-                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, VersionOracle.DefaultGitCommitIdShortLength);
+                this.GitCommitIdShort = string.IsNullOrEmpty(this.GitCommitId) ? null : this.GitCommitId.Substring(0, gitCommitIdShortLength);
             }
 
             this.VersionHeightOffset = this.VersionOptions?.BuildNumberOffsetOrDefault ?? 0;

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -76,7 +76,7 @@
         },
         "gitCommitIdShortAutoMinimum": {
           "type": "integer",
-          "description": "The minimum number of digits to use for the commit ID abbreviation as determined by the git repository.",
+          "description": "When greater than 0, the length of the commit ID will be either this value or the shortest unambiguous git-abbreviated commit ID possible, whichever is greater. When 0, the gitCommitIdShortFixedLength property is used instead.",
           "default": 0,
           "maximum": 40
         },

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -70,7 +70,7 @@
         },
         "gitCommitIdShortFixedLength": {
           "type": "integer",
-          "description": "The fixed number of digits to use for the commit ID abbreviation length.",
+          "description": "The fixed number of characters to use for the commit ID abbreviation length. This property is ignored if the gitCommitIdShortAutoMinimum property is greater than 0.",
           "default": 10,
           "maximum": 40
         },

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -68,6 +68,18 @@
           "minimum": 1,
           "maximum": 6
         },
+        "gitCommitIdShortFixedLength": {
+          "type": "integer",
+          "description": "The fxied number of digits to use for the commit ID abbreviation length.",
+          "default": 10,
+          "maximum": 40
+        },
+        "gitCommitIdShortAutoMinimum": {
+          "type": "integer",
+          "description": "The minimum number of digits to use for the commit ID abbreviation as determined by the git repository.",
+          "default": 0,
+          "maximum": 40
+        },
         "nugetPackageVersion": {
           "type": "object",
           "description": "Details for how and what the generated version for NuGet packages will be.",

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -70,7 +70,7 @@
         },
         "gitCommitIdShortFixedLength": {
           "type": "integer",
-          "description": "The fxied number of digits to use for the commit ID abbreviation length.",
+          "description": "The fixed number of digits to use for the commit ID abbreviation length.",
           "default": 10,
           "maximum": 40
         },


### PR DESCRIPTION
~This is what I think the changes might be for #89. It is a draft, because I haven't tested it. There is an override for `ShortenObjectId` that also accepts a minimum length. I was thinking it create a setting for the minimum length. If it is `0`, these are the defaults. If it is not 0, that overload is called.~

Fixes #89. See the discussion there.