### PR TITLE
Add a GitCommitDate property to ThisAssembly

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -743,6 +743,18 @@ public class BuildIntegrationTests : RepoTestBase
         Assert.Equal(result.AssemblyCopyright, thisAssemblyClass.GetField("AssemblyCopyright", fieldFlags)?.GetValue(null));
         Assert.Equal(result.GitCommitId, thisAssemblyClass.GetField("GitCommitId", fieldFlags)?.GetValue(null) ?? string.Empty);
 
+        if (gitRepo)
+        {
+            Assert.True(long.TryParse(result.GitCommitDateTicks, out _), $"Invalid value for GitCommitDateTicks: '{result.GitCommitDateTicks}'");
+            DateTimeOffset gitCommitDate = new DateTimeOffset(long.Parse(result.GitCommitDateTicks), TimeSpan.Zero);
+            Assert.Equal(gitCommitDate, thisAssemblyClass.GetProperty("GitCommitDate", fieldFlags)?.GetValue(null) ?? string.Empty);
+        }
+        else
+        {
+            Assert.Empty(result.GitCommitDateTicks);
+            Assert.Null(thisAssemblyClass.GetProperty("GitCommitDate", fieldFlags));
+        }
+
         // Verify that it doesn't have key fields
         Assert.Null(thisAssemblyClass.GetField("PublicKey", fieldFlags));
         Assert.Null(thisAssemblyClass.GetField("PublicKeyToken", fieldFlags));
@@ -939,6 +951,7 @@ public class BuildIntegrationTests : RepoTestBase
         Assert.Equal(idAsVersion.Build.ToString(), buildResult.BuildVersionNumberComponent);
         Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}", buildResult.BuildVersionSimple);
         Assert.Equal(this.Repo.Head.Commits.First().Id.Sha, buildResult.GitCommitId);
+        Assert.Equal(this.Repo.Head.Commits.First().Author.When.UtcTicks.ToString(), buildResult.GitCommitDateTicks);
         Assert.Equal(commitIdShort, buildResult.GitCommitIdShort);
         Assert.Equal(versionHeight.ToString(), buildResult.GitVersionHeight);
         Assert.Equal($"{version.Major}.{version.Minor}", buildResult.MajorMinorVersion);
@@ -1141,6 +1154,7 @@ public class BuildIntegrationTests : RepoTestBase
         public string MajorMinorVersion => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("MajorMinorVersion");
         public string BuildVersionNumberComponent => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("BuildVersionNumberComponent");
         public string GitCommitIdShort => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitCommitIdShort");
+        public string GitCommitDateTicks => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitCommitDateTicks");
         public string GitVersionHeight => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("GitVersionHeight");
         public string SemVerBuildSuffix => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("SemVerBuildSuffix");
         public string BuildVersion3Components => this.BuildResult.ProjectStateAfterBuild.GetPropertyValue("BuildVersion3Components");

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -951,7 +951,7 @@ public class BuildIntegrationTests : RepoTestBase
         Assert.Equal(idAsVersion.Build.ToString(), buildResult.BuildVersionNumberComponent);
         Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}", buildResult.BuildVersionSimple);
         Assert.Equal(this.Repo.Head.Commits.First().Id.Sha, buildResult.GitCommitId);
-        Assert.Equal(this.Repo.Head.Commits.First().Author.When.UtcTicks.ToString(), buildResult.GitCommitDateTicks);
+        Assert.Equal(this.Repo.Head.Commits.First().Author.When.UtcTicks.ToString(CultureInfo.InvariantCulture), buildResult.GitCommitDateTicks);
         Assert.Equal(commitIdShort, buildResult.GitCommitIdShort);
         Assert.Equal(versionHeight.ToString(), buildResult.GitVersionHeight);
         Assert.Equal($"{version.Major}.{version.Minor}", buildResult.MajorMinorVersion);

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -747,7 +747,7 @@ public class BuildIntegrationTests : RepoTestBase
         {
             Assert.True(long.TryParse(result.GitCommitDateTicks, out _), $"Invalid value for GitCommitDateTicks: '{result.GitCommitDateTicks}'");
             DateTimeOffset gitCommitDate = new DateTimeOffset(long.Parse(result.GitCommitDateTicks), TimeSpan.Zero);
-            Assert.Equal(gitCommitDate, thisAssemblyClass.GetProperty("GitCommitDate", fieldFlags)?.GetValue(null) ?? string.Empty);
+            Assert.Equal(gitCommitDate, thisAssemblyClass.GetProperty("GitCommitDate", fieldFlags)?.GetValue(null) ?? thisAssemblyClass.GetField("GitCommitDate", fieldFlags)?.GetValue(null) ?? string.Empty);
         }
         else
         {

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -83,6 +83,7 @@
             this.VersionOptions = committedVersion ?? workingVersion;
 
             this.GitCommitId = commit?.Id.Sha ?? cloudBuild?.GitCommitId ?? null;
+            this.GitCommitDate = commit?.Author.When;
             this.VersionHeight = CalculateVersionHeight(relativeRepoProjectDirectory, commit, committedVersion, workingVersion);
             this.BuildingRef = cloudBuild?.BuildingTag ?? cloudBuild?.BuildingBranch ?? repo?.Head.CanonicalName;
 
@@ -255,6 +256,11 @@
         /// Gets the first several characters of the Git revision control commit id for HEAD (the current source code version).
         /// </summary>
         public string GitCommitIdShort { get; }
+
+        /// <summary>
+        /// Gets the Git revision control commit date for HEAD (the current source code version).
+        /// </summary>
+        public DateTimeOffset? GitCommitDate { get; }
 
         /// <summary>
         /// Gets the number of commits in the longest single path between

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -350,7 +350,6 @@
                     { "AssemblyCompany", this.AssemblyCompany },
                     { "AssemblyConfiguration", this.AssemblyConfiguration },
                     { "GitCommitId", this.GitCommitId },
-                    { "GitCommitDateTicks", this.GitCommitDateTicks },
                 };
             if (hasKeyInfo)
             {
@@ -464,7 +463,7 @@
 
             internal override void AddCommitDateProperty(long ticks)
             {
-                this.codeBuilder.AppendLine($"    static member this.GitCommitDate = new DateTimeOffset({ticks}, TimeZpan.Zero)");
+                this.codeBuilder.AppendLine($"    static member internal GitCommitDate = new DateTimeOffset({ticks}, TimeZpan.Zero)");
             }
 
             internal override void EndThisAssemblyClass()
@@ -505,7 +504,7 @@
 
             internal override void AddCommitDateProperty(long ticks)
             {
-                this.codeBuilder.AppendLine($"    internal static System.DateTimeOffset GitCommitDate {{ get; }} = new System.DateTimeOffset({ticks}, System.TimeSpan.Zero);");
+                this.codeBuilder.AppendLine($"    internal static readonly System.DateTimeOffset GitCommitDate = new System.DateTimeOffset({ticks}, System.TimeSpan.Zero);");
             }
 
             internal override void EndThisAssemblyClass()
@@ -539,7 +538,7 @@
 
             internal override void AddCommitDateProperty(long ticks)
             {
-                this.codeBuilder.AppendLine($"    Friend Shared ReadOnly Property GitCommitDate As System.DateTimeOffset = New System.DateTimeOffset({ticks}, System.TimeSpan.Zero)");
+                this.codeBuilder.AppendLine($"    Friend Shared ReadOnly GitCommitDate As System.DateTimeOffset = New System.DateTimeOffset({ticks}, System.TimeSpan.Zero)");
             }
 
             internal override void EndThisAssemblyClass()

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -71,6 +71,8 @@
 
         public string GitCommitId { get; set; }
 
+        public string GitCommitDateTicks { get; set; }
+
 #if NET461
         public override bool Execute()
         {
@@ -150,6 +152,7 @@
                     { "AssemblyCompany", this.AssemblyCompany },
                     { "AssemblyConfiguration", this.AssemblyConfiguration },
                     { "GitCommitId", this.GitCommitId },
+                    { "GitCommitDate", this.GitCommitDateTicks },
                 }).ToArray());
             if (hasKeyInfo)
             {
@@ -310,6 +313,7 @@
                     { "AssemblyCompany", this.AssemblyCompany },
                     { "AssemblyConfiguration", this.AssemblyConfiguration },
                     { "GitCommitId", this.GitCommitId },
+                    { "GitCommitDateTicks", this.GitCommitDateTicks },
                 };
             if (hasKeyInfo)
             {
@@ -323,6 +327,11 @@
                 {
                     this.generator.AddThisAssemblyMember(pair.Key, pair.Value);
                 }
+            }
+
+            if (long.TryParse(this.GitCommitDateTicks, out long gitCommitDateTicks))
+            {
+                this.generator.AddCommitDateProperty(gitCommitDateTicks);
             }
 
             // These properties should be defined even if they are empty.
@@ -380,6 +389,8 @@
                 this.codeBuilder.AppendLine();
             }
 
+            internal abstract void AddCommitDateProperty(long ticks);
+
             protected void AddCodeComment(string comment, string token)
             {
                 var sr = new StringReader(comment);
@@ -412,6 +423,11 @@
             internal override void DeclareAttribute(Type type, string arg)
             {
                 this.codeBuilder.AppendLine($"[<assembly: {type.FullName}(\"{arg}\")>]");
+            }
+
+            internal override void AddCommitDateProperty(long ticks)
+            {
+                this.codeBuilder.AppendLine($"    static member this.GitCommitDate = new DateTimeOffset({ticks}, TimeZpan.Zero)");
             }
 
             internal override void EndThisAssemblyClass()
@@ -450,6 +466,11 @@
                 this.codeBuilder.AppendLine($"    internal const string {name} = \"{value}\";");
             }
 
+            internal override void AddCommitDateProperty(long ticks)
+            {
+                this.codeBuilder.AppendLine($"    internal static System.DateTimeOffset GitCommitDate {{ get; }} = new System.DateTimeOffset({ticks}, System.TimeSpan.Zero);");
+            }
+
             internal override void EndThisAssemblyClass()
             {
                 this.codeBuilder.AppendLine("}");
@@ -477,6 +498,11 @@
             internal override void AddThisAssemblyMember(string name, string value)
             {
                 this.codeBuilder.AppendLine($"    Friend Const {name} As String = \"{value}\"");
+            }
+
+            internal override void AddCommitDateProperty(long ticks)
+            {
+                this.codeBuilder.AppendLine($"    Friend Shared ReadOnly Property GitCommitDate As System.DateTimeOffset = New System.DateTimeOffset({ticks}, System.TimeSpan.Zero)");
             }
 
             internal override void EndThisAssemblyClass()

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -154,7 +154,6 @@
                     { "GitCommitId", this.GitCommitId },
                 }).ToArray());
 
-
             if (long.TryParse(this.GitCommitDateTicks, out long gitCommitDateTicks))
             {
                 thisAssembly.Members.AddRange(CreateCommitDateProperty(gitCommitDateTicks).ToArray());

--- a/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GetBuildVersion.cs
@@ -132,8 +132,18 @@
         [Output]
         public string GitCommitId { get; private set; }
 
+        /// <summary>
+        /// Gets the first several characters of the Git revision control commit id for HEAD (the current source code version).
+        /// </summary>
         [Output]
         public string GitCommitIdShort { get; private set; }
+
+        /// <summary>
+        /// Gets the Git revision control commit date for HEAD (the current source code version), expressed as the number of 100-nanosecond
+        /// intervals that have elapsed since January 1, 0001 at 00:00:00.000 in the Gregorian calendar.
+        /// </summary>
+        [Output]
+        public string GitCommitDateTicks { get; private set; }
 
         /// <summary>
         /// Gets the number of commits in the longest single path between
@@ -213,6 +223,7 @@
                 this.PrereleaseVersion = oracle.PrereleaseVersion;
                 this.GitCommitId = oracle.GitCommitId;
                 this.GitCommitIdShort = oracle.GitCommitIdShort;
+                this.GitCommitDateTicks = oracle.GitCommitDate != null ? oracle.GitCommitDate.Value.Ticks.ToString(CultureInfo.InvariantCulture) : null;
                 this.GitVersionHeight = oracle.VersionHeight;
                 this.BuildMetadataFragment = oracle.BuildMetadataFragment;
                 this.CloudBuildNumber = oracle.CloudBuildNumberEnabled ? oracle.CloudBuildNumber : null;

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -79,6 +79,7 @@
       <Output TaskParameter="AssemblyVersion" PropertyName="AssemblyVersion" />
       <Output TaskParameter="GitCommitId" PropertyName="GitCommitId" />
       <Output TaskParameter="GitCommitIdShort" PropertyName="GitCommitIdShort" />
+      <Output TaskParameter="GitCommitDateTicks" PropertyName="GitCommitDateTicks" />
       <Output TaskParameter="GitVersionHeight" PropertyName="GitVersionHeight" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildNumber" />
       <Output TaskParameter="BuildNumber" PropertyName="BuildVersionNumberComponent" />
@@ -154,6 +155,7 @@
                   AssemblyCompany="$(AssemblyCompany)"
                   AssemblyConfiguration="$(Configuration)"
                   GitCommitId="$(GitCommitId)"
+                  GitCommitDateTicks="$(GitCommitDateTicks)"
                   EmitNonVersionCustomAttributes="$(NBGV_EmitNonVersionCustomAttributes)"
                   />
     <!-- Avoid applying the newly generated AssemblyVersionInfo.cs file to the build


### PR DESCRIPTION
Adds a `ThisAssembly.GitCommitDate` property, which contains the Git commit date from HEAD.