### PR TITLE
Harden MSBuild task path handling

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/AssemblyVersionInfo.cs
@@ -53,7 +53,7 @@ namespace Nerdbank.GitVersioning.Tasks
         public string CodeLanguage { get; set; }
 
         [Required]
-        public string OutputFile { get; set; }
+        public ITaskItem OutputFile { get; set; }
 
         public bool EmitNonVersionCustomAttributes { get; set; }
 
@@ -69,7 +69,7 @@ namespace Nerdbank.GitVersioning.Tasks
 
         public string ThisAssemblyNamespace { get; set; }
 
-        public string AssemblyOriginatorKeyFile { get; set; }
+        public ITaskItem AssemblyOriginatorKeyFile { get; set; }
 
         public string AssemblyKeyContainerName { get; set; }
 
@@ -146,8 +146,9 @@ namespace Nerdbank.GitVersioning.Tasks
             string fileContent = this.BuildCode();
             if (fileContent is object)
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(this.OutputFile));
-                Utilities.FileOperationWithRetry(() => File.WriteAllText(this.OutputFile, fileContent));
+                string outputFile = this.OutputFile.GetMetadata("FullPath");
+                Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
+                Utilities.FileOperationWithRetry(() => File.WriteAllText(outputFile, fileContent));
             }
             else if (CodeDomProvider.IsDefinedLanguage(this.CodeLanguage))
             {
@@ -164,9 +165,10 @@ namespace Nerdbank.GitVersioning.Tasks
                         ns.Types.Add(this.CreateThisAssemblyClass());
                     }
 
-                    Directory.CreateDirectory(Path.GetDirectoryName(this.OutputFile));
+                    string outputFile = this.OutputFile.GetMetadata("FullPath");
+                    Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
                     FileStream file = null;
-                    Utilities.FileOperationWithRetry(() => file = File.OpenWrite(this.OutputFile));
+                    Utilities.FileOperationWithRetry(() => file = File.OpenWrite(outputFile));
                     using (file)
                     {
                         using (var fileWriter = new StreamWriter(file, new UTF8Encoding(true), 4096, leaveOpen: true))
@@ -195,8 +197,9 @@ namespace Nerdbank.GitVersioning.Tasks
             string fileContent = this.BuildCode();
             if (fileContent is object)
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(this.OutputFile));
-                Utilities.FileOperationWithRetry(() => File.WriteAllText(this.OutputFile, fileContent));
+                string outputFile = this.OutputFile.GetMetadata("FullPath");
+                Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
+                Utilities.FileOperationWithRetry(() => File.WriteAllText(outputFile, fileContent));
             }
             else
             {
@@ -605,11 +608,14 @@ namespace Nerdbank.GitVersioning.Tasks
             try
             {
                 byte[] publicKeyBytes = null;
-                if (!string.IsNullOrEmpty(this.AssemblyOriginatorKeyFile) && File.Exists(this.AssemblyOriginatorKeyFile))
+                FileInfo keyFile = this.AssemblyOriginatorKeyFile is object
+                    ? new FileInfo(this.AssemblyOriginatorKeyFile.GetMetadata("FullPath"))
+                    : null;
+                if (keyFile is object && keyFile.Exists)
                 {
-                    if (Path.GetExtension(this.AssemblyOriginatorKeyFile).Equals(".snk", StringComparison.OrdinalIgnoreCase))
+                    if (keyFile.Extension.Equals(".snk", StringComparison.OrdinalIgnoreCase))
                     {
-                        byte[] keyBytes = File.ReadAllBytes(this.AssemblyOriginatorKeyFile);
+                        byte[] keyBytes = File.ReadAllBytes(keyFile.FullName);
                         bool publicKeyOnly = keyBytes[0] != 0x07;
                         publicKeyBytes = publicKeyOnly ? keyBytes : GetPublicKeyFromKeyPair(keyBytes);
                     }

--- a/src/Nerdbank.GitVersioning.Tasks/CompareFiles.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/CompareFiles.cs
@@ -51,14 +51,11 @@ namespace Nerdbank.GitVersioning.Tasks
         /// Tests whether a file is up to date with respect to another,
         /// based on existence, last write time and file size.
         /// </summary>
-        /// <param name="sourcePath">The source path.</param>
-        /// <param name="destPath">The dest path.</param>
+        /// <param name="sourceInfo">The source file.</param>
+        /// <param name="destInfo">The destination file.</param>
         /// <returns><see langword="true"/> if the files are the same; <see langword="false"/> if the files are different.</returns>
-        internal static bool FastFileEqualityCheck(string sourcePath, string destPath)
+        internal static bool FastFileEqualityCheck(FileInfo sourceInfo, FileInfo destInfo)
         {
-            FileInfo sourceInfo = new FileInfo(sourcePath);
-            FileInfo destInfo = new FileInfo(destPath);
-
             if (sourceInfo.Exists ^ destInfo.Exists)
             {
                 // Either the source file or the destination file is missing.
@@ -86,7 +83,9 @@ namespace Nerdbank.GitVersioning.Tasks
 
             for (int i = 0; i < this.OriginalItems.Length; i++)
             {
-                if (!this.IsContentOfFilesTheSame(this.OriginalItems[i].ItemSpec, this.NewItems[i].ItemSpec))
+                FileInfo originalFile = new(this.OriginalItems[i].GetMetadata("FullPath"));
+                FileInfo newFile = new(this.NewItems[i].GetMetadata("FullPath"));
+                if (!this.IsContentOfFilesTheSame(originalFile, newFile))
                 {
                     return false;
                 }
@@ -95,29 +94,29 @@ namespace Nerdbank.GitVersioning.Tasks
             return true;
         }
 
-        private bool IsContentOfFilesTheSame(string file1, string file2)
+        private bool IsContentOfFilesTheSame(FileInfo file1, FileInfo file2)
         {
             // If exactly one file is missing, that's different.
-            if (File.Exists(file1) ^ File.Exists(file2))
+            if (file1.Exists ^ file2.Exists)
             {
                 return false;
             }
 
             // If both are missing, that's the same.
-            if (!File.Exists(file1))
+            if (!file1.Exists)
             {
                 return true;
             }
 
-            if (new FileInfo(file1).Length != new FileInfo(file2).Length)
+            if (file1.Length != file2.Length)
             {
                 return false;
             }
 
             // If both are present, we need to do a content comparison.
             // Keep our comparison simple by loading both in memory.
-            byte[] file1Content = File.ReadAllBytes(file1);
-            byte[] file2Content = File.ReadAllBytes(file2);
+            byte[] file1Content = File.ReadAllBytes(file1.FullName);
+            byte[] file2Content = File.ReadAllBytes(file2.FullName);
 
             // One more sanity check.
             if (file1Content.Length != file2Content.Length)

--- a/src/Nerdbank.GitVersioning.Tasks/NativeVersionInfo.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/NativeVersionInfo.cs
@@ -78,7 +78,7 @@ END
         private CodeGenerator generator;
 
         [Required]
-        public string OutputFile { get; set; }
+        public ITaskItem OutputFile { get; set; }
 
         [Required]
         public string CodeLanguage { get; set; }
@@ -131,8 +131,9 @@ END
 
                 this.generator.EndFile();
 
-                Directory.CreateDirectory(Path.GetDirectoryName(this.OutputFile));
-                Utilities.FileOperationWithRetry(() => File.WriteAllText(this.OutputFile, this.generator.GetCode(), Encoding.Unicode));
+                string outputFile = this.OutputFile.GetMetadata("FullPath");
+                Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
+                Utilities.FileOperationWithRetry(() => File.WriteAllText(outputFile, this.generator.GetCode(), Encoding.Unicode));
             }
 
             return !this.Log.HasLoggedErrors;

--- a/src/Nerdbank.GitVersioning.Tasks/SetCloudBuildVariables.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/SetCloudBuildVariables.cs
@@ -20,6 +20,11 @@ namespace Nerdbank.GitVersioning.Tasks
 
         public string CloudBuildNumber { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether cloud build output should be redirected through the MSBuild log.
+        /// </summary>
+        public bool RedirectOutput { get; set; }
+
         /// <inheritdoc/>
         public override bool Execute()
         {
@@ -31,11 +36,10 @@ namespace Nerdbank.GitVersioning.Tasks
                 // Take care in a unit test environment because it would actually
                 // adversely impact the build variables of the cloud build underway that
                 // is running the tests.
-                bool isUnitTest = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("_NBGV_UnitTest"));
                 var testStdOut = new StringBuilder();
                 var testStdErr = new StringBuilder();
-                TextWriter stdout = isUnitTest ? new StringWriter(testStdOut) : Console.Out;
-                TextWriter stderr = isUnitTest ? new StringWriter(testStdErr) : Console.Error;
+                TextWriter stdout = this.RedirectOutput ? new StringWriter(testStdOut) : Console.Out;
+                TextWriter stderr = this.RedirectOutput ? new StringWriter(testStdErr) : Console.Error;
 
                 if (!string.IsNullOrWhiteSpace(this.CloudBuildNumber))
                 {
@@ -67,7 +71,7 @@ namespace Nerdbank.GitVersioning.Tasks
                     Environment.SetEnvironmentVariable(item.Key, item.Value);
                 }
 
-                if (isUnitTest)
+                if (this.RedirectOutput)
                 {
                     this.PipeOutputToMSBuildLog(testStdOut.ToString(), warning: false);
                     this.PipeOutputToMSBuildLog(testStdErr.ToString(), warning: true);

--- a/src/Nerdbank.GitVersioning.Tasks/StampMcpServerJson.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/StampMcpServerJson.cs
@@ -14,13 +14,13 @@ public class StampMcpServerJson : Microsoft.Build.Utilities.Task
     /// Gets or sets the path to the source server.json file.
     /// </summary>
     [Required]
-    public string SourceServerJson { get; set; }
+    public ITaskItem SourceServerJson { get; set; }
 
     /// <summary>
     /// Gets or sets the path where the stamped server.json file should be written.
     /// </summary>
     [Required]
-    public string OutputServerJson { get; set; }
+    public ITaskItem OutputServerJson { get; set; }
 
     /// <summary>
     /// Gets or sets the version to stamp into the server.json file.
@@ -36,31 +36,33 @@ public class StampMcpServerJson : Microsoft.Build.Utilities.Task
     {
         try
         {
-            if (string.IsNullOrEmpty(this.SourceServerJson) || string.IsNullOrEmpty(this.OutputServerJson) || string.IsNullOrEmpty(this.Version))
+            if (this.SourceServerJson is null || this.OutputServerJson is null || string.IsNullOrEmpty(this.Version))
             {
                 this.Log.LogError("SourceServerJson, OutputServerJson, and Version are required parameters.");
                 return !this.Log.HasLoggedErrors;
             }
 
-            if (!File.Exists(this.SourceServerJson))
+            string sourceServerJson = this.SourceServerJson.GetMetadata("FullPath");
+            string outputServerJson = this.OutputServerJson.GetMetadata("FullPath");
+            if (!File.Exists(sourceServerJson))
             {
-                this.Log.LogError($"Source server.json file not found: {this.SourceServerJson}");
+                this.Log.LogError($"Source server.json file not found: {sourceServerJson}");
                 return !this.Log.HasLoggedErrors;
             }
 
             // Ensure output directory exists
-            string outputDir = Path.GetDirectoryName(this.OutputServerJson);
+            string outputDir = Path.GetDirectoryName(outputServerJson);
             if (!string.IsNullOrEmpty(outputDir))
             {
                 Directory.CreateDirectory(outputDir);
             }
 
             // Read the server.json file and replace version placeholders
-            string jsonContent = File.ReadAllText(this.SourceServerJson);
+            string jsonContent = File.ReadAllText(sourceServerJson);
             jsonContent = jsonContent.Replace("\"0.0.0-placeholder\"", $"\"{this.Version}\"");
 
-            File.WriteAllText(this.OutputServerJson, jsonContent);
-            this.Log.LogMessage(MessageImportance.Low, $"Stamped version '{this.Version}' into server.json: {this.OutputServerJson}");
+            File.WriteAllText(outputServerJson, jsonContent);
+            this.Log.LogMessage(MessageImportance.Low, $"Stamped version '{this.Version}' into server.json: {outputServerJson}");
         }
         catch (Exception ex)
         {

--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -124,7 +124,8 @@
         AfterTargets="GetBuildVersion"
         Condition=" '@(CloudBuildVersionVars)' != '' and '$(NBGV_SetCloudBuildVersionVars)' != 'false' ">
     <Nerdbank.GitVersioning.Tasks.SetCloudBuildVariables
-      CloudBuildVersionVars="@(CloudBuildVersionVars)">
+      CloudBuildVersionVars="@(CloudBuildVersionVars)"
+      RedirectOutput="$(_NBGV_UnitTest)">
       <Output TaskParameter="MSBuildPropertyUpdates" ItemName="_MSBuildPropertyUpdates_Vars" />
     </Nerdbank.GitVersioning.Tasks.SetCloudBuildVariables>
     <CreateProperty Value="%(_MSBuildPropertyUpdates_Vars.Value)" Condition=" '@(_MSBuildPropertyUpdates_Vars)' != '' ">
@@ -137,7 +138,8 @@
         AfterTargets="GetBuildVersion"
         Condition=" '$(CloudBuildNumber)' != '' ">
     <Nerdbank.GitVersioning.Tasks.SetCloudBuildVariables
-      CloudBuildNumber="$(CloudBuildNumber)">
+      CloudBuildNumber="$(CloudBuildNumber)"
+      RedirectOutput="$(_NBGV_UnitTest)">
       <Output TaskParameter="MSBuildPropertyUpdates" ItemName="_MSBuildPropertyUpdates_BuildNumber" />
     </Nerdbank.GitVersioning.Tasks.SetCloudBuildVariables>
     <CreateProperty Value="%(_MSBuildPropertyUpdates_BuildNumber.Value)" Condition=" '@(_MSBuildPropertyUpdates_BuildNumber)' != '' ">

--- a/test/Nerdbank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -479,6 +479,7 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
         this.LoadTargetsIntoProjectCollection();
         this.testProject = this.CreateProjectRootElement(this.projectDirectory, "test.prj");
         this.globalProperties.Add("NerdbankGitVersioningTasksPath", Environment.CurrentDirectory + "\\");
+        this.globalProperties.Add("_NBGV_UnitTest", "true");
         Environment.SetEnvironmentVariable("_NBGV_UnitTest", "true");
 
         // Sterilize the test of any environment variables.


### PR DESCRIPTION
MSBuild task path parameters were being flattened to strings, which loses the project-relative path context carried by MSBuild items. This preserves that context so task file operations do not depend on a shared working directory.

## Changes

- Retype path-bearing task parameters as `ITaskItem` and consume their `FullPath` metadata.
- Resolve `CompareFiles` inputs once as `FileInfo` instances and use rooted paths for comparisons.
- Pass output-redirection intent into `SetCloudBuildVariables` explicitly instead of reading process environment state.
- Keep raw console output and process environment updates unchanged because they are part of the existing cloud-build integration behavior.

## Testing

- Built `Nerdbank.GitVersioning.Tests` in Release for `net472` and `net10.0` with warnings as errors.
- Ran all 62 `BuildIntegrationManagedTests` cases on `net10.0`.