### PR TITLE
Fix GITHUB_ENV corruption from concurrent appends

### DIFF
--- a/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
+++ b/src/NerdBank.GitVersioning/CloudBuildServices/GitHubActions.cs
@@ -1,10 +1,18 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using Validation;
+
 namespace Nerdbank.GitVersioning.CloudBuildServices;
 
 internal class GitHubActions : ICloudBuild
 {
+    /// <summary>
+    /// The encoding GitHub Actions uses to read the file identified by the <c>GITHUB_ENV</c> environment variable.
+    /// </summary>
+    private static readonly Encoding EnvironmentFileEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
     /// <inheritdoc/>
     public bool IsApplicable => Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
 
@@ -42,8 +50,88 @@ internal class GitHubActions : ICloudBuild
     /// <inheritdoc/>
     public IReadOnlyDictionary<string, string> SetCloudBuildVariable(string name, string value, TextWriter stdout, TextWriter stderr)
     {
-        Utilities.FileOperationWithRetry(() => File.AppendAllLines(EnvironmentFile, new[] { $"{name}={value}" }));
+        AppendVariable(EnvironmentFile, name, value);
         return GetDictionaryFor(name, value);
+    }
+
+    /// <summary>
+    /// Appends a variable assignment to a GitHub Actions environment file.
+    /// </summary>
+    /// <param name="environmentFilePath">The path to the file identified by the <c>GITHUB_ENV</c> environment variable.</param>
+    /// <param name="name">The name of the variable to set. Must not be empty nor contain a newline.</param>
+    /// <param name="value">The value to assign to the variable. May be <see langword="null" />, empty, or contain newlines.</param>
+    /// <remarks>
+    /// <para>
+    /// Several MSBuild processes may run concurrently within one GitHub Actions step (e.g. when building
+    /// many projects or target frameworks in parallel) and every one of them may append to the same file.
+    /// This method therefore takes an exclusive lock on the file for the duration of the append.
+    /// </para>
+    /// <para>
+    /// The lock is essential on non-Windows platforms because .NET resolves <see cref="FileMode.Append" />
+    /// to a seek-to-end at the time the file is opened rather than to the <c>O_APPEND</c> open flag.
+    /// Concurrent appenders would otherwise each write at the same stale offset, silently overwriting one
+    /// another and leaving torn lines behind that GitHub Actions rejects with the error
+    /// <c>Unable to process file command 'env' successfully</c>.
+    /// </para>
+    /// </remarks>
+    internal static void AppendVariable(string environmentFilePath, string name, string value)
+    {
+        Requires.NotNullOrEmpty(environmentFilePath, nameof(environmentFilePath));
+        Requires.NotNullOrEmpty(name, nameof(name));
+        Requires.Argument(name.IndexOf('\n') < 0 && name.IndexOf('\r') < 0, nameof(name), "Variable names must not contain newlines.");
+
+        byte[] bytes = EnvironmentFileEncoding.GetBytes(FormatVariable(name, value ?? string.Empty));
+
+        Utilities.FileOperationWithRetry(() =>
+        {
+            // FileShare.None asks for an exclusive lock, which .NET honors on non-Windows platforms
+            // by way of an advisory flock on the file descriptor.
+            using FileStream stream = new(environmentFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+
+            // Guard against a prior writer that did not terminate its last line,
+            // which would otherwise merge that line with ours and corrupt both.
+            if (stream.Length > 0)
+            {
+                stream.Seek(-1, SeekOrigin.End);
+                if (stream.ReadByte() != '\n')
+                {
+                    stream.WriteByte((byte)'\n');
+                }
+            }
+
+            stream.Write(bytes, 0, bytes.Length);
+            stream.Flush();
+        });
+    }
+
+    /// <summary>
+    /// Formats a variable assignment using the syntax that GitHub Actions expects in the <c>GITHUB_ENV</c> file.
+    /// </summary>
+    /// <param name="name">The name of the variable.</param>
+    /// <param name="value">The value of the variable.</param>
+    /// <returns>A newline-terminated string to append to the environment file.</returns>
+    /// <remarks>
+    /// A value that spans multiple lines cannot use the <c>name=value</c> syntax, so a heredoc is used for those.
+    /// </remarks>
+    internal static string FormatVariable(string name, string value)
+    {
+        if (value.IndexOf('\n') < 0 && value.IndexOf('\r') < 0)
+        {
+            return $"{name}={value}\n";
+        }
+
+        // A delimiter that appears within the value would let the value terminate its own heredoc,
+        // so keep generating candidates until one is unique to this assignment.
+        string delimiter;
+        do
+        {
+            delimiter = $"NBGV_EOF_{Guid.NewGuid():N}";
+        }
+        while (value.IndexOf(delimiter, StringComparison.Ordinal) >= 0);
+
+        // Normalize the value's line endings so that the delimiter is guaranteed to start its own line.
+        string normalizedValue = value.Replace("\r\n", "\n").Replace('\r', '\n');
+        return $"{name}<<{delimiter}\n{normalizedValue}\n{delimiter}\n";
     }
 
     private static IReadOnlyDictionary<string, string> GetDictionaryFor(string variableName, string value)

--- a/src/Shared/Utilities.cs
+++ b/src/Shared/Utilities.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using Validation;
 
 namespace Nerdbank.GitVersioning;
@@ -10,26 +11,78 @@ internal static class Utilities
     private const int SharingViolation = unchecked((int)0x80070020); // ERROR_SHARING_VIOLATION
     private const int AccessDenied = unchecked((int)0x80070005);   // ERROR_ACCESS_DENIED
 
+    /// <summary>
+    /// How long <see cref="FileOperationWithRetry(Action)" /> keeps retrying a transient failure before giving up.
+    /// </summary>
+    private const int RetryTimeout = 5000;
+
+    /// <summary>
+    /// The longest a single backoff may last, in milliseconds.
+    /// </summary>
+    private const int MaxBackoff = 50;
+
+    private static readonly bool IsWindows =
+#if NETFRAMEWORK
+        true;
+#else
+        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
+#endif
+
+    [ThreadStatic]
+    private static Random random;
+
+    /// <summary>
+    /// Gets a pseudo-random number generator that belongs to the calling thread, since <see cref="Random" /> is not thread-safe.
+    /// </summary>
+    private static Random Random => random ??= new Random(Environment.CurrentManagedThreadId ^ Environment.TickCount);
+
+    /// <summary>
+    /// Invokes a file operation, retrying while it fails for a reason that another process or thread is expected to clear.
+    /// </summary>
+    /// <param name="operation">The operation to invoke. It must be safe to invoke more than once.</param>
+    /// <remarks>
+    /// Many instances of this library may run concurrently within one build, and several of them may contend over one file.
+    /// Backoffs are randomized so that a large set of contenders does not keep colliding in lock step.
+    /// </remarks>
     internal static void FileOperationWithRetry(Action operation)
     {
         Requires.NotNull(operation, nameof(operation));
 
-        for (int retriesLeft = 6; retriesLeft > 0; retriesLeft--)
+        Stopwatch timer = Stopwatch.StartNew();
+        int attempt = 0;
+        while (true)
         {
             try
             {
                 operation();
-                break;
+                return;
             }
-            catch (Exception ex) when (IsTransientFileAccessError(ex) && retriesLeft > 1)
+            catch (Exception ex) when (IsTransientFileAccessError(ex) && timer.ElapsedMilliseconds < RetryTimeout)
             {
-                Thread.Sleep(100);
-                continue;
+                int ceiling = Math.Min(MaxBackoff, 1 << Math.Min(attempt, 30));
+                Thread.Sleep(Random.Next(1, ceiling + 1));
+                attempt++;
             }
         }
     }
 
-    private static bool IsTransientFileAccessError(Exception ex) => ex is
-        IOException { HResult: SharingViolation } or
-        UnauthorizedAccessException { HResult: AccessDenied };
+    private static bool IsTransientFileAccessError(Exception ex) => ex switch
+    {
+        // Windows reports contention with well-known HRESULTs.
+        IOException { HResult: SharingViolation } => true,
+        UnauthorizedAccessException { HResult: AccessDenied } => true,
+
+        // No amount of waiting resolves these, on any platform.
+        FileNotFoundException or DirectoryNotFoundException or PathTooLongException => false,
+
+        // Non-Windows platforms report contention over the advisory lock that .NET takes on behalf of a
+        // restrictive FileShare as an IOException carrying a raw errno in HResult, and those values are not
+        // portable (EAGAIN is 11 on Linux but 35 on macOS, for example), so classify by type instead.
+        // Retrying an error that turns out not to be transient merely delays rethrowing it.
+        // UnauthorizedAccessException is deliberately excluded here because on these platforms it means
+        // EACCES or EPERM, which contention never causes.
+        IOException => !IsWindows,
+
+        _ => false,
+    };
 }

--- a/test/Nerdbank.GitVersioning.Tests/GitHubActionsTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/GitHubActionsTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nerdbank.GitVersioning.CloudBuildServices;
+using Xunit;
+
+public class GitHubActionsTests : IDisposable
+{
+    private readonly string environmentFile;
+
+    public GitHubActionsTests()
+    {
+        this.environmentFile = Path.Combine(Path.GetTempPath(), $"nbgv-github-env-{Guid.NewGuid():N}.txt");
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(this.environmentFile))
+        {
+            File.Delete(this.environmentFile);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void FormatVariable_SingleLineValue()
+    {
+        Assert.Equal("Name=Value\n", GitHubActions.FormatVariable("Name", "Value"));
+    }
+
+    [Fact]
+    public void FormatVariable_EmptyValue()
+    {
+        Assert.Equal("Name=\n", GitHubActions.FormatVariable("Name", string.Empty));
+    }
+
+    [Fact]
+    public void FormatVariable_ValueContainingEqualsSign()
+    {
+        // Only the first '=' is a separator, so this needs no special treatment.
+        Assert.Equal("Name=a=b\n", GitHubActions.FormatVariable("Name", "a=b"));
+    }
+
+    [Theory]
+    [InlineData("first\nsecond")]
+    [InlineData("first\r\nsecond")]
+    [InlineData("first\rsecond")]
+    public void FormatVariable_MultiLineValueUsesHeredoc(string value)
+    {
+        string actual = GitHubActions.FormatVariable("Name", value);
+        string[] lines = actual.Split('\n');
+
+        // Trailing newline produces a final empty element.
+        Assert.Equal(string.Empty, lines[lines.Length - 1]);
+        Assert.StartsWith("Name<<", lines[0], StringComparison.Ordinal);
+
+        string delimiter = lines[0].Substring("Name<<".Length);
+        Assert.NotEmpty(delimiter);
+        Assert.Equal(delimiter, lines[lines.Length - 2]);
+        Assert.Equal(new[] { "first", "second" }, lines.Skip(1).Take(lines.Length - 3));
+
+        // Line endings within the value must be normalized so the delimiter starts its own line.
+        Assert.DoesNotContain('\r', actual);
+    }
+
+    [Fact]
+    public void FormatVariable_HeredocDelimiterDoesNotAppearInValue()
+    {
+        string actual = GitHubActions.FormatVariable("Name", "a\nb");
+        string delimiter = actual.Split('\n')[0].Substring("Name<<".Length);
+        Assert.DoesNotContain(delimiter, "a\nb");
+    }
+
+    [Fact]
+    public void FormatVariable_HeredocDelimiterIsUniquePerCall()
+    {
+        // A predictable delimiter could be smuggled in by a value, so it must vary.
+        Assert.NotEqual(
+            GitHubActions.FormatVariable("Name", "a\nb"),
+            GitHubActions.FormatVariable("Name", "a\nb"));
+    }
+
+    [Fact]
+    public void AppendVariable_CreatesFile()
+    {
+        Assert.False(File.Exists(this.environmentFile));
+        GitHubActions.AppendVariable(this.environmentFile, "Name", "Value");
+        Assert.Equal("Name=Value\n", this.ReadEnvironmentFile());
+    }
+
+    [Fact]
+    public void AppendVariable_AppendsToExistingContent()
+    {
+        File.WriteAllText(this.environmentFile, "Existing=1\n");
+        GitHubActions.AppendVariable(this.environmentFile, "Name", "Value");
+        Assert.Equal("Existing=1\nName=Value\n", this.ReadEnvironmentFile());
+    }
+
+    [Fact]
+    public void AppendVariable_TerminatesAnUnterminatedLastLine()
+    {
+        File.WriteAllText(this.environmentFile, "Existing=1");
+        GitHubActions.AppendVariable(this.environmentFile, "Name", "Value");
+        Assert.Equal("Existing=1\nName=Value\n", this.ReadEnvironmentFile());
+    }
+
+    [Fact]
+    public void AppendVariable_NullValueIsTreatedAsEmpty()
+    {
+        GitHubActions.AppendVariable(this.environmentFile, "Name", null);
+        Assert.Equal("Name=\n", this.ReadEnvironmentFile());
+    }
+
+    [Fact]
+    public void AppendVariable_WritesUtf8WithoutPreamble()
+    {
+        GitHubActions.AppendVariable(this.environmentFile, "Name", "\u00e9");
+        Assert.Equal(new byte[] { (byte)'N', (byte)'a', (byte)'m', (byte)'e', (byte)'=', 0xC3, 0xA9, (byte)'\n' }, File.ReadAllBytes(this.environmentFile));
+    }
+
+    [Fact]
+    public void AppendVariable_RejectsInvalidArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() => GitHubActions.AppendVariable(null, "Name", "Value"));
+        Assert.Throws<ArgumentException>(() => GitHubActions.AppendVariable(string.Empty, "Name", "Value"));
+        Assert.Throws<ArgumentNullException>(() => GitHubActions.AppendVariable(this.environmentFile, null, "Value"));
+        Assert.Throws<ArgumentException>(() => GitHubActions.AppendVariable(this.environmentFile, string.Empty, "Value"));
+        Assert.Throws<ArgumentException>(() => GitHubActions.AppendVariable(this.environmentFile, "Na\nme", "Value"));
+    }
+
+    /// <summary>
+    /// Verifies that concurrent writers neither lose nor interleave their assignments.
+    /// </summary>
+    /// <remarks>
+    /// This is the regression test for the corruption that GitHub Actions reports as the error
+    /// <c>Unable to process file command 'env' successfully</c>. Many MSBuild processes (and threads within
+    /// them) can build projects in parallel within a single step, and every one of them appends the
+    /// version variables to the one file named by <c>GITHUB_ENV</c>.
+    /// </remarks>
+    [Fact]
+    public async Task AppendVariable_IsSafeForConcurrentWriters()
+    {
+        const int writers = 16;
+        const int writesPerWriter = 100;
+
+        var tasks = new Task[writers];
+        for (int w = 0; w < writers; w++)
+        {
+            int writer = w;
+            tasks[w] = Task.Run(
+                () =>
+                {
+                    for (int i = 0; i < writesPerWriter; i++)
+                    {
+                        // A value long enough that a torn write is very likely to be detected.
+                        GitHubActions.AppendVariable(this.environmentFile, $"NBGV_{writer}_{i}", new string((char)('a' + writer), 100) + i);
+                    }
+                },
+                TestContext.Current.CancellationToken);
+        }
+
+        await Task.WhenAll(tasks);
+
+        var expected = new HashSet<string>(StringComparer.Ordinal);
+        for (int w = 0; w < writers; w++)
+        {
+            for (int i = 0; i < writesPerWriter; i++)
+            {
+                expected.Add($"NBGV_{w}_{i}={new string((char)('a' + w), 100)}{i}");
+            }
+        }
+
+        string[] actual = this.ReadEnvironmentFile().Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(expected.Count, actual.Length);
+        Assert.Equal(expected, new HashSet<string>(actual, StringComparer.Ordinal));
+    }
+
+    private string ReadEnvironmentFile() => Encoding.UTF8.GetString(File.ReadAllBytes(this.environmentFile));
+}

--- a/test/Nerdbank.GitVersioning.Tests/Nerdbank.GitVersioning.Tests.csproj
+++ b/test/Nerdbank.GitVersioning.Tests/Nerdbank.GitVersioning.Tests.csproj
@@ -11,6 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\src\Shared\**\*.cs" LinkBase="Shared" />
+    <!-- Linked in (rather than reached via InternalsVisibleTo, which a strong-named assembly cannot grant
+         to this unsigned test assembly) so that its internal members can be tested directly. -->
+    <Compile Include="..\..\src\NerdBank.GitVersioning\CloudBuildServices\GitHubActions.cs" LinkBase="CloudBuildServices" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\..\src\Nerdbank.GitVersioning.Tasks\build\*.targets;..\..\src\Nerdbank.GitVersioning.Tasks\build\*.props;..\..\src\Nerdbank.GitVersioning.Tasks\build\*.proj">


### PR DESCRIPTION
GitHub Actions builds intermittently fail at the end of a successful `dotnet build` step with:

    ##[error]Unable to process file command 'env' successfully.
    ##[error]Value cannot be null. (Parameter 'name')

`SetCloudBuildVariable` appended to the file named by `GITHUB_ENV` with `File.AppendAllLines`. On non-Windows platforms .NET implements `FileMode.Append` as a seek-to-end performed when the file is opened rather than as the `O_APPEND` open flag, and `File.AppendAllLines` requests only `FileShare.Read`, which .NET maps to a *shared* advisory lock. Concurrent appenders therefore all write at the same stale offset.

A single build step runs many MSBuild processes (and threads) in parallel, each setting the version variables, so assignments overwrote one another. A reproduction with 8 concurrent writers each appending 200 assignments left only ~450 of the expected 1600 lines in the file, some of them torn mid-line. A torn line that happens to begin with `=` is what the runner reports as a null `name`.

Windows was unaffected: there `FileMode.Append` maps to `FILE_APPEND_DATA` and `FileShare.Read` denies a second writer outright, so the pre-existing retry loop serialized the writers.

Appends now take an exclusive lock (`FileShare.None`) for the duration of a seek-to-end plus write, which .NET honors on non-Windows platforms via `flock`. Alongside that:

* An unterminated trailing line in the file is now terminated before appending, so one truncated write cannot corrupt the next assignment.
* Values spanning multiple lines now use the heredoc syntax, matching `tools/GitHubActions.ps1`. `name=value` cannot represent them.
* Empty variable names are rejected rather than written out.

`Utilities.FileOperationWithRetry` needed two fixes to support this:

* It only recognized Windows HRESULTs as transient. Non-Windows platforms surface lock contention as an `IOException` carrying a raw errno, whose value is not portable (EAGAIN is 11 on Linux but 35 on macOS), so contention is now classified by exception type instead.
* Its fixed 100 ms backoff made contenders collide in lock step, and its budget of 6 attempts was exhausted by 48 concurrent writers. Backoff is now randomized and the budget is time-based. 128 concurrent writers performing 25,600 appends now complete in about 1.3 seconds.

Adds `GitHubActionsTests`, the first coverage of this provider. The concurrency test fails against the previous implementation.