### PR TITLE
Always use `Branch.Tip` instead of `Branch.Commits.First()`

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -80,7 +80,7 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         }
     }
 
-    private string CommitIdShort => this.Repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength);
+    private string CommitIdShort => this.Repo.Head.Tip.Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength);
 
     protected override void Dispose(bool disposing)
     {
@@ -183,8 +183,8 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         this.WriteVersionFile("3.4");
         Assumes.True(repo.Index[VersionFile.JsonFileName] == null);
         var buildResult = await this.BuildAsync();
-        Assert.Equal("3.4.0." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("3.4.0+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("3.4.0." + repo.Head.Tip.GetIdAsVersion().Revision, buildResult.BuildVersion);
+        Assert.Equal("3.4.0+" + repo.Head.Tip.Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]
@@ -208,8 +208,8 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         var repo = new Repository(this.RepoPath); // do not assign Repo property to avoid commits being generated later
         repo.Commit("empty", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
         var buildResult = await this.BuildAsync();
-        Assert.Equal("0.0.0." + repo.Head.Commits.First().GetIdAsVersion().Revision, buildResult.BuildVersion);
-        Assert.Equal("0.0.0+" + repo.Head.Commits.First().Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength), buildResult.AssemblyInformationalVersion);
+        Assert.Equal("0.0.0." + repo.Head.Tip.GetIdAsVersion().Revision, buildResult.BuildVersion);
+        Assert.Equal("0.0.0+" + repo.Head.Tip.Id.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength), buildResult.AssemblyInformationalVersion);
     }
 
     [Fact]
@@ -288,7 +288,7 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         var buildResult = await this.BuildAsync();
         this.AssertStandardProperties(VersionOptions.FromVersion(new Version(majorMinorVersion)), buildResult);
 
-        Version version = this.Repo.Head.Commits.First().GetIdAsVersion();
+        Version version = this.Repo.Head.Tip.GetIdAsVersion();
         Assert.Equal($"{version.Major}.{version.Minor}.{buildResult.GitVersionHeight}", buildResult.NuGetPackageVersion);
     }
 
@@ -1003,8 +1003,8 @@ public class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuildFixture>
         Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}", buildResult.BuildVersion3Components);
         Assert.Equal(idAsVersion.Build.ToString(), buildResult.BuildVersionNumberComponent);
         Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}", buildResult.BuildVersionSimple);
-        Assert.Equal(this.Repo.Head.Commits.First().Id.Sha, buildResult.GitCommitId);
-        Assert.Equal(this.Repo.Head.Commits.First().Author.When.UtcTicks.ToString(CultureInfo.InvariantCulture), buildResult.GitCommitDateTicks);
+        Assert.Equal(this.Repo.Head.Tip.Id.Sha, buildResult.GitCommitId);
+        Assert.Equal(this.Repo.Head.Tip.Author.When.UtcTicks.ToString(CultureInfo.InvariantCulture), buildResult.GitCommitDateTicks);
         Assert.Equal(commitIdShort, buildResult.GitCommitIdShort);
         Assert.Equal(versionHeight.ToString(), buildResult.GitVersionHeight);
         Assert.Equal($"{version.Major}.{version.Minor}", buildResult.MajorMinorVersion);

--- a/src/NerdBank.GitVersioning/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/GitExtensions.cs
@@ -108,7 +108,7 @@
         /// <returns>The height of the branch till the version is changed.</returns>
         public static int GetVersionHeight(this Branch branch, string repoRelativeProjectDirectory = null)
         {
-            return GetVersionHeight(branch.Commits.First(), repoRelativeProjectDirectory);
+            return GetVersionHeight(branch.Tip ?? throw new InvalidOperationException("No commit exists."), repoRelativeProjectDirectory);
         }
 
         /// <summary>
@@ -143,7 +143,7 @@
         /// <returns>The height of the branch.</returns>
         public static int GetHeight(this Branch branch, Func<Commit, bool> continueStepping = null)
         {
-            return GetHeight(branch.Commits.First(), continueStepping);
+            return GetHeight(branch.Tip ?? throw new InvalidOperationException("No commit exists."), continueStepping);
         }
 
         /// <summary>
@@ -241,7 +241,7 @@
         {
             Requires.NotNull(repo, nameof(repo));
 
-            var headCommit = repo.Head.Commits.FirstOrDefault();
+            var headCommit = repo.Head.Tip;
             VersionOptions workingCopyVersionOptions, committedVersionOptions;
             if (IsVersionFileChangedInWorkingCopy(repo, repoRelativeProjectDirectory, out committedVersionOptions, out workingCopyVersionOptions))
             {
@@ -803,7 +803,7 @@
         private static bool IsVersionFileChangedInWorkingCopy(Repository repo, string repoRelativeProjectDirectory, out VersionOptions committedVersion, out VersionOptions workingCopyVersion)
         {
             Requires.NotNull(repo, nameof(repo));
-            Commit headCommit = repo.Head.Commits.FirstOrDefault();
+            Commit headCommit = repo.Head.Tip;
             committedVersion = VersionFile.GetVersion(headCommit, repoRelativeProjectDirectory);
 
             if (!repo.Info.IsBare)

--- a/src/NerdBank.GitVersioning/VersionFile.cs
+++ b/src/NerdBank.GitVersioning/VersionFile.cs
@@ -128,7 +128,7 @@
                 return workingCopyVersion;
             }
 
-            return GetVersion(repo.Head.Commits.FirstOrDefault(), repoRelativeProjectDirectory);
+            return GetVersion(repo.Head.Tip, repoRelativeProjectDirectory);
         }
 
         /// <summary>


### PR DESCRIPTION
More fixes like the one required to fix #384