### PR TITLE
Fix the GitLab cloud provider, add unit tests

### DIFF
--- a/src/NerdBank.GitVersioning/CloudBuildServices/GitLab.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/GitLab.cs
@@ -17,7 +17,7 @@
             Environment.GetEnvironmentVariable("CI_COMMIT_TAG") == null ? 
                 $"refs/heads/{Environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME")}" : null;
 
-        public string BuildingRef => this.BuildingBranch != null ? this.BuildingBranch : this.BuildingTag;
+        public string BuildingRef => this.BuildingBranch ?? this.BuildingTag;
 
         public string BuildingTag =>
             Environment.GetEnvironmentVariable("CI_COMMIT_TAG") != null ?

--- a/src/NerdBank.GitVersioning/CloudBuildServices/GitLab.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/GitLab.cs
@@ -2,8 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
-    using System.Diagnostics;
     using System.IO;
 
     /// <summary>
@@ -15,11 +13,15 @@
     /// </remarks>
     internal class GitLab : ICloudBuild
     {
-        public string BuildingBranch => Environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME");
+        public string BuildingBranch =>
+            Environment.GetEnvironmentVariable("CI_COMMIT_TAG") == null ? 
+                $"refs/heads/{Environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME")}" : null;
 
-        public string BuildingRef => Environment.GetEnvironmentVariable("CI_COMMIT_TAG");
+        public string BuildingRef => this.BuildingBranch != null ? this.BuildingBranch : this.BuildingTag;
 
-        public string BuildingTag => Environment.GetEnvironmentVariable("CI_COMMIT_TAG");
+        public string BuildingTag =>
+            Environment.GetEnvironmentVariable("CI_COMMIT_TAG") != null ?
+                $"refs/tags/{Environment.GetEnvironmentVariable("CI_COMMIT_TAG")}" : null;
 
         public string GitCommitId => Environment.GetEnvironmentVariable("CI_COMMIT_SHA");
 


### PR DESCRIPTION
This improves how the GitLab cloud provider handles refs and tags (although some level of guesswork is involved, as Gitlab doesn't provide raw access to the full ref).

Also adds unit tests. This requires mocking the `Environment.GetEnvironmentVariable` call, so there now is a `CloudBuildEnvironment` class with just a single `GetEnvironmentVariable` method which can be overriden for unit tests.

A bunch of classes are no longer `static` so we can use constructor DI on them.

Fixes #335 