### PR TITLE
Merge latest Library.Template updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicrosoftTestingPlatformVersion>2.2.3</MicrosoftTestingPlatformVersion>
+    <MicrosoftTestingPlatformVersion>2.3.0</MicrosoftTestingPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Put repo-specific PackageVersion items in this group. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>

--- a/tools/GitHubActions.ps1
+++ b/tools/GitHubActions.ps1
@@ -8,6 +8,10 @@ function Add-GitHubActionsEnvVariable {
         [string]$Value
     )
 
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "GitHub Actions environment file must not be empty."
+    }
+
     if ([string]::IsNullOrWhiteSpace($Name)) {
         throw "GitHub Actions environment variable names must not be empty."
     }

--- a/tools/GitHubActions.ps1
+++ b/tools/GitHubActions.ps1
@@ -16,3 +16,18 @@ function Add-GitHubActionsEnvVariable {
     $delimiter = [guid]::NewGuid().ToString('N')
     [System.IO.File]::AppendAllText($Path, "$Name<<$delimiter`n$Value`n$delimiter`n", $utf8NoBom)
 }
+
+function Add-GitHubActionsPath {
+    param(
+        [string]$Path = $env:GITHUB_PATH,
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "GitHub Actions path file must not be empty."
+    }
+
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::AppendAllText($Path, "$Value`n", $utf8NoBom)
+}

--- a/tools/Set-EnvVars.ps1
+++ b/tools/Set-EnvVars.ps1
@@ -82,7 +82,7 @@ if ($PrependPath) {
             Write-Host "##vso[task.prependpath]$_"
         }
         if ($env:GITHUB_ACTIONS) {
-            Add-GitHubActionsEnvVariable -Name PATH -Value $newPathValue
+            Add-GitHubActionsPath -Value $_
         }
 
         $CmdEnvScript += "SET PATH=$_$pathDelimiter%PATH%"

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -52,12 +52,13 @@ $globalJson = Get-Content $PSScriptRoot/../global.json | ConvertFrom-Json
 $isMTP = $globalJson.test.runner -eq 'Microsoft.Testing.Platform'
 $extraArgs = @()
 $failedTests = 0
+$publishTrx = $PublishResults -and $env:TF_BUILD
 
 if ($isMTP) {
     if ($OnCI) { $extraArgs += '--no-progress' }
 
     $dumpSwitches = @()
-    if ($IsWindows) {
+    if ($IsWindows -and $env:TF_BUILD) {
         $dumpSwitches = @(
             ,'--hangdump'
             ,'--hangdump-timeout','120s'
@@ -71,11 +72,14 @@ if ($isMTP) {
         ,'--diagnostic-output-directory',$testLogs
         ,'--diagnostic-verbosity','Information'
         ,'--results-directory',$testLogs
-        ,'--report-trx'
     )
 
+    if ($publishTrx) {
+       $mtpArgs += '--report-trx'
+    }
+
     & $dotnet test --solution $RepoRoot `
-        --no-build `
+       --no-build `
         -c $Configuration `
         -bl:"$testBinLog" `
         --filter-not-trait 'TestCategory=FailsInCloudTest' `
@@ -85,24 +89,31 @@ if ($isMTP) {
         @extraArgs
     if ($LASTEXITCODE -ne 0) { $failedTests += 1 }
 
-    $trxFiles = Get-ChildItem -Recurse -Path $testLogs\*.trx
+    $trxFiles = @(Get-ChildItem -Recurse -Path $testLogs\*.trx -ErrorAction Ignore)
 } else {
     $testDiagLog = Join-Path $ArtifactStagingFolder (Join-Path test_logs diag.log)
+    $vstestArgs = @(
+        '--collect', 'Code Coverage;Format=cobertura',
+        '--settings', "$PSScriptRoot/test.runsettings",
+        '--blame-hang-timeout', '60s',
+        '--blame-crash',
+        '-bl:"$testBinLog"',
+        '--diag', "$testDiagLog;TraceLevel=info"
+    )
+    if ($publishTrx) {
+        $vstestArgs += '--logger'
+        $vstestArgs += 'trx'
+    }
+
     & $dotnet test $RepoRoot `
         --no-build `
         -c $Configuration `
         --filter "TestCategory!=FailsInCloudTest" `
-        --collect "Code Coverage;Format=cobertura" `
-        --settings "$PSScriptRoot/test.runsettings" `
-        --blame-hang-timeout 60s `
-        --blame-crash `
-        -bl:"$testBinLog" `
-        --diag "$testDiagLog;TraceLevel=info" `
-        --logger trx `
+        @vstestArgs `
         @extraArgs
     if ($LASTEXITCODE -ne 0) { $failedTests += 1 }
 
-    $trxFiles = Get-ChildItem -Recurse -Path $RepoRoot\test\*.trx
+    $trxFiles = @(Get-ChildItem -Recurse -Path $RepoRoot\test\*.trx -ErrorAction Ignore)
 }
 
 $unknownCounter = 0

--- a/tools/variables/_define.ps1
+++ b/tools/variables/_define.ps1
@@ -11,7 +11,9 @@
 param (
 )
 
-. "$PSScriptRoot\..\GitHubActions.ps1"
+if ($env:GITHUB_ACTIONS) {
+    . "$PSScriptRoot\..\GitHubActions.ps1"
+}
 
 (& "$PSScriptRoot\_all.ps1").GetEnumerator() |% {
     # Always use ALL CAPS for env var names since Azure Pipelines converts variable names to all caps and on non-Windows OS, env vars are case sensitive.


### PR DESCRIPTION
This syncs the repo with the latest Library.Template changes so it picks up the recent CI script improvements and template dependency updates.

It brings in the GitHub Actions PATH handling changes, avoids loading `GitHubActions.ps1` on Azure Pipelines, and updates `MicrosoftTestingPlatformVersion` to 2.3.0 while preserving this repo's existing package version overrides in `Directory.Packages.props`.

Validation notes:
- `dotnet restore` passed
- `dotnet build` passed
- `tools/dotnet-test-cloud.ps1` only failed in the `net472`/`net48` leg because the local machine is missing the VS 2019 `v142` toolset