### PR TITLE
Exclude runtime assets for MSBuild

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/AssemblyInfoTest.cs
+++ b/src/NerdBank.GitVersioning.Tests/AssemblyInfoTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Build.Locator;
 using Nerdbank.GitVersioning.Tasks;
 using Xunit;
 
@@ -13,7 +12,7 @@ namespace NerdBank.GitVersioning.Tests
     {
         public AssemblyInfoTest()
         {
-            MSBuildLocator.RegisterDefaults();
+            MSBuildExtensions.LoadMSBuild();
         }
 
         [Fact]

--- a/src/NerdBank.GitVersioning.Tests/AssemblyInfoTest.cs
+++ b/src/NerdBank.GitVersioning.Tests/AssemblyInfoTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Build.Locator;
 using Nerdbank.GitVersioning.Tasks;
 using Xunit;
 
@@ -10,6 +11,11 @@ namespace NerdBank.GitVersioning.Tests
 {
     public class AssemblyInfoTest
     {
+        public AssemblyInfoTest()
+        {
+            MSBuildLocator.RegisterDefaults();
+        }
+
         [Fact]
         public void FSharpGenerator()
         {

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -46,9 +47,15 @@ public class BuildIntegrationTests : RepoTestBase
     };
     private Random random;
 
+    static BuildIntegrationTests()
+    {
+        MSBuildLocator.RegisterDefaults();
+    }
+
     public BuildIntegrationTests(ITestOutputHelper logger)
         : base(logger)
     {
+
         int seed = (int)DateTime.Now.Ticks;
         this.random = new Random(seed);
         this.Logger.WriteLine("Random seed: {0}", seed);

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -14,7 +14,6 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -47,14 +46,10 @@ public class BuildIntegrationTests : RepoTestBase
     };
     private Random random;
 
-    static BuildIntegrationTests()
-    {
-        MSBuildLocator.RegisterDefaults();
-    }
-
     public BuildIntegrationTests(ITestOutputHelper logger)
         : base(logger)
     {
+        MSBuildExtensions.LoadMSBuild();
 
         int seed = (int)DateTime.Now.Ticks;
         this.random = new Random(seed);

--- a/src/NerdBank.GitVersioning.Tests/MSBuildExtensions.cs
+++ b/src/NerdBank.GitVersioning.Tests/MSBuildExtensions.cs
@@ -7,12 +7,28 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Locator;
 using Microsoft.Build.Logging;
 using Validation;
 using Xunit.Abstractions;
 
 internal static class MSBuildExtensions
 {
+    private static object loadLock = new object();
+    private static bool loaded = false;
+
+    internal static void LoadMSBuild()
+    {
+        lock (loadLock)
+        {
+            if (!loaded)
+            {
+                MSBuildLocator.RegisterDefaults();
+                loaded = true;
+            }
+        }
+    }
+
     internal static async Task<BuildResult> BuildAsync(this BuildManager buildManager, ITestOutputHelper logger, ProjectCollection projectCollection, ProjectRootElement project, string target, IDictionary<string, string> globalProperties = null, LoggerVerbosity logVerbosity = LoggerVerbosity.Detailed, ILogger[] additionalLoggers = null)
     {
         Requires.NotNull(buildManager, nameof(buildManager));

--- a/src/NerdBank.GitVersioning.Tests/MSBuildExtensions.cs
+++ b/src/NerdBank.GitVersioning.Tests/MSBuildExtensions.cs
@@ -14,8 +14,8 @@ using Xunit.Abstractions;
 
 internal static class MSBuildExtensions
 {
-    private static object loadLock = new object();
-    private static bool loaded = false;
+    private static readonly object loadLock = new object();
+    private static bool loaded;
 
     internal static void LoadMSBuild()
     {

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -31,7 +31,8 @@
     <PackageReference Include="7z.NET" Version="1.0.3" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.10" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" Condition=" '$(TargetFramework)' == 'net461' " />
+    <PackageReference Include="Microsoft.Build" Version="15.1.548" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" ExcludeAssets="runtime" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.7" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -43,11 +44,7 @@
     </PackageReference>
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.548" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
+++ b/src/NerdBank.GitVersioning.Tests/NerdBank.GitVersioning.Tests.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="Microsoft.Build" Version="15.1.548" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.7" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
It took me a while to get `BuildIntegrationTests.AssemblyInfo` to work on my machine - it used to complain about two different versions of the MSBuild assemblies being loaded.

If I'm not mistaken, we can avoid this by adding `ExcludeAssets='runtime'` to the package reference for the MSBuild packages. That way, the assemblies which are sourced from NuGet are not copied to the output folder, and the MSBuild assemblies which ship with the .NET SDK would be used - pretty much the same way the MSBuildLocator works. https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application?view=vs-2019#use-microsoftbuildlocator

It seemed to work locally, creating a PR to trigger CI (and feedback).