### PR TITLE
Rollback Newtonsoft.Json 12 upgrade

### DIFF
--- a/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
+++ b/src/NerdBank.GitVersioning/NerdBank.GitVersioning.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="DotNetMDDocs" Version="0.111.0" PrivateAssets="all" Condition=" '$(GenerateMarkdownApiDocs)' == 'true' " />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0007" PrivateAssets="none" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" Condition=" '$(TargetFramework)' == 'netcoreapp2.0' " />
     <PackageReference Include="Validation" Version="2.4.18" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" Version="1.6.20-beta-gfea83a8c9e" />

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -7,7 +7,6 @@
     using System.Reflection;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
-    using Newtonsoft.Json.Serialization;
     using Validation;
 
     /// <summary>
@@ -209,7 +208,7 @@
                     new VersionConverter(),
                     new SemanticVersionJsonConverter(),
                     new AssemblyVersionOptionsConverter(includeDefaults),
-                    new StringEnumConverter() { NamingStrategy = new CamelCaseNamingStrategy() },
+                    new StringEnumConverter() { CamelCaseText = true },
                 },
                 ContractResolver = new VersionOptionsContractResolver
                 {


### PR DESCRIPTION
This should allow mono msbuild on Mac to work again.

Fixes #306 