### PR TITLE
Add a ReleaseOptions.VersionFieldCount option to control version in branch name

### DIFF
--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -1105,7 +1105,8 @@
             {
                 branchName = "v{version}",
                 versionIncrement = ReleaseVersionIncrement.Minor,
-                firstUnstableTag = "alpha"
+                firstUnstableTag = "alpha",
+                versionFieldCount = 0
             };
 
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -1119,6 +1120,9 @@
 
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             private string firstUnstableTag;
+
+            [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+            private int versionFieldCount;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="ReleaseOptions"/> class
@@ -1184,6 +1188,24 @@
             [JsonIgnore]
             public string FirstUnstableTagOrDefault => this.FirstUnstableTag ?? DefaultInstance.FirstUnstableTag;
 
+            /// <summary>
+            /// The number of version components to use in the branch name (e.g. use '2' to always create a branch name where '{version}' is replaced with the Major.Minor version, regardless of the version specified in the version file).
+            /// Default is '0', which means it will use the number of version components equal to the one specified in the version file
+            /// </summary>
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public int VersionFieldCount
+            {
+                get => this.versionFieldCount;
+                set => this.SetIfNotReadOnly(ref this.versionFieldCount, value);
+            }
+
+            /// <summary>
+            /// The number of version components to use in the branch name (e.g. use '2' to always create a branch name where '{version}' is replaced with the Major.Minor version, regardless of the version specified in the version file).
+            /// Default is '0', which means it will use the number of version components equal to the one specified in the version file
+            /// </summary>
+            [JsonIgnore]
+            public int VersionFieldCountOrDefault => this.VersionFieldCount > 0 ? this.VersionFieldCount : DefaultInstance.VersionFieldCount;
+
             /// <inheritdoc />
             public override bool Equals(object obj) => this.Equals(obj as ReleaseOptions);
 
@@ -1231,7 +1253,8 @@
 
                     return StringComparer.Ordinal.Equals(x.BranchNameOrDefault, y.BranchNameOrDefault) &&
                            x.VersionIncrementOrDefault == y.VersionIncrementOrDefault &&
-                           StringComparer.Ordinal.Equals(x.FirstUnstableTagOrDefault, y.FirstUnstableTagOrDefault);
+                           StringComparer.Ordinal.Equals(x.FirstUnstableTagOrDefault, y.FirstUnstableTagOrDefault) &&
+                           x.VersionFieldCountOrDefault == y.VersionFieldCountOrDefault;
                 }
 
                 /// <inheritdoc />
@@ -1245,6 +1268,7 @@
                         var hash = StringComparer.Ordinal.GetHashCode(obj.BranchNameOrDefault) * 397;
                         hash ^= (int)obj.VersionIncrementOrDefault;
                         hash ^= StringComparer.Ordinal.GetHashCode(obj.FirstUnstableTagOrDefault);
+                        hash ^= obj.VersionFieldCountOrDefault;
                         return hash;
                     }
                 }

--- a/src/NerdBank.GitVersioning/VersionOptionsContractResolver.cs
+++ b/src/NerdBank.GitVersioning/VersionOptionsContractResolver.cs
@@ -141,6 +141,11 @@
                 {
                     property.ShouldSerialize = instance => ((VersionOptions.ReleaseOptions)instance).FirstUnstableTagOrDefault != VersionOptions.ReleaseOptions.DefaultInstance.FirstUnstableTag;
                 }
+
+                if (property.DeclaringType == typeof(VersionOptions.ReleaseOptions) && member.Name == nameof(VersionOptions.ReleaseOptions.VersionFieldCount))
+                {
+                    property.ShouldSerialize = instance => ((VersionOptions.ReleaseOptions)instance).VersionFieldCountOrDefault != VersionOptions.ReleaseOptions.DefaultInstance.VersionFieldCount;
+                }
             }
 
             return property;

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -172,6 +172,13 @@
               "description": "Specifies the first/default prerelease tag for new versions",
               "type": "string",
               "default": "alpha"
+            },
+            "versionFieldCount": {
+              "type": "integer",
+              "description": "The number of version field components to use in {version} when creating a branch name.",
+              "default": 0,
+              "minimum": 0,
+              "maximum": 4
             }
           },
           "additionalProperties": false

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -51,6 +51,7 @@ namespace Nerdbank.GitVersioning.Tool
             InvalidVersionIncrementSetting,
             InvalidParameters,
             InvalidVersionIncrement,
+            InvalidVersionFieldCountSetting
         }
 
         private static ExitCodes exitCode;
@@ -645,6 +646,8 @@ namespace Nerdbank.GitVersioning.Tool
                         return ExitCodes.UncommittedChanges;
                     case ReleaseManager.ReleasePreparationError.InvalidBranchNameSetting:
                         return ExitCodes.InvalidBranchNameSetting;
+                    case ReleaseManager.ReleasePreparationError.InvalidVersionFieldCountSetting:
+                        return ExitCodes.InvalidVersionFieldCountSetting;
                     case ReleaseManager.ReleasePreparationError.NoVersionFile:
                         return ExitCodes.NoVersionJsonFound;
                     case ReleaseManager.ReleasePreparationError.VersionDecrement:


### PR DESCRIPTION
 This allows specifying the number of version components to use in the branch name.

Example setup:

```json
{
  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
  "version": "1.0.0-preview.{height}",
  "nuGetPackageVersion": {
    "semVer": 2.0
  },
  "publicReleaseRefSpec": [
    "^refs/heads/master$",
    "^refs/heads/release/v\\d+(?:\\.\\d+)?$"
  ],
  "release": {
    "branchName": "release/v{version}",
    "firstUnstableTag": "preview"
  }
}
```

- We don't want to use {height} in public release number (use version with 3 components)
- Minor releases are managed from their own branch (release/v1.0 release/v1.1 release/v2.0 etc)
- version in a release branch is: "1.0.0" and manually updated to "1.0.1-preview.{height}" or "1.0.1" when releasing (preview)patches.

Currently when using this setup, we cannot use "nbgv prepare-release", as this creates a branch named "release/v1.0.0"

The "VersionFieldCount" option allows to override how many fields of the version should be used when constructing the branch name.

This would be my new settings file:

```json
{
  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
  "version": "1.0.0-preview.{height}",
  "nuGetPackageVersion": {
    "semVer": 2.0
  },
  "publicReleaseRefSpec": [
    "^refs/heads/master$",
    "^refs/heads/release/v\\d+(?:\\.\\d+)?$"
  ],
  "release": {
    "branchName": "release/v{version}",
    "firstUnstableTag": "preview",
    "versionFieldCount": 2
  }
}
```

Notes:

- I'm not sure I like the "VersionFieldCount" option name, but couldn't come up with a better one.