### PR TITLE
Enable custom .net core dotnet process calls in getVersion and setPackageVersion

### DIFF
--- a/src/nerdbank-gitversioning.npm/ts/index.ts
+++ b/src/nerdbank-gitversioning.npm/ts/index.ts
@@ -39,11 +39,13 @@ export interface IGitVersion {
 /**
  * Gets an object describing various aspects of the version of a project.
  * @param projectDirectory The directory of the source code to get the version of.
+ * @param dotnetCommand The location of the dotnet command line executable
  */
-export async function getVersion(projectDirectory?: string): Promise<IGitVersion> {
+export async function getVersion(projectDirectory?: string, dotnetCommand?: string): Promise<IGitVersion> {
     projectDirectory = projectDirectory || '.';
+    var command = dotnetCommand || 'dotnet';
     var getVersionScriptPath = path.join(__dirname, nbgvPath, "tools", "netcoreapp2.1", "any", "nbgv.dll");
-    var versionText = await execAsync(`dotnet "${getVersionScriptPath}" get-version --format json`, { cwd: projectDirectory })
+    var versionText = await execAsync(`${command} "${getVersionScriptPath}" get-version --format json`, { cwd: projectDirectory })
     if (versionText.stderr) {
         throw versionText.stderr;
     }
@@ -61,11 +63,12 @@ export async function getVersion(projectDirectory?: string): Promise<IGitVersion
  * Sets an NPM package version based on the git height and version.json.
  * @param packageDirectory The directory of the package about to be published.
  * @param srcDirectory The directory of the source code behind the package, if different than the packageDirectory.
+ * @param dotnetCommand The location of the dotnet command line executable
  */
-export async function setPackageVersion(packageDirectory?: string, srcDirectory?: string) {
+export async function setPackageVersion(packageDirectory?: string, srcDirectory?: string, dotnetCommand?: string) {
     packageDirectory = packageDirectory || '.';
     srcDirectory = srcDirectory || packageDirectory;
-    const gitVersion = await getVersion(srcDirectory);
+    const gitVersion = await getVersion(srcDirectory, dotnetCommand);
     console.log(`Setting package version to ${gitVersion.npmPackageVersion}`);
     var result = await execAsync(`npm version ${gitVersion.npmPackageVersion} --no-git-tag-version`, { cwd: packageDirectory });
     if (result.stderr) {


### PR DESCRIPTION
Internal build servers may not allow direct calls to "dotnet" alias as it's not setup due to containing multiple versions of the .net core dotnet cli process.

In the index.ts file there is a getVersion() method that calls execAsync() method. This method calls "dotnet" directly. Modify the methods to allow callers to pass in a location where dotnet process resides.

Fixes #379