### PR TITLE
Suppress `cloudBuild.buildNumber: null` being written for `nbgv prepare-release`

### DIFF
--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -934,6 +934,7 @@ namespace Nerdbank.GitVersioning
             /// <summary>
             /// Gets or sets options around how and whether to set the build number preset by the cloud build with one enriched with version information.
             /// </summary>
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
             public CloudBuildNumberOptions? BuildNumber
             {
                 get => this.buildNumber;


### PR DESCRIPTION
Fixes #630