### PR TITLE
Restrict MSBuild package updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,11 @@
 		{
 			"matchPackageNames": ["LibGit2Sharp.NativeBinaries", "LibGit2Sharp"],
 			"groupName": "LibGit2Sharp"
+		},
+		{
+			"matchPackageNames": ["Microsoft.Build.Framework", "Microsoft.Build.Tasks.Core", "Microsoft.Build.Utilities.Core", "Microsoft.Build"],
+			"matchUpdateTypes": ["major", "minor"],
+			"enabled": false
 		}
 	]
 }


### PR DESCRIPTION
Prevent Renovate from applying major or minor updates to packages that share the MSBuildPackageVersion property, while allowing patch updates.