### PR TITLE
Add fsharp and vb integration tests

### DIFF
--- a/azure-pipelines/xplattest-pipeline.yml
+++ b/azure-pipelines/xplattest-pipeline.yml
@@ -31,7 +31,7 @@ steps:
       echo Testing language $l &&
       dotnet new classlib -lang=$l &&
       dotnet add package nerdbank.gitversioning -v $NBGV_NuGetPackageVersion &&
-      dotnet pack -c debug &&
+      dotnet pack -c debug /p:TreatWarningsAsErrors=false &&
       ls bin/debug/lib.42.42.1*.nupkg 1> /dev/null 2>&1 &&
       rm -r *
       if [ $? -ne 0 ]; then exit 1; fi

--- a/azure-pipelines/xplattest-pipeline.yml
+++ b/azure-pipelines/xplattest-pipeline.yml
@@ -21,15 +21,21 @@ steps:
     NBGV_NuGetPackageVersion=$([[ $PkgFileName =~ Nerdbank.GitVersioning\.(.*)\.nupkg ]] && echo "${BASH_REMATCH[1]}")
 
     echo "<configuration><packageSources><clear /><add key='local' value='deployables' /></packageSources></configuration>" > nuget.config &&
-    dotnet new classlib -o lib &&
-    cd lib &&
     echo '{"version":"42.42"}' > version.json &&
-    git init &&
-    git add lib.csproj version.json Class1.cs &&
-    dotnet add package nerdbank.gitversioning -v $NBGV_NuGetPackageVersion &&
+    git init && 
+    git add version.json &&
     git commit -m "Initial commit" &&
-    dotnet pack -c debug &&
-    if ! ls bin/debug/lib.42.42.1*.nupkg 1> /dev/null 2>&1; then exit 1; fi
+    mkdir lib && cd lib &&
+    for l in c# f# vb;
+    do
+      echo Testing language $l &&
+      dotnet new classlib -lang=$l &&
+      dotnet add package nerdbank.gitversioning -v $NBGV_NuGetPackageVersion &&
+      dotnet pack -c debug &&
+      ls bin/debug/lib.42.42.1*.nupkg 1> /dev/null 2>&1 &&
+      rm -r *
+      if [ $? -ne 0 ]; then exit 1; fi
+    done
   displayName: Consume NB.GV from .NET Core build
   failOnStderr: true
 

--- a/azure-pipelines/xplattest-pipeline.yml
+++ b/azure-pipelines/xplattest-pipeline.yml
@@ -20,7 +20,7 @@ steps:
 
     NBGV_NuGetPackageVersion=$([[ $PkgFileName =~ Nerdbank.GitVersioning\.(.*)\.nupkg ]] && echo "${BASH_REMATCH[1]}")
 
-    echo "<configuration><packageSources><clear /><add key='local' value='deployables' /></packageSources></configuration>" > nuget.config &&
+    echo "<configuration><packageSources><add key='local' value='deployables' /></packageSources></configuration>" > nuget.config &&
     echo '{"version":"42.42"}' > version.json &&
     git init && 
     git add version.json &&


### PR DESCRIPTION
This adds an integration test for F# (#353) and also for VB.

In F# the following warning is emitted: `warning FS2003: The attribute System.Reflection.AssemblyInformationalVersionAttribute specified version '42.42.1+2146ddd457', but this value is invalid and has been ignored [/mnt/c/temp/nbgv-int-test/lib/lib.fsproj]`

I noticed that the F# test fails with dotnet SDK 2.2. It wants to download the FSharp.Core package from nuget, but the official feed is removed in the created nuget.config:
error: Unable to find package FSharp.Core. No packages exist with this id in source(s): local
But with 2.1 it should be fine.

Closes #353