### PR TITLE
Fix native heap corruption in GitPackIndexMappedReaderTests

### DIFF
--- a/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitPackIndexMappedReaderTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitPackIndexMappedReaderTests.cs
@@ -27,8 +27,7 @@ public class GitPackIndexMappedReaderTests
             resourceStream.CopyTo(stream);
         }
 
-        using (FileStream stream = File.OpenRead(indexFile))
-        using (GitPackIndexReader reader = new GitPackIndexMappedReader(stream))
+        using (GitPackIndexReader reader = new GitPackIndexMappedReader(File.OpenRead(indexFile)))
         {
             // Offset of an object which is present
             Assert.Equal(12, reader.GetOffset(GitObjectId.Parse("f5b401f40ad83f13030e946c9ea22cb54cb853cd")));
@@ -59,17 +58,18 @@ public class GitPackIndexMappedReaderTests
             resourceStream.CopyTo(stream);
         }
 
-        using (FileStream stream = File.OpenRead(indexFile))
-        using (var reader = new GitPackIndexMappedReader(stream))
+        using (var reader = new GitPackIndexMappedReader(File.OpenRead(indexFile)))
         {
             // Offset of an object which is present
             (long? offset, GitObjectId? objectId) = reader.GetOffset(new byte[] { 0xf5, 0xb4, 0x01, 0xf4 });
             Assert.Equal(12, offset);
-            Assert.Equal(GitObjectId.Parse("f5b401f40ad83f13030e946c9ea22cb54cb853cd"), objectId);
+            Assert.True(objectId.HasValue);
+            Assert.Equal("f5b401f40ad83f13030e946c9ea22cb54cb853cd", objectId.Value.ToString());
 
             (offset, objectId) = reader.GetOffset(new byte[] { 0xd6, 0x78, 0x15, 0x52 });
             Assert.Equal(317, offset);
-            Assert.Equal(GitObjectId.Parse("d6781552a0a94adbf73ed77696712084754dc274"), objectId);
+            Assert.True(objectId.HasValue);
+            Assert.Equal("d6781552a0a94adbf73ed77696712084754dc274", objectId.Value.ToString());
 
             // null for an object which is not present
             (offset, objectId) = reader.GetOffset(new byte[] { 0x00, 0x00, 0x00, 0x00 });


### PR DESCRIPTION
## Problem

The ubuntu-24.04 CI build has been failing non-deterministically with native heap corruption errors during test execution:

- `free(): invalid pointer` (runs [#24475017484](https://github.com/dotnet/Nerdbank.GitVersioning/actions/runs/24475017484/job/71524835512), [#24474758609](https://github.com/dotnet/Nerdbank.GitVersioning/actions/runs/24474758609/job/71523948242))
- `double free or corruption (out)` (run [#24474464353](https://github.com/dotnet/Nerdbank.GitVersioning/actions/runs/24474464353/job/71522943418))
- `malloc_consolidate(): invalid chunk size` (run [#24475399839](https://github.com/dotnet/Nerdbank.GitVersioning/actions/runs/24475399839/job/71526133356))

All four failures show the test host crashing with exit code 134 (SIGABRT) and **zero actual test failures** — the process dies during cleanup. A separate Windows build ([#24473836691](https://github.com/dotnet/Nerdbank.GitVersioning/actions/runs/24473836691/job/71520780301)) also failed in the same test class (`GetOffsetFromPartialTest`) with a value-equality assertion failure on net472/x86.

## Root Cause

**Double-free of FileStream**: `GitPackIndexMappedReaderTests` wrapped the `FileStream` in an explicit `using` block *and* passed it to `GitPackIndexMappedReader`, which takes ownership via `MemoryMappedFile.CreateFromFile(..., leaveOpen: false)`. When the outer `using` block then tried to dispose the already-closed stream, the native file handle was freed twice — causing heap corruption on Linux.

**Nullable struct equality**: `GetOffsetFromPartialTest` compared `GitObjectId?` (boxed nullable) with `GitObjectId` (value type) using `Assert.Equal`. On .NET Framework x86, the boxing path could produce a false negative even when the underlying bytes matched.

## Fix

1. Remove the outer `using` on `FileStream` so `GitPackIndexMappedReader` is the sole owner
2. Assert on `objectId.Value.ToString()` instead of comparing boxed nullable structs