### PR TITLE
[WIP] update to LibGit2Sharp 0.27.0-preview-0007

### DIFF
--- a/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
+++ b/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DotNetMDDocs" Version="0.111.0" PrivateAssets="all" Condition=" '$(GenerateMarkdownApiDocs)' == 'true' " />
-    <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0070" PrivateAssets="none" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0007" PrivateAssets="none" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" Condition=" '$(TargetFramework)' == 'netcoreapp2.0' " />


### PR DESCRIPTION
@bording, continuing from https://github.com/AArnott/Nerdbank.GitVersioning/issues/314#issuecomment-485148398 , this is not working yet. I updated to `0.27.0-preview-0007`. I then build it:

```
git clean -xfd
dotnet restore .\src\Nerdbank.GitVersioning.sln
.\build.ps1 -Configuration Release

docker run -it --rm -v ${PWD}:/src -w /src mcr.microsoft.com/dotnet/core/sdk:2.2.203-alpine3.9 sh
dotnet tool install -g nbgv --add-source bin/nbgv/Release --version 2.3.144-gf6c3a65298
$HOME/.dotnet/tools/nbgv get-version
```

And installed and tried running it:
```
PS C:\Users\taggac\github\Nerdbank.GitVersioning> docker run -it --rm -v ${PWD}:/src -w /src mcr.microsoft.com/dotnet/core/sdk:2.2.203-alpine3.9 sh
/src # dotnet tool install -g nbgv --add-source bin/nbgv/Release --version 2.3.144-gf6c3a65298
Tools directory '/root/.dotnet/tools' is not currently on the PATH environment variable.
If you are using bash, you can add it to your profile by running the following command:

cat << \EOF >> ~/.bash_profile
# Add .NET Core SDK tools
export PATH="$PATH:/root/.dotnet/tools"
EOF

You can add it to the current session by running the following command:

export PATH="$PATH:/root/.dotnet/tools"

You can invoke the tool using the following command: nbgv
Tool 'nbgv' (version '2.3.144-gf6c3a65298') was successfully installed.
/src # $HOME/.dotnet/tools/nbgv get-version

Unhandled Exception: System.TypeInitializationException: The type initializer for 'LibGit2Sharp.Core.NativeMethods' threw an exception. ---> System.DllNotFoundException: Unable to load shared library 'git2-572e4d8' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: Error loading shared library libgit2-572e4d8: No such file or directory
   at LibGit2Sharp.Core.NativeMethods.git_libgit2_init()
   at LibGit2Sharp.Core.NativeMethods.InitializeNativeLibrary()
   at LibGit2Sharp.Core.NativeMethods..cctor()
   --- End of inner exception stack trace ---
   at LibGit2Sharp.Core.NativeMethods.git_libgit2_opts(Int32 option, UInt32 level, String path)
   at LibGit2Sharp.GlobalSettings.SetConfigSearchPaths(ConfigurationLevel level, String[] paths)
   at Nerdbank.GitVersioning.GitExtensions.OpenGitRepo(String pathUnderGitRepo, Boolean useDefaultConfigSearchPaths)
   at Nerdbank.GitVersioning.Tool.Program.OnGetVersionCommand(String projectPath, String format, String singleVariable, String versionOrRef) in C:\Users\taggac\github\Nerdbank.GitVersioning\src\nbgv\Program.cs:line 261
   at Nerdbank.GitVersioning.Tool.Program.Main(String[] args) in C:\Users\taggac\github\Nerdbank.GitVersioning\src\nbgv\Program.cs:line 131
Aborted
/src #
```

I did notice that the new `alpine.3.9-x64` dependencies look right. I'm not sure how to tell if the dotnet runtime is loading from that directory.

```
apk add --update binutils

/src # readelf -d ~/.dotnet/tools/.store/nbgv/2.3.144-gf6c3a65298/nbgv/2.3.144-gf6c3a65298/tools/netcoreapp2.1/any/runtimes/alpine-x64/native/libgit2-572e4d8.so | grep NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libssl.so.1.0.0]
 0x0000000000000001 (NEEDED)             Shared library: [libcrypto.so.1.0.0]
 0x0000000000000001 (NEEDED)             Shared library: [libc.musl-x86_64.so.1]

/src # readelf -d ~/.dotnet/tools/.store/nbgv/2.3.144-gf6c3a65298/nbgv/2.3.144-gf6c3a65298/tools/netcoreapp2.1/any/runtimes/alpine.3.9-x64/native/libgit2-572e4d8.so | grep NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libssl.so.1.1]
 0x0000000000000001 (NEEDED)             Shared library: [libcrypto.so.1.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.musl-x86_64.so.1]
```