### PR TITLE
feat: Implement nbgv path-filters command for monorepo pathFilters automation

### DIFF
--- a/docfx/docs/nbgv-cli.md
+++ b/docfx/docs/nbgv-cli.md
@@ -252,6 +252,4 @@ usage: nbgv <command> [<args>]
                      current branch.
     path-filters     Manages the pathFilters property in version.json files
                      based on MSBuild project references and imports.
-                     See Path filters for more information.
-
 ```

--- a/docfx/docs/nbgv-cli.md
+++ b/docfx/docs/nbgv-cli.md
@@ -250,4 +250,8 @@ usage: nbgv <command> [<args>]
     prepare-release  Prepares a release by creating a release branch for
                      the current version and adjusting the version on the
                      current branch.
+    path-filters     Manages the pathFilters property in version.json files
+                     based on MSBuild project references and imports.
+                     See Path filters for more information.
+
 ```

--- a/docfx/docs/path-filters.md
+++ b/docfx/docs/path-filters.md
@@ -57,3 +57,138 @@ Multiple path filters may also be specified. The order is irrelevant. After a pa
 | `/root-file.txt`<br>`:/dir/file.txt`                                               | File will be included. Path is absolute (i.e., relative to the root of the repository).                    |
 | `:!bar.txt`<br>`:^../foo/baz.txt`                                                  | File will be excluded. Path is relative to the `version.json` file. `:!` and `:^` prefixes are synonymous. |
 | `:!/root-file.txt`                                                                 | File will be excluded. Path is absolute (i.e., relative to the root of the repository).                    |
+
+## Managing path filters with `nbgv path-filters`
+
+For repositories with multiple projects and version.json files, manually maintaining `pathFilters` can be error-prone. The `nbgv path-filters` command automates this process by analyzing your MSBuild project structure and computing the correct path filters based on project references and shared build files.
+
+### When to use path-filters command
+
+Use the `nbgv path-filters` command in the following scenarios:
+
+- **Monorepo with multiple projects** - You have multiple projects in different directories, each with their own `version.json`
+- **Complex project dependencies** - Projects reference each other, and you need path filters to reflect these dependencies
+- **Shared build files** - You use `Directory.Build.props` or other shared MSBuild imports that should be tracked by multiple projects
+- **Maintaining accuracy** - You want to ensure path filters automatically stay in sync with your project structure
+
+### How it works
+
+The `nbgv path-filters` command uses the MSBuild project graph API to:
+
+1. **Discover project files** - Finds all MSBuild project files (`.csproj`, `.vbproj`, etc.) associated with each `version.json`
+2. **Compute transitive dependencies** - Uses the MSBuild project graph to determine the complete set of projects that each project depends on
+3. **Include shared build files** - Identifies MSBuild imports like `Directory.Build.props` that reside within the repository
+4. **Respect boundaries** - Stops searching for projects at directories containing their own `version.json` files, ensuring clean separation of concerns
+5. **Generate path filters** - Converts the discovered projects and files into appropriate `pathFilters` entries
+
+### Important behaviors
+
+- **Only processes version.json files with projects** - A `version.json` file with no associated MSBuild projects is skipped and left unchanged
+- **Respects version.json hierarchy** - When searching for projects under a `version.json`, the search stops at subdirectories that have their own `version.json` files
+- **Includes project directories** - Path filters include entire project directories (e.g., `/ProjectA`) rather than individual `.csproj` files, making filters cleaner and more intuitive
+- **Filters generated files** - Automatically excludes files in `obj/` and `bin/` directories (NuGet-generated imports)
+
+### Usage
+
+#### Check current path filters
+
+To see what path filters should be present without making changes:
+
+```ps1
+nbgv path-filters check
+```
+
+This command will:
+- Compare the computed path filters against what's currently in each `version.json`
+- Display mismatches (missing or extra filters)
+- Exit with non-zero code if any mismatches are found (useful for CI validation)
+
+#### Update path filters
+
+To automatically compute and update all `version.json` files:
+
+```ps1
+nbgv path-filters update
+```
+
+This command will:
+- Compute the correct path filters for each `version.json`
+- Update each file that needs changes
+- Display which files were updated
+- Skip any `version.json` files that have no associated projects
+
+#### Specify which version.json files to process
+
+By default, both commands search from the current directory. You can specify specific paths:
+
+```ps1
+nbgv path-filters check --path ./src/ProjectA --path ./src/ProjectB
+```
+
+#### Include additional project file extensions
+
+By default, the tool searches for `.csproj` and `.vbproj` files. You can include other extensions:
+
+```ps1
+nbgv path-filters update --ext .fsproj --ext .csproj
+```
+
+### Example
+
+Consider a monorepo with this structure:
+
+```
+/
+  version.json (version: "1.0")
+  Directory.Build.props
+  /ProjectA
+    version.json (version: "2.0")
+    ProjectA.csproj
+  /ProjectB
+    version.json (version: "3.0")
+    ProjectB.csproj
+    (ProjectB.csproj references ProjectA.csproj)
+```
+
+Running `nbgv path-filters update` would produce:
+
+**Root version.json** - Left unchanged (has no projects directly under it)
+
+**ProjectA/version.json**:
+```json
+{
+  "version": "2.0",
+  "pathFilters": [
+    "/ProjectA",
+    "/Directory.Build.props"
+  ]
+}
+```
+
+**ProjectB/version.json**:
+```json
+{
+  "version": "3.0",
+  "pathFilters": [
+    "/ProjectA",
+    "/ProjectB",
+    "/Directory.Build.props"
+  ]
+}
+```
+
+Note that ProjectB's filters include ProjectA because ProjectB depends on it. Any change to ProjectA's source files will now correctly trigger a version bump for ProjectB as well.
+
+### CI Integration
+
+You can use the `path-filters check` command in your CI pipeline to validate that `pathFilters` are correctly maintained:
+
+```ps1
+nbgv path-filters check
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "Path filters are out of date. Run 'nbgv path-filters update' locally."
+  exit 1
+}
+```
+
+This ensures that developers keep path filters in sync with project structure changes.

--- a/docfx/docs/path-filters.md
+++ b/docfx/docs/path-filters.md
@@ -85,8 +85,8 @@ The `nbgv path-filters` command uses the MSBuild project graph API to:
 
 - **Only processes version.json files with projects** - A `version.json` file with no associated MSBuild projects is skipped and left unchanged
 - **Respects version.json hierarchy** - When searching for projects under a `version.json`, the search stops at subdirectories that have their own `version.json` files
-- **Includes project directories** - Path filters include entire project directories (e.g., `/ProjectA`) rather than individual `.csproj` files, making filters cleaner and more intuitive
-- **Filters generated files** - Automatically excludes files in `obj/` and `bin/` directories (NuGet-generated imports)
+- **Includes project directories** - Path filters include entire project directories (e.g., `/ProjectA`) rather than individual `.csproj` files so that all source changes under those directories result in a new version of the project
+- **Filters ignored files** - Automatically excludes files that match `.gitignore` patterns (including generated directories like `obj/` and `bin/`)
 
 ### Usage
 
@@ -122,7 +122,7 @@ This command will:
 By default, both commands search from the current directory. You can specify specific paths:
 
 ```ps1
-nbgv path-filters check --path ./src/ProjectA --path ./src/ProjectB
+nbgv path-filters check ./src/ProjectA ./src/ProjectB
 ```
 
 #### Include additional project file extensions

--- a/src/NerdBank.GitVersioning/GitContext.cs
+++ b/src/NerdBank.GitVersioning/GitContext.cs
@@ -228,6 +228,13 @@ public abstract class GitContext : IDisposable
         }
     }
 
+    /// <summary>
+    /// Determines whether a file would be ignored by git based on common .gitignore patterns.
+    /// </summary>
+    /// <param name="path">The absolute file path to check.</param>
+    /// <returns>True if the file is ignored by git; false otherwise.</returns>
+    public virtual bool IsIgnored(string path) => false;
+
     /// <inheritdoc />
     public void Dispose()
     {

--- a/src/NerdBank.GitVersioning/GitContext.cs
+++ b/src/NerdBank.GitVersioning/GitContext.cs
@@ -301,7 +301,7 @@ public abstract class GitContext : IDisposable
 
     internal abstract Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, int versionHeight);
 
-    internal string GetRepoRelativePath(string absolutePath)
+    internal string GetRepoRelativePath(string absolutePath, bool replaceBackslashes = false)
     {
         string? repoRoot = this.WorkingTreePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
@@ -310,8 +310,9 @@ public abstract class GitContext : IDisposable
             throw new ArgumentException($"Path '{absolutePath}' is not within repository '{repoRoot}'", nameof(absolutePath));
         }
 
-        return absolutePath.Substring(repoRoot.Length)
+        string result = absolutePath.Substring(repoRoot.Length)
             .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return replaceBackslashes ? result.Replace('\\', '/') : result;
     }
 
     /// <summary>

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
@@ -91,28 +91,19 @@ public class LibGit2Context : GitContext
     /// <inheritdoc />
     public override bool IsIgnored(string path)
     {
-        // Use some common patterns that are typically in .gitignore files
-        // This is a simple approach that covers the most common build artifacts
-        string normalizedPath = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-
-        // Check for common generated directories
-        string[] ignoredDirNames = { "bin", "obj", "packages", ".vs", ".vscode", "node_modules" };
-        foreach (string dirName in ignoredDirNames)
+        try
         {
-            string pattern = $"{Path.DirectorySeparatorChar}{dirName}{Path.DirectorySeparatorChar}";
-            if (normalizedPath.Contains(pattern))
-            {
-                return true;
-            }
+            // Convert absolute path to repo-relative path
+            string repoRelativePath = Path.GetRelativePath(this.WorkingTreePath, path);
 
-            // Also check for the directory at the end of the path
-            if (normalizedPath.EndsWith($"{Path.DirectorySeparatorChar}{dirName}"))
-            {
-                return true;
-            }
+            // Use LibGit2Sharp's built-in ignore checking
+            return this.Repository.Ignore.IsPathIgnored(repoRelativePath);
         }
-
-        return false;
+        catch
+        {
+            // If we can't determine ignore status, assume it's not ignored
+            return false;
+        }
     }
 
     /// <inheritdoc />

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
@@ -89,22 +89,7 @@ public class LibGit2Context : GitContext
     }
 
     /// <inheritdoc />
-    public override bool IsIgnored(string path)
-    {
-        try
-        {
-            // Convert absolute path to repo-relative path
-            string repoRelativePath = Path.GetRelativePath(this.WorkingTreePath, path);
-
-            // Use LibGit2Sharp's built-in ignore checking
-            return this.Repository.Ignore.IsPathIgnored(repoRelativePath);
-        }
-        catch
-        {
-            // If we can't determine ignore status, assume it's not ignored
-            return false;
-        }
-    }
+    public override bool IsIgnored(string path) => this.Repository.Ignore.IsPathIgnored(this.GetRepoRelativePath(path, replaceBackslashes: true));
 
     /// <inheritdoc />
     public override void ApplyTag(string name) => this.Repository.Tags.Add(name, this.Commit);

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
@@ -89,6 +89,33 @@ public class LibGit2Context : GitContext
     }
 
     /// <inheritdoc />
+    public override bool IsIgnored(string path)
+    {
+        // Use some common patterns that are typically in .gitignore files
+        // This is a simple approach that covers the most common build artifacts
+        string normalizedPath = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
+        // Check for common generated directories
+        string[] ignoredDirNames = { "bin", "obj", "packages", ".vs", ".vscode", "node_modules" };
+        foreach (string dirName in ignoredDirNames)
+        {
+            string pattern = $"{Path.DirectorySeparatorChar}{dirName}{Path.DirectorySeparatorChar}";
+            if (normalizedPath.Contains(pattern))
+            {
+                return true;
+            }
+
+            // Also check for the directory at the end of the path
+            if (normalizedPath.EndsWith($"{Path.DirectorySeparatorChar}{dirName}"))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
     public override void ApplyTag(string name) => this.Repository.Tags.Add(name, this.Commit);
 
     /// <inheritdoc />

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -386,7 +386,7 @@ namespace Nerdbank.GitVersioning.Tool
                     Description = "One or more paths to search. Each may be a directory (recursively searched for version.json files) or a version.json file directly (processed without recursive search). Defaults to the current directory.",
                     Arity = ArgumentArity.ZeroOrMore,
                 };
-                var extraExtensions = new Option<string[]>("--ext", ["-e"])
+                var extraExtensions = new Option<string[]>("--ext")
                 {
                     Description = "Additional MSBuild project file extensions to include (e.g. --ext .myproj). Default extensions are .csproj, .vbproj, .fsproj, and .vcxproj.",
                     Arity = ArgumentArity.OneOrMore,
@@ -1180,6 +1180,8 @@ namespace Nerdbank.GitVersioning.Tool
                             {
                                 Console.Error.WriteLine($"  - extra:   :/{e}");
                             }
+
+                            Console.Error.WriteLine("Use the 'nbgv path-filters update' command to update the pathFilters.");
                         }
                     }
                 }

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -4,7 +4,11 @@
 using System.CommandLine;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Graph;
+using Microsoft.Build.Locator;
 using Nerdbank.GitVersioning.Commands;
 using Nerdbank.GitVersioning.LibGit2;
 using Newtonsoft.Json;
@@ -61,6 +65,7 @@ namespace Nerdbank.GitVersioning.Tool
             InternalError,
             InvalidTagNameSetting,
             InvalidUnformattedCommitMessage,
+            PathFiltersMismatch,
         }
 
         private static bool AlwaysUseLibGit2 => string.Equals(Environment.GetEnvironmentVariable("NBGV_GitEngine"), "LibGit2", StringComparison.Ordinal);
@@ -374,6 +379,51 @@ namespace Nerdbank.GitVersioning.Tool
                 });
             }
 
+            Command pathFilters;
+            {
+                var paths = new Argument<string[]>("path")
+                {
+                    Description = "One or more paths to search. Each may be a directory (recursively searched for version.json files) or a version.json file directly (processed without recursive search). Defaults to the current directory.",
+                    Arity = ArgumentArity.ZeroOrMore,
+                };
+                var extraExtensions = new Option<string[]>("--ext", ["-e"])
+                {
+                    Description = "Additional MSBuild project file extensions to include (e.g. --ext .myproj). Default extensions are .csproj, .vbproj, .fsproj, and .vcxproj.",
+                    Arity = ArgumentArity.OneOrMore,
+                    AllowMultipleArgumentsPerToken = true,
+                };
+
+                var updateSubCommand = new Command("update", "Computes pathFilters based on MSBuild project references and imports and writes the result to each applicable version.json file.")
+                {
+                    paths,
+                    extraExtensions,
+                };
+                updateSubCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+                {
+                    var pathsValue = parseResult.GetValue(paths);
+                    var extraExtensionsValue = parseResult.GetValue(extraExtensions);
+                    return await OnPathFiltersUpdateCommand(pathsValue, extraExtensionsValue);
+                });
+
+                var checkSubCommand = new Command("check", "Computes pathFilters based on MSBuild project references and imports and verifies they match what is in each applicable version.json file. Exits with a non-zero exit code when differences are found.")
+                {
+                    paths,
+                    extraExtensions,
+                };
+                checkSubCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+                {
+                    var pathsValue = parseResult.GetValue(paths);
+                    var extraExtensionsValue = parseResult.GetValue(extraExtensions);
+                    return await OnPathFiltersCheckCommand(pathsValue, extraExtensionsValue);
+                });
+
+                pathFilters = new Command("path-filters", "Manages the pathFilters property in version.json files based on MSBuild project references and imports.")
+                {
+                    updateSubCommand,
+                    checkSubCommand,
+                };
+            }
+
             var root = new RootCommand($"{ThisAssembly.AssemblyTitle} v{ThisAssembly.AssemblyInformationalVersion}")
             {
                 install,
@@ -383,6 +433,7 @@ namespace Nerdbank.GitVersioning.Tool
                 getCommits,
                 cloud,
                 prepareRelease,
+                pathFilters,
             };
 
             return root;
@@ -415,6 +466,20 @@ namespace Nerdbank.GitVersioning.Tool
 
         private static int MainInner(string[] args)
         {
+            // Register MSBuild locator to ensure SDK resolvers are available for project evaluation.
+            // This must be called before any MSBuild code is loaded.
+            if (!MSBuildLocator.IsRegistered)
+            {
+                try
+                {
+                    MSBuildLocator.RegisterDefaults();
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Warning: Failed to register MSBuildLocator: {ex.Message}");
+                }
+            }
+
             try
             {
                 RootCommand rootCommand = BuildCommandLine();
@@ -1030,6 +1095,270 @@ namespace Nerdbank.GitVersioning.Tool
             }
         }
 
+#nullable enable
+        private static Task<int> OnPathFiltersUpdateCommand(string[] paths, string[] extraExtensions)
+        {
+            return OnPathFiltersCommandCore(paths, extraExtensions, updateMode: true);
+        }
+
+        private static Task<int> OnPathFiltersCheckCommand(string[] paths, string[] extraExtensions)
+        {
+            return OnPathFiltersCommandCore(paths, extraExtensions, updateMode: false);
+        }
+
+        private static Task<int> OnPathFiltersCommandCore(string[] paths, string[] extraExtensions, bool updateMode)
+        {
+            IReadOnlyList<string> projectExtensions = GetProjectExtensions(extraExtensions);
+            bool anyFound = false;
+            bool anyMismatch = false;
+
+            foreach (string versionJsonPath in FindVersionJsonPaths(paths))
+            {
+                anyFound = true;
+                string versionJsonDir = Path.GetDirectoryName(versionJsonPath)!;
+
+                using GitContext context = GitContext.Create(versionJsonDir, engine: GetEffectiveGitEngine());
+                if (!context.IsRepository)
+                {
+                    Console.Error.WriteLine($"No git repository found for version.json at: {versionJsonPath}");
+                    continue;
+                }
+
+                try
+                {
+                    IReadOnlyList<FilterPath> computed = ComputePathFilters(versionJsonDir, context.WorkingTreePath, projectExtensions);
+                    VersionOptions? versionOptions = context.VersionFile.GetWorkingCopyVersion(
+                        VersionFileRequirements.NonMergedResult | VersionFileRequirements.AcceptInheritingFile);
+
+                    if (versionOptions is null)
+                    {
+                        Console.Error.WriteLine($"Could not load version.json at: {versionJsonPath}");
+                        continue;
+                    }
+
+                    if (updateMode)
+                    {
+                        versionOptions.PathFilters = computed.Count > 0 ? computed : null;
+                        context.VersionFile.SetVersion(versionJsonDir, versionOptions);
+                        Console.WriteLine($"Updated pathFilters in: {versionJsonPath}");
+                    }
+                    else
+                    {
+                        // Check mode: compare computed with existing
+                        IReadOnlyList<FilterPath> existing = versionOptions.PathFilters ?? [];
+                        var computedPaths = new SortedSet<string>(
+                            computed.Select(f => f.RepoRelativePath),
+                            StringComparer.OrdinalIgnoreCase);
+                        var existingPaths = new SortedSet<string>(
+                            existing.Select(f => f.RepoRelativePath),
+                            StringComparer.OrdinalIgnoreCase);
+
+                        if (!computedPaths.SetEquals(existingPaths))
+                        {
+                            anyMismatch = true;
+                            Console.Error.WriteLine($"pathFilters mismatch in: {versionJsonPath}");
+
+                            foreach (string m in computedPaths.Except(existingPaths, StringComparer.OrdinalIgnoreCase))
+                            {
+                                Console.Error.WriteLine($"  + missing: :/{m}");
+                            }
+
+                            foreach (string e in existingPaths.Except(computedPaths, StringComparer.OrdinalIgnoreCase))
+                            {
+                                Console.Error.WriteLine($"  - extra:   :/{e}");
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Error processing {versionJsonPath}: {ex.Message}");
+                }
+            }
+
+            if (!anyFound)
+            {
+                Console.Error.WriteLine("No version.json files found.");
+                return Task.FromResult((int)ExitCodes.NoVersionJsonFound);
+            }
+
+            return Task.FromResult(anyMismatch ? (int)ExitCodes.PathFiltersMismatch : (int)ExitCodes.OK);
+        }
+
+        /// <summary>
+        /// Computes the <see cref="FilterPath"/> list for a given version.json directory
+        /// by using the MSBuild project graph API to find the transitive closure of project references
+        /// and the MSBuild evaluation model to find all imported files within the repository.
+        /// </summary>
+        /// <param name="versionJsonDir">The directory containing the version.json file.</param>
+        /// <param name="repoRoot">The absolute path to the root of the git repository.</param>
+        /// <param name="projectExtensions">The MSBuild project file extensions to search for.</param>
+        /// <returns>A sorted, deduplicated list of repo-root-relative <see cref="FilterPath"/> objects.</returns>
+        private static IReadOnlyList<FilterPath> ComputePathFilters(
+            string versionJsonDir,
+            string repoRoot,
+            IReadOnlyList<string> projectExtensions)
+        {
+            // Find all project files under the version.json directory.
+            List<string> projectFiles = projectExtensions
+                .SelectMany(ext => Directory.EnumerateFiles(versionJsonDir, "*" + ext, SearchOption.AllDirectories))
+                .Select(Path.GetFullPath)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (projectFiles.Count == 0)
+            {
+                Console.Error.WriteLine($"Warning: No project files found under: {versionJsonDir}");
+                return [];
+            }
+
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildingProject"] = "false",
+            };
+
+            // Use ProjectGraph to find the transitive closure of all project references.
+            IEnumerable<ProjectGraphEntryPoint> entryPoints = projectFiles.Select(f => new ProjectGraphEntryPoint(f, globalProperties));
+            ProjectGraph graph = new ProjectGraph(entryPoints);
+
+            List<string> allProjectFiles = graph.ProjectNodes
+                .Select(n => Path.GetFullPath(n.ProjectInstance.FullPath))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            // For each project in the transitive closure, use the MSBuild evaluation model
+            // to collect all imported files that reside within the repository.
+            var results = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string projectFile in allProjectFiles)
+            {
+                if (IsWithinRepo(projectFile, repoRoot))
+                {
+                    results.Add(projectFile);
+                }
+            }
+
+            using var collection = new ProjectCollection(globalProperties);
+            foreach (string projectFile in allProjectFiles)
+            {
+                try
+                {
+                    Project project = collection.LoadProject(projectFile, globalProperties, toolsVersion: null);
+                    foreach (ResolvedImport import in project.Imports)
+                    {
+                        string importPath = Path.GetFullPath(import.ImportedProject.FullPath);
+                        if (IsWithinRepo(importPath, repoRoot))
+                        {
+                            // Skip files in obj and bin directories as they are generated
+                            string normalizedPath = importPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+                            if (normalizedPath.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}") ||
+                                normalizedPath.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+                            {
+                                continue;
+                            }
+
+                            results.Add(importPath);
+                        }
+                    }
+
+                    collection.UnloadProject(project);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Warning: Could not load imports for {projectFile}: {ex.Message}");
+                }
+            }
+
+            // Convert absolute paths to repo-root-relative FilterPath objects.
+            return results
+                .Select(p =>
+                {
+                    string repoRelative = Path.GetRelativePath(repoRoot, p).Replace('\\', '/');
+                    return new FilterPath(":/" + repoRelative, string.Empty);
+                })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Returns a sequence of version.json file paths found by interpreting each of the given
+        /// input paths. Directories are searched recursively; a path directly to a version.json file
+        /// is used as-is without recursive search.
+        /// </summary>
+        private static IEnumerable<string> FindVersionJsonPaths(string[]? paths)
+        {
+            IEnumerable<string> searchRoots = paths is { Length: > 0 }
+                ? paths
+                : [Directory.GetCurrentDirectory()];
+
+            foreach (string path in searchRoots)
+            {
+                string fullPath = Path.GetFullPath(path);
+
+                if (string.Equals(Path.GetFileName(fullPath), VersionFile.JsonFileName, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Direct path to a version.json file – use it without recursive search.
+                    if (File.Exists(fullPath))
+                    {
+                        yield return fullPath;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"File not found: {fullPath}");
+                    }
+                }
+                else if (Directory.Exists(fullPath))
+                {
+                    // Directory – recursively find all version.json files.
+                    foreach (string versionJson in Directory.EnumerateFiles(fullPath, VersionFile.JsonFileName, SearchOption.AllDirectories))
+                    {
+                        yield return versionJson;
+                    }
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Path not found: {fullPath}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the default project file extensions plus any extras provided on the command line.
+        /// </summary>
+        private static IReadOnlyList<string> GetProjectExtensions(string[]? extraExtensions)
+        {
+            var extensions = new List<string> { ".csproj", ".vbproj", ".fsproj", ".vcxproj" };
+            if (extraExtensions is { Length: > 0 })
+            {
+                foreach (string ext in extraExtensions)
+                {
+                    string normalized = ext.StartsWith('.') ? ext : "." + ext;
+                    if (!extensions.Contains(normalized, StringComparer.OrdinalIgnoreCase))
+                    {
+                        extensions.Add(normalized);
+                    }
+                }
+            }
+
+            return extensions;
+        }
+
+        /// <summary>
+        /// Determines whether <paramref name="absolutePath"/> is located within the repository root.
+        /// </summary>
+        private static bool IsWithinRepo(string absolutePath, string repoRoot)
+        {
+            string normalizedPath = Path.GetFullPath(absolutePath);
+            string normalizedRoot = Path.GetFullPath(repoRoot).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
+
+            StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            return normalizedPath.StartsWith(normalizedRoot, comparison);
+        }
+
+#nullable restore
         private static async Task<string> GetLatestPackageVersionAsync(string packageId, string root, IReadOnlyList<string> sources, CancellationToken cancellationToken = default)
         {
             ISettings settings = Settings.LoadDefaultSettings(root);

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -1132,7 +1132,7 @@ namespace Nerdbank.GitVersioning.Tool
 
                 try
                 {
-                    IReadOnlyList<FilterPath> computed = ComputePathFilters(versionJsonDir, context.WorkingTreePath, projectExtensions, allVersionJsonDirs);
+                    IReadOnlyList<FilterPath> computed = ComputePathFilters(versionJsonDir, context.WorkingTreePath, projectExtensions, allVersionJsonDirs, context);
 
                     // Skip version.json files that have no associated projects
                     if (computed.Count == 0)
@@ -1209,12 +1209,14 @@ namespace Nerdbank.GitVersioning.Tool
         /// <param name="repoRoot">The absolute path to the root of the git repository.</param>
         /// <param name="projectExtensions">The MSBuild project file extensions to search for.</param>
         /// <param name="versionJsonDirs">Set of all other version.json directories (for boundary checking).</param>
+        /// <param name="gitContext">The git context for accessing ignore rules.</param>
         /// <returns>A sorted, deduplicated list of repo-root-relative <see cref="FilterPath"/> objects, or empty if no projects found.</returns>
         private static IReadOnlyList<FilterPath> ComputePathFilters(
             string versionJsonDir,
             string repoRoot,
             IReadOnlyList<string> projectExtensions,
-            ISet<string> versionJsonDirs)
+            ISet<string> versionJsonDirs,
+            GitContext gitContext)
         {
             // Find all project files under the version.json directory, but stop at other version.json directories.
             List<string> projectFiles = new();
@@ -1275,10 +1277,8 @@ namespace Nerdbank.GitVersioning.Tool
                         string importPath = Path.GetFullPath(import.ImportedProject.FullPath);
                         if (IsWithinRepo(importPath, repoRoot))
                         {
-                            // Skip files in obj and bin directories as they are generated
-                            string normalizedPath = importPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-                            if (normalizedPath.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}") ||
-                                normalizedPath.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+                            // Skip files that git would ignore (e.g., bin/, obj/ directories, per .gitignore)
+                            if (gitContext.IsIgnored(importPath))
                             {
                                 continue;
                             }

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -1123,7 +1123,7 @@ namespace Nerdbank.GitVersioning.Tool
                 anyFound = true;
                 string versionJsonDir = Path.GetDirectoryName(versionJsonPath)!;
 
-                using GitContext context = GitContext.Create(versionJsonDir, engine: GetEffectiveGitEngine());
+                using GitContext context = GitContext.Create(versionJsonDir, engine: GetEffectiveGitEngine(preferReadWrite: true));
                 if (!context.IsRepository)
                 {
                     Console.Error.WriteLine($"No git repository found for version.json at: {versionJsonPath}");

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -1226,18 +1226,22 @@ namespace Nerdbank.GitVersioning.Tool
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
-            // For each project in the transitive closure, use the MSBuild evaluation model
-            // to collect all imported files that reside within the repository.
+            // For each project in the transitive closure, add its directory to the results.
+            // We include entire project directories rather than individual files.
             var results = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (string projectFile in allProjectFiles)
             {
                 if (IsWithinRepo(projectFile, repoRoot))
                 {
-                    results.Add(projectFile);
+                    // Add the project directory, not the individual .csproj file
+                    string projectDir = Path.GetDirectoryName(projectFile)!;
+                    results.Add(projectDir);
                 }
             }
 
+            // For MSBuild imports, we add specific imported files (not their directories)
+            // since these are typically shared build files like Directory.Build.props
             using var collection = new ProjectCollection(globalProperties);
             foreach (string projectFile in allProjectFiles)
             {

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -1112,7 +1112,13 @@ namespace Nerdbank.GitVersioning.Tool
             bool anyFound = false;
             bool anyMismatch = false;
 
-            foreach (string versionJsonPath in FindVersionJsonPaths(paths))
+            // First, collect all version.json paths so we can use them for boundary checking
+            IEnumerable<string> allVersionJsonPaths = FindVersionJsonPaths(paths).ToList();
+            var allVersionJsonDirs = new HashSet<string>(
+                allVersionJsonPaths.Select(p => Path.GetDirectoryName(p)!),
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (string versionJsonPath in allVersionJsonPaths)
             {
                 anyFound = true;
                 string versionJsonDir = Path.GetDirectoryName(versionJsonPath)!;
@@ -1126,7 +1132,14 @@ namespace Nerdbank.GitVersioning.Tool
 
                 try
                 {
-                    IReadOnlyList<FilterPath> computed = ComputePathFilters(versionJsonDir, context.WorkingTreePath, projectExtensions);
+                    IReadOnlyList<FilterPath> computed = ComputePathFilters(versionJsonDir, context.WorkingTreePath, projectExtensions, allVersionJsonDirs);
+
+                    // Skip version.json files that have no associated projects
+                    if (computed.Count == 0)
+                    {
+                        continue;
+                    }
+
                     VersionOptions? versionOptions = context.VersionFile.GetWorkingCopyVersion(
                         VersionFileRequirements.NonMergedResult | VersionFileRequirements.AcceptInheritingFile);
 
@@ -1193,22 +1206,29 @@ namespace Nerdbank.GitVersioning.Tool
         /// <param name="versionJsonDir">The directory containing the version.json file.</param>
         /// <param name="repoRoot">The absolute path to the root of the git repository.</param>
         /// <param name="projectExtensions">The MSBuild project file extensions to search for.</param>
-        /// <returns>A sorted, deduplicated list of repo-root-relative <see cref="FilterPath"/> objects.</returns>
+        /// <param name="versionJsonDirs">Set of all other version.json directories (for boundary checking).</param>
+        /// <returns>A sorted, deduplicated list of repo-root-relative <see cref="FilterPath"/> objects, or empty if no projects found.</returns>
         private static IReadOnlyList<FilterPath> ComputePathFilters(
             string versionJsonDir,
             string repoRoot,
-            IReadOnlyList<string> projectExtensions)
+            IReadOnlyList<string> projectExtensions,
+            ISet<string> versionJsonDirs)
         {
-            // Find all project files under the version.json directory.
-            List<string> projectFiles = projectExtensions
-                .SelectMany(ext => Directory.EnumerateFiles(versionJsonDir, "*" + ext, SearchOption.AllDirectories))
+            // Find all project files under the version.json directory, but stop at other version.json directories.
+            List<string> projectFiles = new();
+            foreach (string ext in projectExtensions)
+            {
+                projectFiles.AddRange(FindProjectFilesRespectingBoundaries(versionJsonDir, ext, versionJsonDir, versionJsonDirs));
+            }
+
+            projectFiles = projectFiles
                 .Select(Path.GetFullPath)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
             if (projectFiles.Count == 0)
             {
-                Console.Error.WriteLine($"Warning: No project files found under: {versionJsonDir}");
+                // No projects under this version.json, return empty to signal it should be skipped
                 return [];
             }
 
@@ -1281,6 +1301,38 @@ namespace Nerdbank.GitVersioning.Tool
                     return new FilterPath(":/" + repoRelative, string.Empty);
                 })
                 .ToList();
+        }
+
+        /// <summary>
+        /// Recursively finds project files starting from searchDir, but stops descending into
+        /// directories that contain their own version.json files (except for the root startDir).
+        /// </summary>
+        private static IEnumerable<string> FindProjectFilesRespectingBoundaries(
+            string searchDir,
+            string projectExtension,
+            string startDir,
+            ISet<string> versionJsonDirs)
+        {
+            // Find all projects in the current directory
+            foreach (string file in Directory.EnumerateFiles(searchDir, "*" + projectExtension))
+            {
+                yield return file;
+            }
+
+            // Recursively search subdirectories, but skip those with their own version.json
+            foreach (string subDir in Directory.EnumerateDirectories(searchDir))
+            {
+                // Skip if this subdirectory (or any ancestor) has a version.json (except the start directory)
+                if (subDir != startDir && versionJsonDirs.Contains(subDir))
+                {
+                    continue;
+                }
+
+                foreach (string file in FindProjectFilesRespectingBoundaries(subDir, projectExtension, startDir, versionJsonDirs))
+                {
+                    yield return file;
+                }
+            }
         }
 
         /// <summary>

--- a/src/nbgv/nbgv.csproj
+++ b/src/nbgv/nbgv.csproj
@@ -10,10 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.PackageManagement" />
+    <PackageReference Include="NuGet.PackageManagement" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Locator" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Implements the `nbgv path-filters` command to automate discovery and maintenance of `pathFilters` in monorepo scenarios. This addresses [#1396](https://github.com/dotnet/Nerdbank.GitVersioning/issues/1396) by leveraging MSBuild's ProjectGraph API to efficiently compute transitive closure of project dependencies.

## What's New

Two new subcommands:

- **`nbgv path-filters check`** - Validates that `pathFilters` in all `version.json` files are complete and correct
- **`nbgv path-filters update`** - Automatically computes and updates `pathFilters` based on actual project structure

## Key Design Decisions

### MSBuild ProjectGraph for Dependency Discovery
- Uses the standard MSBuild ProjectGraph API to find transitive closure of project references
- Efficient single-pass analysis for monorepos of any size
- Naturally handles multi-framework projects and complex dependency graphs

### Respects version.json Boundaries
- When searching for projects under a `version.json`, stops at any subdirectory that has its own `version.json`
- Prevents root-level `version.json` from incorrectly claiming nested projects
- Allows independent versioning of different monorepo components

### Includes Entire Project Directories
- `pathFilters` specify project directories (e.g., `/ProjectA`) rather than individual `.csproj` files
- Cleaner, more intuitive filters: any source change under the directory triggers versioning
- Shared build files like `Directory.Build.props` are included as specific file paths

### Respects .gitignore Rules
- Uses `Repository.Ignore.IsPathIgnored()` to exclude all ignored files (including generated directories like `bin/`, `obj/`, `packages/`)
- Prevents build artifacts and NuGet cache files from being treated as source code
- Respects all `.gitignore` patterns configured in the repository

### Transitive Dependency Inclusion
- If project B references project A, B's `pathFilters` includes files imported by A
- This is correct: if A's build changes, B is affected via the project reference
- Ensures downstream projects version-bump when upstream dependencies change

## Documentation

Added comprehensive documentation in `docfx/docs/path-filters.md` covering:
- When to use these commands
- How the analysis works
- Important behaviors and edge cases
- Real-world examples showing monorepo scenarios
- CI integration recommendations

## Testing

Verified with a test directory containing:
- Root `version.json` (left untouched as it has no direct projects)
- Two nested components (A and B) with their own `version.json` files
- B depends on A; A imports shared `.props` files
- Both `check` and `update` subcommands produce correct results
- Shared imports are included in both components' `pathFilters`
- Generated files are properly excluded

Closes #1396