### PR TITLE
Fix `nbgv get-commits` when version.json is in a subdirectory of repo

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/GitExtensionsTests.cs
@@ -257,25 +257,28 @@ public class GitExtensionsTests : RepoTestBase
     public void GetIdAsVersion_Roundtrip(string version, string assemblyVersion, int versionHeightOffset)
     {
         var semanticVersion = SemanticVersion.Parse(version);
-        this.WriteVersionFile(new VersionOptions
-        {
-            Version = semanticVersion,
-            AssemblyVersion = new VersionOptions.AssemblyVersionOptions(new Version(assemblyVersion)),
-            VersionHeightOffset = versionHeightOffset,
-        });
+        const string repoRelativeSubDirectory = "subdir";
+        this.WriteVersionFile(
+            new VersionOptions
+            {
+                Version = semanticVersion,
+                AssemblyVersion = new VersionOptions.AssemblyVersionOptions(new Version(assemblyVersion)),
+                VersionHeightOffset = versionHeightOffset,
+            },
+            repoRelativeSubDirectory);
 
         Commit[] commits = new Commit[16]; // create enough that statistically we'll likely hit interesting bits as MSB and LSB
         Version[] versions = new Version[commits.Length];
         for (int i = 0; i < commits.Length; i++)
         {
             commits[i] = this.Repo.Commit($"Commit {i + 1}", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
-            versions[i] = commits[i].GetIdAsVersion();
+            versions[i] = commits[i].GetIdAsVersion(repoRelativeSubDirectory);
             this.Logger.WriteLine($"Commit {commits[i].Id.Sha.Substring(0, 8)} as version: {versions[i]}");
         }
 
         for (int i = 0; i < commits.Length; i++)
         {
-            Assert.Equal(commits[i], this.Repo.GetCommitFromVersion(versions[i]));
+            Assert.Equal(commits[i], this.Repo.GetCommitFromVersion(versions[i], repoRelativeSubDirectory));
 
             // Also verify that we can find it without the revision number.
             // This is important because stable, publicly released NuGet packages
@@ -283,7 +286,7 @@ public class GitExtensionsTests : RepoTestBase
             // But folks who specify a.b.c version numbers don't have any unique version component for the commit at all without the 4th integer.
             if (semanticVersion.Version.Build == -1)
             {
-                Assert.Equal(commits[i], this.Repo.GetCommitFromVersion(new Version(versions[i].Major, versions[i].Minor, versions[i].Build)));
+                Assert.Equal(commits[i], this.Repo.GetCommitFromVersion(new Version(versions[i].Major, versions[i].Minor, versions[i].Build), repoRelativeSubDirectory));
             }
         }
     }

--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -278,7 +278,7 @@
             Requires.NotNull(version, nameof(version));
 
             var possibleCommits = from commit in GetCommitsReachableFromRefs(repo).Distinct()
-                                  let commitVersionOptions = VersionFile.GetVersion(commit)
+                                  let commitVersionOptions = VersionFile.GetVersion(commit, repoRelativeProjectDirectory)
                                   where commitVersionOptions != null
                                   where !IsCommitIdMismatch(version, commitVersionOptions, commit)
                                   where !IsVersionHeightMismatch(version, commitVersionOptions, commit, repoRelativeProjectDirectory)


### PR DESCRIPTION
Fixes #342