### PR TITLE
Add support for GitHub Actions v2

### DIFF
--- a/src/NerdBank.GitVersioning/CloudBuild.cs
+++ b/src/NerdBank.GitVersioning/CloudBuild.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using CloudBuildServices;
+    using NerdBank.GitVersioning.CloudBuildServices;
 
     /// <summary>
     /// Provides access to cloud build providers.
@@ -15,6 +16,7 @@
         public static readonly ICloudBuild[] SupportedCloudBuilds = new ICloudBuild[] {
             new AppVeyor(),
             new VisualStudioTeamServices(),
+            new GitHubActions(),
             new TeamCity(),
             new AtlassianBamboo(), 
             new Jenkins(),

--- a/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
@@ -1,0 +1,32 @@
+﻿namespace NerdBank.GitVersioning.CloudBuildServices
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Nerdbank.GitVersioning;
+
+    internal class GitHubActions : ICloudBuild
+    {
+        public bool IsApplicable => Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
+
+        public bool IsPullRequest => Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME") == "PullRequestEvent";
+
+        public string BuildingBranch => (BuildingRef?.StartsWith("refs/heads/") ?? false) ? BuildingRef : null;
+
+        public string BuildingTag => (BuildingRef?.StartsWith("refs/tags/") ?? false) ? BuildingRef : null;
+
+        public string GitCommitId => Environment.GetEnvironmentVariable("GITHUB_SHA");
+
+        private static string BuildingRef => Environment.GetEnvironmentVariable("GITHUB_REF");
+
+        public IReadOnlyDictionary<string, string> SetCloudBuildNumber(string buildNumber, TextWriter stdout, TextWriter stderr)
+        {
+            return new Dictionary<string, string>();
+        }
+
+        public IReadOnlyDictionary<string, string> SetCloudBuildVariable(string name, string value, TextWriter stdout, TextWriter stderr)
+        {
+            return new Dictionary<string, string>();
+        }
+    }
+}

--- a/src/NerdBank.GitVersioning/CloudBuildServices/VisualStudioTeamServices.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/VisualStudioTeamServices.cs
@@ -13,19 +13,17 @@
     /// </remarks>
     internal class VisualStudioTeamServices : ICloudBuild
     {
-        public bool IsPullRequest => Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")?.StartsWith("refs/pull/") ?? false;
+        public bool IsPullRequest => BuildingRef?.StartsWith("refs/pull/") ?? false;
 
-        public string BuildingTag => Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")?.StartsWith("refs/tags/") ?? false 
-            ? Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH") 
-            : null;
+        public string BuildingTag => (BuildingRef?.StartsWith("refs/tags/") ?? false) ? BuildingRef : null;
 
-        public string BuildingBranch => Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")?.StartsWith("refs/heads/") ?? false 
-            ? Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")
-            : null;
-        
+        public string BuildingBranch => (BuildingRef?.StartsWith("refs/heads/") ?? false) ? BuildingRef : null;
+
         public string GitCommitId => null;
 
         public bool IsApplicable => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_TEAMPROJECTID"));
+
+        private static string BuildingRef => Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
 
         public IReadOnlyDictionary<string, string> SetCloudBuildNumber(string buildNumber, TextWriter stdout, TextWriter stderr)
         {


### PR DESCRIPTION
I don't see support in GitHub Actions to set "cloud variables" or set a cloud build number, so like several other CI systems I'm leaving those as not implemented. But we can certainly recognize the PublicRelease state.

Closes #375