### PR TITLE
Emit .rc file with UTF16 encoding

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/NativeVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/NativeVersionInfo.cs
@@ -124,7 +124,7 @@ END
                 this.generator.EndFile();
 
                 Directory.CreateDirectory(Path.GetDirectoryName(this.OutputFile));
-                Utilities.FileOperationWithRetry(() => File.WriteAllText(this.OutputFile, this.generator.GetCode()));
+                Utilities.FileOperationWithRetry(() => File.WriteAllText(this.OutputFile, this.generator.GetCode(), Encoding.Unicode));
             }
 
             return !this.Log.HasLoggedErrors;


### PR DESCRIPTION
This fixes encoding of characters that are not representable in ANSI. rc.exe doesn't support UTF8, but it does support UTF16.

Fixes #172