### PR TITLE
Improve support of WPF projects

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -1,22 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets="NBGV_SetDefaults">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-
-    <PrepareForBuildDependsOn>
-      GenerateNativeVersionInfo;
-      $(PrepareForBuildDependsOn);
-    </PrepareForBuildDependsOn>
-
-    <PrepareResourcesDependsOn>
-      GenerateAssemblyVersionInfo;
-      $(PrepareResourcesDependsOn)
-    </PrepareResourcesDependsOn>
-
-    <CoreCompileDependsOn>
-      GenerateAssemblyVersionInfo;
-      $(CoreCompileDependsOn)
-    </CoreCompileDependsOn>
 
     <VersionDependsOn>
       GetNuPkgVersion;
@@ -32,9 +17,6 @@
       GetBuildVersion;
       $(GetPackageVersionDependsOn)
     </GetPackageVersionDependsOn>
-
-    <!-- Suppress assembly version info generation if not obviously compiling an assembly. -->
-    <GenerateAssemblyVersionInfo Condition=" '$(GenerateAssemblyVersionInfo)' == '' and '$(TargetExt)' != '.dll' and '$(TargetExt)' != '.exe'">false</GenerateAssemblyVersionInfo>
 
     <!-- Suppress version attribute generation in Microsoft.NET.Sdk projects to avoid build failures
          when two sets of attributes are emitted. -->
@@ -52,6 +34,32 @@
   <UsingTask AssemblyFile="$(NerdbankGitVersioningTasksPath)Nerdbank.GitVersioning.Tasks.dll" TaskName="Nerdbank.GitVersioning.Tasks.SetCloudBuildVariables"/>
   <UsingTask AssemblyFile="$(NerdbankGitVersioningTasksPath)Nerdbank.GitVersioning.Tasks.dll" TaskName="Nerdbank.GitVersioning.Tasks.GetBuildVersion"/>
   <UsingTask AssemblyFile="$(NerdbankGitVersioningTasksPath)Nerdbank.GitVersioning.Tasks.dll" TaskName="Nerdbank.GitVersioning.Tasks.CompareFiles"/>
+
+  <Target Name="NBGV_SetDefaults">
+    <!-- Workarounds for https://github.com/AArnott/Nerdbank.GitVersioning/issues/404 -->
+    <PropertyGroup>
+      <!-- $(TargetExt) isn't set at evaluation time for us when built in wpftmp.csproj with manual imports -->
+      <!-- Suppress assembly version info generation if not obviously compiling an assembly. -->
+      <GenerateAssemblyVersionInfo Condition=" '$(GenerateAssemblyVersionInfo)' == '' and '$(TargetExt)' != '.dll' and '$(TargetExt)' != '.exe'">false</GenerateAssemblyVersionInfo>
+
+      <!-- Workaround the property stomping that msbuild does (see https://github.com/microsoft/msbuild/pull/4922) with manual imports. -->
+      <PrepareForBuildDependsOn>
+        GenerateNativeVersionInfo;
+        $(PrepareForBuildDependsOn);
+      </PrepareForBuildDependsOn>
+
+      <PrepareResourcesDependsOn>
+        GenerateAssemblyVersionInfo;
+        $(PrepareResourcesDependsOn)
+      </PrepareResourcesDependsOn>
+
+      <CoreCompileDependsOn>
+        GenerateAssemblyVersionInfo;
+        $(CoreCompileDependsOn)
+      </CoreCompileDependsOn>
+
+    </PropertyGroup>
+  </Target>
 
   <PropertyGroup>
     <!-- Consider building a tag to be more precise than the branch we're building. -->


### PR DESCRIPTION
Workaround for #404 till the dependent bugs we have open against NuGet are resolved.

This workaround is only complete with two xml snippets added to a WPF project:

Add this just under the opening `<Project>` tag:

```xml
  <Import Project="$(BaseIntermediateOutputPath)$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g.props"
          Condition=" '$(_TargetAssemblyProjectName)' != '' and '$(ImportProjectExtensionProps)' != 'false' and exists('$(BaseIntermediateOutputPath)$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g.props')" />
```

Add this just above the closing `</Project>` tag:

```xml
  <Import Project="$(BaseIntermediateOutputPath)$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g.targets"
          Condition=" '$(_TargetAssemblyProjectName)' != '' and '$(ImportProjectExtensionProps)' != 'false' and exists('$(BaseIntermediateOutputPath)$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g.targets')" />
```

This is tested to work both for .NET Framework WPF projects and .NET Core WPF projects.