### PR TITLE
fix: extend error message in case there are uncommited changes, in order to get the files which are causing the issue

### DIFF
--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -414,7 +414,7 @@
             {
                 var changedFiles = status.OfType<StatusEntry>().ToList();
                 var changesFilesFormatted = string.Join(Environment.NewLine, changedFiles.Select(t => $"- {t.FilePath} changed with {nameof(FileStatus)} {t.State}"));
-                this.stderr.WriteLine($"Uncommitted changes {changedFiles.Count} in directory '{projectDirectory}':");
+                this.stderr.WriteLine($"Uncommitted changes ({changedFiles.Count}) in directory '{projectDirectory}':");
                 this.stderr.WriteLine(changesFilesFormatted);
                 throw new ReleasePreparationException(ReleasePreparationError.UncommittedChanges);
             }


### PR DESCRIPTION
This will make it possible, that the .gitignore file will be extended to exclude the temp files who are causing the issue in related repos. This fix is related to #603