### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,30 +3,37 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.5.3",
+      "version": "7.5.4",
       "commands": [
         "pwsh"
       ],
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "17.14.2",
+      "version": "18.1.0",
       "commands": [
         "dotnet-coverage"
       ],
       "rollForward": false
     },
     "nbgv": {
-      "version": "3.7.115",
+      "version": "3.8.118",
       "commands": [
         "nbgv"
       ],
       "rollForward": false
     },
     "docfx": {
-      "version": "2.78.3",
+      "version": "2.78.4",
       "commands": [
         "docfx"
+      ],
+      "rollForward": false
+    },
+    "nerdbank.dotnetrepotools": {
+      "version": "1.0.92",
+      "commands": [
+        "repo"
       ],
       "rollForward": false
     }

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:9.0.305-noble@sha256:604ef064c6d91068eeb9d946036d8ffadbe25589c4cd77a230fc96e0f6d01d72
+FROM mcr.microsoft.com/dotnet/sdk:9.0.306-noble@sha256:d88e637d15248531967111fba05c6725ad45ea1dace3d35d8cfe2c4d4094e25d
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/actions/publish-artifacts/action.yaml
+++ b/.github/actions/publish-artifacts/action.yaml
@@ -14,46 +14,46 @@ runs:
 
   - name: 📢 Upload project.assets.json files
     if: always()
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: projectAssetsJson-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/projectAssetsJson
     continue-on-error: true
   - name: 📢 Upload variables
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: variables-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/Variables
     continue-on-error: true
   - name: 📢 Upload build_logs
     if: always()
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: build_logs-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/build_logs
     continue-on-error: true
   - name: 📢 Upload testResults
     if: always()
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: testResults-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/testResults
     continue-on-error: true
   - name: 📢 Upload coverageResults
     if: always()
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: coverageResults-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/coverageResults
     continue-on-error: true
   - name: 📢 Upload symbols
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: symbols-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/symbols
     continue-on-error: true
   - name: 📢 Upload deployables
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: deployables-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/deployables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,4 +304,4 @@ jobs:
     - name: 🔗 Markup Link Checker (mlc)
       uses: becheran/mlc@18a06b3aa2901ca197de59c8b0b1f54fdba6b3fa # v1.0.0
       with:
-        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx -i https://www.npmjs.com/package/*
+        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx -i https://www.npmjs.com/package/*,https://get.dot.net/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: windows-latest
     environment: Signing
     permissions:
-      actions: read
-      contents: write
-      id-token: write # Required for Azure / NuGet CLI Login
+      actions: read # Required to download artifacts
+      contents: write # Upload artifacts to Release
+      id-token: write # Required for NuGet CLI Login
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
@@ -68,7 +68,7 @@ jobs:
         Echo "runid=$runid" >> $env:GITHUB_OUTPUT
 
     - name: 🔻 Download deployables artifacts
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
       with:
         name: deployables-Windows
         path: ${{ runner.temp }}/deployables
@@ -111,13 +111,13 @@ jobs:
         }
 
     - name: 🪪 Authorize NuGet package push
-      uses: NuGet/login@v1
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1
       id: nuget-login
       with:
         user: ${{ secrets.NUGET_USER }}
 
     - name: 🚀 Push NuGet packages
-      run: dotnet nuget push ${{ runner.temp }}\deployables\*.nupkg --source https://api.nuget.org/v3/index.json -k '${{ steps.nuget-login.outputs.NUGET_API_KEY }}'
+      run: dotnet nuget push ${{ runner.temp }}/deployables/*.nupkg --source https://api.nuget.org/v3/index.json -k '${{ steps.nuget-login.outputs.NUGET_API_KEY }}'
 
     - name: 🚀 Push NPM packages
       shell: pwsh

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.305",
+    "version": "9.0.306",
     "rollForward": "patch",
     "allowPrerelease": false
   }


### PR DESCRIPTION
- Add dotnet-tools.json to Solution Items
- Skip testing get.dot.net links
- Update nbgv and nerdbank.gitversioning updates to 3.8.118
- Switch to NuGet Trusted Publishing
- Update xunit
- Update dependency dotnet-coverage to v18
- Update mcr.microsoft.com/dotnet/sdk:9.0.305-noble Docker digest to 8a26226
- Update dependency Microsoft.NET.Test.Sdk to v18
- Update mcr.microsoft.com/dotnet/sdk:9.0.305-noble Docker digest to 9ae2f68
- Add `repo` command as a CLI tool
- Update dependency dotnet-coverage to v18.1.0
- Update Dockerfile and global.json updates to v9.0.306
- Update dependency powershell to v7.5.4
- Update mcr.microsoft.com/dotnet/sdk:9.0.306-noble Docker digest to d88e637
- Switch from sln to slnx
- Fix template expansion after slnx rename
- Another template expansion fix
- Update dependency docfx to v2.78.4
- Update GitHub Artifact Actions
- Update dependency xunit.v3 to 3.2.0
