### PR TITLE
Add support for BuildingTag in VisualStudioTeamServices

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -450,7 +450,6 @@ public class BuildIntegrationTests : RepoTestBase
         {
             new object[] { CloudBuild.AppVeyor.SetItem("APPVEYOR_REPO_BRANCH", branchName) },
             new object[] { CloudBuild.VSTS.SetItem("BUILD_SOURCEBRANCH", $"refs/heads/{branchName}") },
-            new object[] { CloudBuild.VSTS.SetItem("BUILD_SOURCEBRANCH", branchName) }, // VSTS building a github repo
             new object[] { CloudBuild.Teamcity.SetItem("BUILD_GIT_BRANCH", $"refs/heads/{branchName}") },
         };
     }

--- a/src/NerdBank.GitVersioning/CloudBuildServices/VisualStudioTeamServices.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/VisualStudioTeamServices.cs
@@ -13,14 +13,16 @@
     /// </remarks>
     internal class VisualStudioTeamServices : ICloudBuild
     {
-        public bool IsPullRequest => false; // VSTS doesn't define this.
+        public bool IsPullRequest => Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")?.StartsWith("refs/pull/") ?? false;
 
-        public string BuildingTag => null; // VSTS doesn't define this.
+        public string BuildingTag => Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")?.StartsWith("refs/tags/") ?? false 
+            ? Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH") 
+            : null;
 
-        public string BuildingBranch => CloudBuild.ShouldStartWith(Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH"), "refs/heads/");
-
-        public string BuildingRef => this.BuildingBranch;
-
+        public string BuildingBranch => Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")?.StartsWith("refs/heads/") ?? false 
+            ? Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")
+            : null;
+        
         public string GitCommitId => null;
 
         public bool IsApplicable => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_TEAMPROJECTID"));


### PR DESCRIPTION
This improves the VisualStudioTeamServices aka Azure DevOps integration, mostly just adds support for `BuildingTag`.

I removed one case from the BuildIntegrationTests, because in my tests even GitHub builds on Azure DevOps had the `refs/heads/` prefix.

Closes #332