### PR TITLE
Emit a warning when SemVer 2.0 format version is used with explicit SemVer 1.0

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -9,7 +9,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\Nerdbank.GitVersioning\SemanticVersionExtensions.cs" />
+    <Compile Include="..\Shared\**\*.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Nerdbank.GitVersioning.Tasks\build\Nerdbank.GitVersioning.targets">

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -386,6 +386,22 @@
         public int SemVer1NumericIdentifierPadding => this.VersionOptions?.SemVer1NumericIdentifierPaddingOrDefault ?? 4;
 
         /// <summary>
+        /// Gets the SemVer 1 format without padding or the build metadata.
+        /// </summary>
+        public string SemVer1WithoutPaddingOrBuildMetadata =>
+            $"{this.Version.ToStringSafe(3)}{MakePrereleaseSemVer1Compliant(this.PrereleaseVersion, 0)}";
+
+        /// <summary>
+        /// Determines if it was likely the user misconfigured their the prerelease version options and
+        /// their semver setting.
+        /// </summary>
+        /// <returns>False when NuGet SemVer 1 explicitly set but the prerelease does not match.</returns>
+        public bool MisconfiguredPrereleaseAndSemVer1()
+        {
+            return this.VersionOptions != null && this.VersionOptions.NuGetPackageVersion != null && this.VersionOptions.NuGetPackageVersion.SemVer == 1 && this.PrereleaseVersion != MakePrereleaseSemVer1Compliant(this.PrereleaseVersion, 0);
+        }
+
+        /// <summary>
         /// Gets the build metadata, compliant to the NuGet-compatible subset of SemVer 1.0.
         /// </summary>
         /// <remarks>

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -15,11 +15,6 @@
     public class VersionOracle
     {
         /// <summary>
-        /// A regex that matches on numeric identifiers for prerelease or build metadata.
-        /// </summary>
-        private static readonly Regex NumericIdentifierRegex = new Regex(@"(?<![\w-])(\d+)(?![\w-])");
-
-        /// <summary>
         /// The 0.0 version.
         /// </summary>
         private static readonly Version Version0 = new Version(0, 0);
@@ -177,7 +172,7 @@
         /// <summary>
         /// Gets the version options used to initialize this instance.
         /// </summary>
-        private VersionOptions VersionOptions { get; }
+        public VersionOptions VersionOptions { get; }
 
         /// <summary>
         /// Gets the version string to use for the <see cref="System.Reflection.AssemblyVersionAttribute"/>.
@@ -386,22 +381,6 @@
         public int SemVer1NumericIdentifierPadding => this.VersionOptions?.SemVer1NumericIdentifierPaddingOrDefault ?? 4;
 
         /// <summary>
-        /// Gets the SemVer 1 format without padding or the build metadata.
-        /// </summary>
-        public string SemVer1WithoutPaddingOrBuildMetadata =>
-            $"{this.Version.ToStringSafe(3)}{MakePrereleaseSemVer1Compliant(this.PrereleaseVersion, 0)}";
-
-        /// <summary>
-        /// Determines if it was likely the user misconfigured their the prerelease version options and
-        /// their semver setting.
-        /// </summary>
-        /// <returns>False when NuGet SemVer 1 explicitly set but the prerelease does not match.</returns>
-        public bool MisconfiguredPrereleaseAndSemVer1()
-        {
-            return this.VersionOptions != null && this.VersionOptions.NuGetPackageVersion != null && this.VersionOptions.NuGetPackageVersion.SemVer == 1 && this.PrereleaseVersion != MakePrereleaseSemVer1Compliant(this.PrereleaseVersion, 0);
-        }
-
-        /// <summary>
         /// Gets the build metadata, compliant to the NuGet-compatible subset of SemVer 1.0.
         /// </summary>
         /// <remarks>
@@ -437,7 +416,7 @@
         private string SemVer2BuildMetadata =>
             (this.PublicRelease ? string.Empty : this.GitCommitIdShortForNonPublicPrereleaseTag) + FormatBuildMetadata(this.BuildMetadata);
 
-        private string PrereleaseVersionSemVer1 => MakePrereleaseSemVer1Compliant(this.PrereleaseVersion, this.SemVer1NumericIdentifierPadding);
+        private string PrereleaseVersionSemVer1 => SemanticVersionExtensions.MakePrereleaseSemVer1Compliant(this.PrereleaseVersion, this.SemVer1NumericIdentifierPadding);
 
         private string GitCommitIdShortForNonPublicPrereleaseTag => (string.IsNullOrEmpty(this.PrereleaseVersion) ? "-" : ".") + this.GitCommitIdShort;
 
@@ -473,32 +452,6 @@
         /// <param name="prereleaseOrBuildMetadata">The prerelease or build metadata.</param>
         /// <returns>The specified string, with macros substituted for actual values.</returns>
         private string ReplaceMacros(string prereleaseOrBuildMetadata) => prereleaseOrBuildMetadata?.Replace("{height}", this.VersionHeightWithOffset.ToString(CultureInfo.InvariantCulture));
-
-        /// <summary>
-        /// Converts a semver 2 compliant "-beta.5" prerelease tag to a semver 1 compatible one.
-        /// </summary>
-        /// <param name="prerelease">The semver 2 prerelease tag, including its leading hyphen.</param>
-        /// <param name="paddingSize">The minimum number of digits to use for any numeric identifier.</param>
-        /// <returns>A semver 1 compliant prerelease tag. For example "-beta-0005".</returns>
-        private static string MakePrereleaseSemVer1Compliant(string prerelease, int paddingSize)
-        {
-            if (string.IsNullOrEmpty(prerelease))
-            {
-                return prerelease;
-            }
-
-            string paddingFormatter = "{0:" + new string('0', paddingSize) + "}";
-
-            string semver1 = prerelease;
-
-            // Identify numeric identifiers and pad them.
-            Assumes.True(prerelease.StartsWith("-"));
-            semver1 = "-" + NumericIdentifierRegex.Replace(semver1.Substring(1), m => string.Format(CultureInfo.InvariantCulture, paddingFormatter, int.Parse(m.Groups[1].Value)));
-
-            semver1 = semver1.Replace('.', '-');
-
-            return semver1;
-        }
 
         private static int CalculateVersionHeight(string relativeRepoProjectDirectory, LibGit2Sharp.Commit headCommit, VersionOptions committedVersion, VersionOptions workingVersion)
         {

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -202,6 +202,11 @@
                     oracle.BuildMetadata.AddRange(this.BuildMetadata);
                 }
 
+                if (oracle.MisconfiguredPrereleaseAndSemVer1())
+                {
+                    this.Log.LogWarning("The 'nugetPackageVersion' is explicitly set to 'semVer': 1 but the prerelease version '{0}' is not SemVer1 compliant. Change the 'nugetPackageVersion'.'semVer' value to 2 or chagne the 'version' member to follow SemVer1 (like: '{1}').", oracle.PrereleaseVersion, oracle.SemVer1WithoutPaddingOrBuildMetadata);
+                }
+
                 this.PublicRelease = oracle.PublicRelease;
                 this.Version = oracle.Version.ToString();
                 this.AssemblyVersion = oracle.AssemblyVersion.ToString();

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -202,9 +202,9 @@
                     oracle.BuildMetadata.AddRange(this.BuildMetadata);
                 }
 
-                if (oracle.MisconfiguredPrereleaseAndSemVer1())
+                if (IsMisconfiguredPrereleaseAndSemVer1(oracle))
                 {
-                    this.Log.LogWarning("The 'nugetPackageVersion' is explicitly set to 'semVer': 1 but the prerelease version '{0}' is not SemVer1 compliant. Change the 'nugetPackageVersion'.'semVer' value to 2 or chagne the 'version' member to follow SemVer1 (like: '{1}').", oracle.PrereleaseVersion, oracle.SemVer1WithoutPaddingOrBuildMetadata);
+                    this.Log.LogWarning("The 'nugetPackageVersion' is explicitly set to 'semVer': 1 but the prerelease version '{0}' is not SemVer1 compliant. Change the 'nugetPackageVersion'.'semVer' value to 2 or change the 'version' member to follow SemVer1 rules (e.g.: '{1}').", oracle.PrereleaseVersion, GetSemVer1WithoutPaddingOrBuildMetadata(oracle));
                 }
 
                 this.PublicRelease = oracle.PublicRelease;
@@ -260,6 +260,24 @@
                 this.Log.LogErrorFromException(ex);
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Gets the SemVer v1 format without padding or the build metadata.
+        /// </summary>
+        private static string GetSemVer1WithoutPaddingOrBuildMetadata(VersionOracle oracle)
+        {
+            Requires.NotNull(oracle, nameof(oracle));
+            return $"{oracle.Version.ToStringSafe(3)}{SemanticVersionExtensions.MakePrereleaseSemVer1Compliant(oracle.PrereleaseVersion, 0)}";
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the user wants SemVer v1 compliance yet specified a non-v1 compliant prerelease tag.
+        /// </summary>
+        private static bool IsMisconfiguredPrereleaseAndSemVer1(VersionOracle oracle)
+        {
+            Requires.NotNull(oracle, nameof(oracle));
+            return oracle.VersionOptions?.NuGetPackageVersion?.SemVer == 1 && oracle.PrereleaseVersion != SemanticVersionExtensions.MakePrereleaseSemVer1Compliant(oracle.PrereleaseVersion, 0);
         }
     }
 }


### PR DESCRIPTION
Should the user explicitly set `nugetPackageVersion.semVer` to `1` but
use a SemVer 2 prerelease in their `version` (such as: `1.0.0-preview.{height})
a warning will now be displayed telling the user they are probably not
getting what they expected.

Fixes #318