### PR TITLE
Only bump version height for filtered-path changes against the first parent

### DIFF
--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
@@ -501,13 +501,17 @@ public static class LibGit2GitExtensions
                         ? null
                         : includePaths;
 
-                // If the diff between this commit and any of its parents
-                // touches a path that we care about, bump the height.
+                // Bump the height only if this commit changed a filtered path relative to its
+                // first parent (the mainline this commit extends). Changes contributed by other
+                // parents were already counted in those parents' heights, which flow in via
+                // maxHeightAmongParents; comparing against every parent instead would count merge
+                // commits that never touched the filtered path (e.g. merges of a stale branch
+                // whose filtered path lagged the mainline), inflating the version height.
                 // A no-parent commit is relevant if it introduces anything in the filtered path.
                 bool relevantCommit =
                     commit.Parents.Any()
-                        ? commit.Parents.Any(parent => ContainsRelevantChanges(commit.GetRepository().Diff
-                            .Compare<TreeChanges>(parent.Tree, commit.Tree, diffInclude, DiffOptions)))
+                        ? ContainsRelevantChanges(commit.GetRepository().Diff
+                            .Compare<TreeChanges>(commit.Parents.First().Tree, commit.Tree, diffInclude, DiffOptions))
                         : ContainsRelevantChanges(commit.GetRepository().Diff
                             .Compare<TreeChanges>(null, commit.Tree, diffInclude, DiffOptions));
 

--- a/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
@@ -149,22 +149,19 @@ internal static class GitExtensions
 
             if (pathFilters is not null)
             {
-                // If the diff between this commit and any of its parents
-                // touches a path that we care about, bump the height.
-                bool relevantCommit = false, anyParents = false;
-                foreach (GitObjectId parentId in commit.Parents)
+                // Bump the height only if this commit changed a filtered path relative to its
+                // first parent (the mainline this commit extends). Changes contributed by other
+                // parents were already counted in those parents' heights, which flow in via
+                // maxHeightAmongParents; comparing against every parent instead would count merge
+                // commits that never touched the filtered path (e.g. merges of a stale branch
+                // whose filtered path lagged the mainline), inflating the version height.
+                bool relevantCommit;
+                if (commit.Parents.Any())
                 {
-                    anyParents = true;
-                    GitCommit parent = repository.GetCommit(parentId);
-                    if (IsRelevantCommit(repository, commit, parent, pathFilters))
-                    {
-                        // No need to scan further, as a positive match will never turn negative.
-                        relevantCommit = true;
-                        break;
-                    }
+                    GitCommit firstParent = repository.GetCommit(commit.Parents.First());
+                    relevantCommit = IsRelevantCommit(repository, commit, firstParent, pathFilters);
                 }
-
-                if (!anyParents)
+                else
                 {
                     // A no-parent commit is relevant if it introduces anything in the filtered path.
                     relevantCommit = IsRelevantCommit(repository, commit, parent: default(GitCommit), pathFilters);

--- a/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
@@ -848,6 +848,48 @@ public abstract class VersionOracleTests : RepoTestBase
     }
 
     [Fact]
+    public void GetVersionHeight_MergeOfStaleBranchThatDidNotTouchFilteredPathDoesNotBumpHeight()
+    {
+        this.InitializeSourceControl();
+
+        string relativeDirectory = "some-sub-dir";
+
+        var versionData = VersionOptions.FromVersion(new Version("1.2"));
+        versionData.PathFilters = new[] { new FilterPath("./", relativeDirectory) };
+        this.WriteVersionFile(versionData, relativeDirectory);
+        Assert.Equal(1, this.GetVersionHeight(relativeDirectory));
+
+        // Branch off before the filtered folder advances, so the branch's copy of the folder lags the mainline.
+        string mainBranchName = this.LibGit2Repository.Head.FriendlyName;
+        Branch featureBranch = this.LibGit2Repository.CreateBranch("feature");
+
+        // On the mainline: a real edit to the filtered folder bumps the height.
+        string includedFilePath = Path.Combine(this.RepoPath, relativeDirectory, "included.txt");
+        File.WriteAllText(includedFilePath, "v1");
+        Commands.Stage(this.LibGit2Repository, includedFilePath);
+        this.LibGit2Repository.Commit("Edit filtered folder on main", this.Signer, this.Signer);
+        Assert.Equal(2, this.GetVersionHeight(relativeDirectory));
+
+        // On the (now stale) feature branch: edit only a file OUTSIDE the filtered folder.
+        Commands.Checkout(this.LibGit2Repository, featureBranch);
+        string outsideFilePath = Path.Combine(this.RepoPath, "outside.txt");
+        File.WriteAllText(outsideFilePath, "x");
+        Commands.Stage(this.LibGit2Repository, outsideFilePath);
+        this.LibGit2Repository.Commit("Edit outside the filtered folder on feature", this.Signer, this.Signer);
+
+        // Merge the stale feature branch back into the mainline as a non-fast-forward merge (as a PR merge would).
+        // The merge leaves the filtered folder identical to its first parent (main), so it must NOT bump the
+        // filtered height, even though the folder differs from the stale feature-branch (second) parent.
+        Commands.Checkout(this.LibGit2Repository, mainBranchName);
+        this.LibGit2Repository.Merge(
+            featureBranch,
+            this.Signer,
+            new MergeOptions { FastForwardStrategy = FastForwardStrategy.NoFastForward });
+
+        Assert.Equal(2, this.GetVersionHeight(relativeDirectory));
+    }
+
+    [Fact]
     public void GetVersionHeight_IntroducingFiltersIncrementsHeight()
     {
         this.InitializeSourceControl();


### PR DESCRIPTION
### Problem

When `pathFilters` are configured, the version-height walk marks a commit as height-relevant if the filtered path differs from **any** of its parents:

```csharp
commit.Parents.Any(parent => ContainsRelevantChanges(Compare(parent.Tree, commit.Tree, ...)))
```

For a non-fast-forward merge of a **stale branch** whose copy of the filtered path lagged the mainline, the merge tree is identical to its **first parent** (the mainline) but still differs from the **second parent** (the stale branch). The any-parent check therefore counts the merge as relevant and bumps the height, even though the merge introduced no change to the filtered path.

The practical consequence: routine PR merges of stale branches inflate the version height of a path-filtered project, so its version drifts upward with no actual change under the filtered path.

### Fix

Compare the filtered path against the **first parent only** — the mainline the commit extends. Changes contributed by other parents were already counted in those parents' own heights, which flow into the result via `maxHeightAmongParents`, so they are not lost. A root (no-parent) commit is still relevant if it introduces anything under the filtered path.

Applied to both backends:
- `src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs`
- `src/NerdBank.GitVersioning/Managed/GitExtensions.cs`

### Test

Added `GetVersionHeight_MergeOfStaleBranchThatDidNotTouchFilteredPathDoesNotBumpHeight` (runs against both backends): branches before the filtered folder advances, edits the folder on the mainline, edits only a file **outside** the folder on the stale branch, then non-fast-forward merges the stale branch back. The merge leaves the filtered folder identical to its first parent, so the height must stay at 2. This test fails before the fix (height 3) and passes after.