### PR TITLE
Use nearest relevant commit id based on path filters (fixes #643)

### DIFF
--- a/src/NerdBank.GitVersioning/GitContext.cs
+++ b/src/NerdBank.GitVersioning/GitContext.cs
@@ -176,7 +176,7 @@ namespace Nerdbank.GitVersioning
         /// <returns>A string that is at least <paramref name="minLength"/> in length but may be more as required to uniquely identify the git object identified by <see cref="GitCommitId"/>.</returns>
         public abstract string GetShortUniqueCommitId(int minLength);
 
-        internal abstract int CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion);
+        internal abstract (int height, string? nearestRelevantCommit) CalculateVersionHeightAndNearestRelevantCommit(VersionOptions? committedVersion, VersionOptions? workingVersion);
 
         internal abstract Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, int versionHeight);
 

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
@@ -82,8 +82,11 @@ namespace Nerdbank.GitVersioning.LibGit2
         /// <inheritdoc/>
         public override string GetShortUniqueCommitId(int minLength) => this.Repository.ObjectDatabase.ShortenObjectId(this.Commit, minLength);
 
-        internal override int CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion)
+        internal override (int height, string? nearestRelevantCommit) CalculateVersionHeightAndNearestRelevantCommit(VersionOptions? committedVersion, VersionOptions? workingVersion)
         {
+            throw new NotImplementedException("nearestRelevantCommit for libgit2");
+
+#if false
             var headCommitVersion = committedVersion?.Version ?? SemVer0;
 
             if (IsVersionFileChangedInWorkingTree(committedVersion, workingVersion))
@@ -99,6 +102,7 @@ namespace Nerdbank.GitVersioning.LibGit2
             }
 
             return LibGit2GitExtensions.GetVersionHeight(this);
+#endif
         }
 
         internal override System.Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, int versionHeight)

--- a/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
+++ b/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
@@ -86,7 +86,7 @@ namespace Nerdbank.GitVersioning.Managed
             };
         }
 
-        internal override int CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion)
+        internal override (int height, string? nearestRelevantCommit) CalculateVersionHeightAndNearestRelevantCommit(VersionOptions? committedVersion, VersionOptions? workingVersion)
         {
             var headCommitVersion = committedVersion?.Version ?? SemVer0;
 
@@ -98,11 +98,12 @@ namespace Nerdbank.GitVersioning.Managed
                 {
                     // The working copy has changed the major.minor version.
                     // So by definition the version height is 0, since no commit represents it yet.
-                    return 0;
+                    return (0, null);
                 }
             }
 
-            return GitExtensions.GetVersionHeight(this);
+            var (height, nearestRelevantCommit) = GitExtensions.GetVersionHeight(this);
+            return (height, nearestRelevantCommit?.Sha.ToString());
         }
 
         internal override Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, int versionHeight)

--- a/src/NerdBank.GitVersioning/ManagedGit/GitObjectId.cs
+++ b/src/NerdBank.GitVersioning/ManagedGit/GitObjectId.cs
@@ -116,6 +116,9 @@ namespace Nerdbank.GitVersioning.ManagedGit
 
                 bytes[i >> 1] = (byte)(c1 + c2);
             }
+            
+            // Clear any cached sha. This can happen when debugging, and is very confusing.
+            objectId.sha = null;
 
             return objectId;
         }

--- a/src/NerdBank.GitVersioning/NoGit/NoGitContext.cs
+++ b/src/NerdBank.GitVersioning/NoGit/NoGitContext.cs
@@ -32,7 +32,7 @@ namespace Nerdbank.GitVersioning
         public override void Stage(string path) => throw new InvalidOperationException(NotAGitRepoMessage);
         public override string GetShortUniqueCommitId(int minLength) => throw new InvalidOperationException(NotAGitRepoMessage);
         public override bool TrySelectCommit(string committish) => throw new InvalidOperationException(NotAGitRepoMessage);
-        internal override int CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion) => 0;
+        internal override (int height, string? nearestRelevantCommit) CalculateVersionHeightAndNearestRelevantCommit(VersionOptions? committedVersion, VersionOptions? workingVersion) => (0, null);
         internal override Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, int versionHeight) => throw new NotImplementedException();
     }
 }

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -107,6 +107,7 @@ namespace Nerdbank.GitVersioning
                 var gitCommitIdShortFixedLength = this.VersionOptions?.GitCommitIdShortFixedLength ?? VersionOptions.DefaultGitCommitIdShortFixedLength;
                 var gitCommitIdShortAutoMinimum = this.VersionOptions?.GitCommitIdShortAutoMinimum ?? 0;
 
+                // Get it from the git repository if there is a repository present and it is enabled.
                 this.GitCommitIdShort = this.GitCommitId is object && gitCommitIdShortAutoMinimum > 0
                     ? this.context.GetShortUniqueCommitId(gitCommitIdShortAutoMinimum)
                     : this.GitCommitId!.Substring(0, gitCommitIdShortFixedLength);


### PR DESCRIPTION
This is work in progress for discussion. I've also been affected by #643 so I'm attempting a fix.

@AArnott I'd welcome comments on the general approach. I've implemented in managed only for now, plan to implement for libgit if/when the managed implementation is acceptable.

The basic idea is to leverage the work of `GitWalkTracker`, keeping track of the commit with greatest height (which I believe should be the relevant commit nearest to the 'current' commit, and only commits that survive path filtering are tracked).

Note the comment [here](https://github.com/zanyants/Nerdbank.GitVersioning/blob/7a99e3c06e3530df0b0e8d41a2d0fff6567501e6/src/NerdBank.GitVersioning/Managed/ManagedGitExtensions.cs#L49) - I don't have a deep enough understanding of this scenario to know what should be done.