### PR TITLE
prepend version source file to compile file list

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -163,7 +163,11 @@
     </Nerdbank.GitVersioning.Tasks.CompareFiles>
     <Copy Condition=" '$(AssemblyVersionInfoChanged)' == 'true' " SourceFiles="$(NewVersionSourceFile)" DestinationFiles="$(VersionSourceFile)" />
     <ItemGroup>
-      <Compile Include="$(VersionSourceFile)" />
+      <!-- prepend the source file so we don't break F# console apps that have a "special" last source file -->
+      <_CompileWithVersionFile Include="$(VersionSourceFile);@(Compile)" />
+      <Compile Remove="@(Compile)" />
+      <Compile Include="@(_CompileWithVersionFile)" />
+      <_CompileWithVersionFile Remove="@(_CompileWithVersionFile)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
fix #308. Code from there too, except for one `$` to a `@`.

Tested locally by modifying in place:
"C:\Users\taggac\.nuget\packages\nerdbank.gitversioning\2.3.136\build\Nerdbank.GitVersioning.targets"

``` xml
    <Message Text="Compile Items Before" Importance="high" />
    <Message Text="@(Compile)" Importance="high" />
    <ItemGroup>
      <_CompileWithVersionFile Include="$(VersionSourceFile);@(Compile)" />
      <Compile Remove="@(Compile)" />
      <Compile Include="@(_CompileWithVersionFile)" />
      <_CompileWithVersionFile Remove="@(_CompileWithVersionFile)" />
    </ItemGroup>
    <Message Text="Compile Items After" Importance="high" />
    <Message Text="@(Compile)" Importance="high" />
```

Everything compile correctly and I saw this like I was expecting:
```
       GenerateAssemblyVersionInfo:
         Compile Items Before
         Ast.fs;Parser.fs;ClassModel.fs
         Compile Items After
         obj\Debug\netstandard2.0\\Froto.Parser.Version.fs;Ast.fs;Parser.fs;ClassModel.fs
```
```
   1:2>Project "C:\Users\taggac\github\froto\Froto.sln" (1:2) is building "C:\Users\taggac\github\froto\Compiler\Froto.Compiler.fsproj" (3:6) on node 5 (default targets).
     3>GetBuildVersion:
         Building version 0.6.4.62844 from commit 7cf54c4eb8adb025047f63f74f72db2b9204a8c0
       GenerateAssemblyVersionInfo:
         Compile Items Before
         Program.fs
         Compile Items After
         obj\Debug\netcoreapp2.1\\Froto.Compiler.Version.fs;Program.fs
```