### PR TITLE
Fix nano framework targeting

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/AssemblyInfoTest.cs
+++ b/src/NerdBank.GitVersioning.Tests/AssemblyInfoTest.cs
@@ -34,7 +34,9 @@ namespace AssemblyInfo
 [<assembly: System.Reflection.AssemblyFileVersionAttribute(""1.3.1.0"")>]
 [<assembly: System.Reflection.AssemblyInformationalVersionAttribute("""")>]
 do()
+#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP
 [<System.CodeDom.Compiler.GeneratedCode(""" + AssemblyVersionInfo.GeneratorName + @""",""" + AssemblyVersionInfo.GeneratorVersion + @""")>]
+#endif
 type internal ThisAssembly() =
   static member internal AssemblyVersion = ""1.3.0.0""
   static member internal AssemblyFileVersion = ""1.3.1.0""

--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -799,7 +799,7 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         if (gitRepo)
         {
             Assert.True(long.TryParse(result.GitCommitDateTicks, out _), $"Invalid value for GitCommitDateTicks: '{result.GitCommitDateTicks}'");
-            DateTimeOffset gitCommitDate = new DateTimeOffset(long.Parse(result.GitCommitDateTicks), TimeSpan.Zero);
+            var gitCommitDate = new DateTime(long.Parse(result.GitCommitDateTicks), DateTimeKind.Utc);
             Assert.Equal(gitCommitDate, thisAssemblyClass.GetProperty("GitCommitDate", fieldFlags)?.GetValue(null) ?? thisAssemblyClass.GetField("GitCommitDate", fieldFlags)?.GetValue(null) ?? string.Empty);
         }
         else

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -424,7 +424,14 @@
 
         private string PrereleaseVersionSemVer1 => SemanticVersionExtensions.MakePrereleaseSemVer1Compliant(this.PrereleaseVersion, this.SemVer1NumericIdentifierPadding);
 
-        private string GitCommitIdShortForNonPublicPrereleaseTag => (string.IsNullOrEmpty(this.PrereleaseVersion) ? "-" : ".") + this.GitCommitIdShort;
+        /// <summary>
+        /// Gets the -gc0ffee or .gc0ffee suffix for the version.
+        /// </summary>
+        /// <remarks>
+        /// The `g` prefix to the commit ID is to remain SemVer2 compliant particularly when the partial commit ID we use is made up entirely of numerals.
+        /// SemVer2 forbids numerals to begin with leading zeros, but a git commit just might, so we begin with `g` always to avoid failures when the commit ID happens to be problematic.
+        /// </remarks>
+        private string GitCommitIdShortForNonPublicPrereleaseTag => (string.IsNullOrEmpty(this.PrereleaseVersion) ? "-" : ".") + "g" + this.GitCommitIdShort;
 
         private VersionOptions.CloudBuildNumberOptions CloudBuildNumberOptions { get; }
 

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -13,6 +13,14 @@
 
     public class AssemblyVersionInfo : Task
     {
+        /// <summary>
+        /// The #if expression that surrounds a <see cref="GeneratedCodeAttribute"/> to avoid a compilation failure when targeting the nano framework.
+        /// </summary>
+        /// <remarks>
+        /// See https://github.com/AArnott/Nerdbank.GitVersioning/issues/346
+        /// </remarks>
+        private const string CompilerDefinesAroundGeneratedCodeAttribute = "NETSTANDARD || NETFRAMEWORK || NETCOREAPP";
+
         public static readonly string GeneratorName = ThisAssembly.AssemblyName;
         public static readonly string GeneratorVersion = ThisAssembly.AssemblyVersion;
 #if NET461
@@ -474,7 +482,9 @@
             internal override void StartThisAssemblyClass()
             {
                 this.codeBuilder.AppendLine("do()");
+                this.codeBuilder.AppendLine($"#if {CompilerDefinesAroundGeneratedCodeAttribute}");
                 this.codeBuilder.AppendLine($"[<System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")>]");
+                this.codeBuilder.AppendLine("#endif");
                 this.codeBuilder.AppendLine("type internal ThisAssembly() =");
             }
         }
@@ -493,7 +503,9 @@
 
             internal override void StartThisAssemblyClass()
             {
+                this.codeBuilder.AppendLine($"#if {CompilerDefinesAroundGeneratedCodeAttribute}");
                 this.codeBuilder.AppendLine($"[System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")]");
+                this.codeBuilder.AppendLine("#endif");
                 this.codeBuilder.AppendLine("internal static partial class ThisAssembly {");
             }
 
@@ -527,7 +539,9 @@
 
             internal override void StartThisAssemblyClass()
             {
+                this.codeBuilder.AppendLine($"#if {CompilerDefinesAroundGeneratedCodeAttribute}");
                 this.codeBuilder.AppendLine($"<System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")>");
+                this.codeBuilder.AppendLine("#endif");
                 this.codeBuilder.AppendLine("Partial Friend NotInheritable Class ThisAssembly");
             }
 

--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -233,22 +233,22 @@
 
         private static IEnumerable<CodeTypeMember> CreateCommitDateProperty(long ticks)
         {
-            // internal static System.DateTimeOffset GitCommitDate {{ get; }} = new System.DateTimeOffset({ticks}, System.TimeSpan.Zero);");
-            yield return new CodeMemberField(typeof(DateTimeOffset), "gitCommitDate")
+            // internal static System.DateTime GitCommitDate {{ get; }} = new System.DateTime({ticks}, System.DateTimeKind.Utc);");
+            yield return new CodeMemberField(typeof(DateTime), "gitCommitDate")
             {
                 Attributes = MemberAttributes.Private,
                 InitExpression = new CodeObjectCreateExpression(
-                     typeof(DateTimeOffset),
+                     typeof(DateTime),
                      new CodePrimitiveExpression(ticks),
                      new CodePropertyReferenceExpression(
-                         new CodeTypeReferenceExpression(typeof(TimeSpan)),
-                         nameof(TimeSpan.Zero)))
+                         new CodeTypeReferenceExpression(typeof(DateTimeKind)),
+                         nameof(DateTimeKind.Utc)))
             };
 
             var property = new CodeMemberProperty()
             {
                 Attributes = MemberAttributes.Assembly,
-                Type = new CodeTypeReference(typeof(DateTimeOffset)),
+                Type = new CodeTypeReference(typeof(DateTime)),
                 Name = "GitCommitDate",
                 HasGet = true,
                 HasSet = false,
@@ -471,7 +471,7 @@
 
             internal override void AddCommitDateProperty(long ticks)
             {
-                this.codeBuilder.AppendLine($"    static member internal GitCommitDate = new System.DateTimeOffset({ticks}L, System.TimeSpan.Zero)");
+                this.codeBuilder.AppendLine($"    static member internal GitCommitDate = new System.DateTime({ticks}L, System.DateTimeKind.Utc)");
             }
 
             internal override void EndThisAssemblyClass()
@@ -516,7 +516,7 @@
 
             internal override void AddCommitDateProperty(long ticks)
             {
-                this.codeBuilder.AppendLine($"    internal static readonly System.DateTimeOffset GitCommitDate = new System.DateTimeOffset({ticks}, System.TimeSpan.Zero);");
+                this.codeBuilder.AppendLine($"    internal static readonly System.DateTime GitCommitDate = new System.DateTime({ticks}L, System.DateTimeKind.Utc);");
             }
 
             internal override void EndThisAssemblyClass()
@@ -539,9 +539,9 @@
 
             internal override void StartThisAssemblyClass()
             {
-                this.codeBuilder.AppendLine($"#if {CompilerDefinesAroundGeneratedCodeAttribute}");
+                this.codeBuilder.AppendLine($"#If {CompilerDefinesAroundGeneratedCodeAttribute.Replace("||", " Or ")} Then");
                 this.codeBuilder.AppendLine($"<System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\",\"{GeneratorVersion}\")>");
-                this.codeBuilder.AppendLine("#endif");
+                this.codeBuilder.AppendLine("#End If");
                 this.codeBuilder.AppendLine("Partial Friend NotInheritable Class ThisAssembly");
             }
 
@@ -552,7 +552,7 @@
 
             internal override void AddCommitDateProperty(long ticks)
             {
-                this.codeBuilder.AppendLine($"    Friend Shared ReadOnly GitCommitDate As System.DateTimeOffset = New System.DateTimeOffset({ticks}, System.TimeSpan.Zero)");
+                this.codeBuilder.AppendLine($"    Friend Shared ReadOnly GitCommitDate As System.DateTime = New System.DateTime({ticks}L, System.DateTimeKind.Utc)");
             }
 
             internal override void EndThisAssemblyClass()


### PR DESCRIPTION
1. Quit using `DateTimeOffset` in the generated code.
1. Surround `GeneratedCodeAttribute` with `#if` that demands any of the 3 targets that can be expected to define it.

Fixes #346