### PR TITLE
Fix F# code generation

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -463,7 +463,7 @@
 
             internal override void AddCommitDateProperty(long ticks)
             {
-                this.codeBuilder.AppendLine($"    static member internal GitCommitDate = new DateTimeOffset({ticks}, TimeZpan.Zero)");
+                this.codeBuilder.AppendLine($"    static member internal GitCommitDate = new DateTimeOffset({ticks}L, TimeSpan.Zero)");
             }
 
             internal override void EndThisAssemblyClass()

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -463,7 +463,7 @@
 
             internal override void AddCommitDateProperty(long ticks)
             {
-                this.codeBuilder.AppendLine($"    static member internal GitCommitDate = new DateTimeOffset({ticks}L, TimeSpan.Zero)");
+                this.codeBuilder.AppendLine($"    static member internal GitCommitDate = new System.DateTimeOffset({ticks}L, System.TimeSpan.Zero)");
             }
 
             internal override void EndThisAssemblyClass()


### PR DESCRIPTION
Currently causes build failures whenever 2.3.167 is referenced from F# projects.

The actual failure is due to the `ticks` literal being interpreted as an `int` rather than a `long`, but being too large for a 32-bit integer.

Presumably if this wasn't failing it would fail with the `TimeZpan`.

Afraid I'm at work where I can't build this, but I think this should work. Will look at adding some test coverage when I'm able to build it as well.