### PR TITLE
Remove workaround for OSX DOTNET_ROOT variable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,7 +153,5 @@ jobs:
   dependsOn: Windows
   pool:
     vmImage: macOS 10.13
-  variables:
-    DOTNET_ROOT: /Users/vsts/.dotnet
   steps:
   - template: azure-pipelines/xplattest-pipeline.yml


### PR DESCRIPTION
Per the fix notice at https://github.com/microsoft/azure-pipelines-image-generation/issues/531#issuecomment-551450908