### PR TITLE
Make prepare-release merge optional

### DIFF
--- a/docfx/docs/nbgv-cli.md
+++ b/docfx/docs/nbgv-cli.md
@@ -74,6 +74,15 @@ This will:
    This avoids having to resolve the conflict when merging the branch at a later
    time.
 
+To leave the release and main branches unmerged, pass `--no-merge`:
+
+```ps1
+nbgv prepare-release --no-merge
+```
+
+This is useful for branching models where fixes flow from the main branch to
+release branches by cherry-picking instead of merging release branches back.
+
 You can optionally include a prerelease tag on the release branch, e.g. when
 you want to do some stabilization first. This can be achieved by passing a
 tag to the command, e.g.:

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -140,12 +140,15 @@ public class ReleaseManager
     /// <param name="whatIf">
     /// If true, simulates the prepare-release operation and returns the versions that would be set without making any changes.
     /// </param>
+    /// <param name="mergeReleaseBranch">
+    /// A value indicating whether to merge the release branch back into the current branch.
+    /// </param>
     /// <returns>
     /// A <see cref="ReleaseInfo"/> object containing information about the release when <paramref name="whatIf"/> is true; otherwise null.
     /// </returns>
-    public ReleaseInfo PrepareRelease(string projectDirectory, string releaseUnstableTag = null, Version nextVersion = null, VersionOptions.ReleaseVersionIncrement? versionIncrement = null, ReleaseManagerOutputMode outputMode = default, string unformattedCommitMessage = null, bool whatIf = false)
+    public ReleaseInfo PrepareRelease(string projectDirectory, string releaseUnstableTag = null, Version nextVersion = null, VersionOptions.ReleaseVersionIncrement? versionIncrement = null, ReleaseManagerOutputMode outputMode = default, string unformattedCommitMessage = null, bool whatIf = false, bool mergeReleaseBranch = true)
     {
-        return this.PrepareReleaseCore(projectDirectory, releaseUnstableTag, nextVersion, versionIncrement, outputMode, unformattedCommitMessage, whatIf);
+        return this.PrepareReleaseCore(projectDirectory, releaseUnstableTag, nextVersion, versionIncrement, outputMode, unformattedCommitMessage, whatIf, mergeReleaseBranch);
     }
 
     private static bool IsVersionDecrement(SemanticVersion oldVersion, SemanticVersion newVersion)
@@ -197,10 +200,13 @@ public class ReleaseManager
     /// <param name="whatIf">
     /// If true, simulates the prepare-release operation and returns the versions that would be set without making any changes.
     /// </param>
+    /// <param name="mergeReleaseBranch">
+    /// A value indicating whether to merge the release branch back into the current branch.
+    /// </param>
     /// <returns>
     /// A <see cref="ReleaseInfo"/> object containing information about the release when <paramref name="whatIf"/> is true; otherwise null.
     /// </returns>
-    private ReleaseInfo PrepareReleaseCore(string projectDirectory, string releaseUnstableTag, Version nextVersion, VersionOptions.ReleaseVersionIncrement? versionIncrement, ReleaseManagerOutputMode outputMode, string unformattedCommitMessage, bool whatIf)
+    private ReleaseInfo PrepareReleaseCore(string projectDirectory, string releaseUnstableTag, Version nextVersion, VersionOptions.ReleaseVersionIncrement? versionIncrement, ReleaseManagerOutputMode outputMode, string unformattedCommitMessage, bool whatIf, bool mergeReleaseBranch)
     {
         Requires.NotNull(projectDirectory, nameof(projectDirectory));
 
@@ -310,13 +316,16 @@ public class ReleaseManager
             this.stdout.WriteLine($"{originalBranchName} branch now tracks v{nextDevVersion} development.");
         }
 
-        // Merge release branch back to main branch
-        var mergeOptions = new MergeOptions()
+        if (mergeReleaseBranch)
         {
-            CommitOnSuccess = true,
-            MergeFileFavor = MergeFileFavor.Ours,
-        };
-        repository.Merge(releaseBranch, this.GetSignature(repository), mergeOptions);
+            // Merge the release branch now to resolve the version.json conflict in favor of the development branch.
+            var mergeOptions = new MergeOptions()
+            {
+                CommitOnSuccess = true,
+                MergeFileFavor = MergeFileFavor.Ours,
+            };
+            repository.Merge(releaseBranch, this.GetSignature(repository), mergeOptions);
+        }
 
         if (outputMode == ReleaseManagerOutputMode.Json)
         {

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -350,6 +350,10 @@ namespace Nerdbank.GitVersioning.Tool
                 {
                     Description = "Simulates the prepare-release operation and prints the new version that would be set, but does not actually make any changes.",
                 };
+                var noMerge = new Option<bool>("--no-merge")
+                {
+                    Description = "Does not merge the release branch back into the current branch after updating both branches.",
+                };
                 var tagArgument = new Argument<string>("tag")
                 {
                     Description = "The prerelease tag to apply on the release branch (if any). If not specified, any existing prerelease tag will be removed. The preceding hyphen may be omitted.",
@@ -363,6 +367,7 @@ namespace Nerdbank.GitVersioning.Tool
                     format,
                     unformattedCommitMessage,
                     whatIf,
+                    noMerge,
                     tagArgument,
                 };
 
@@ -375,7 +380,8 @@ namespace Nerdbank.GitVersioning.Tool
                     var tagArgumentValue = parseResult.GetValue(tagArgument);
                     var unformattedCommitMessageValue = parseResult.GetValue(unformattedCommitMessage);
                     var whatIfValue = parseResult.GetValue(whatIf);
-                    return await OnPrepareReleaseCommand(projectValue, nextVersionValue, versionIncrementValue, formatValue, tagArgumentValue, unformattedCommitMessageValue, whatIfValue);
+                    var noMergeValue = parseResult.GetValue(noMerge);
+                    return await OnPrepareReleaseCommand(projectValue, nextVersionValue, versionIncrementValue, formatValue, tagArgumentValue, unformattedCommitMessageValue, whatIfValue, noMergeValue);
                 });
             }
 
@@ -984,7 +990,7 @@ namespace Nerdbank.GitVersioning.Tool
             return Task.FromResult((int)ExitCodes.OK);
         }
 
-        private static Task<int> OnPrepareReleaseCommand(string project, string nextVersion, string versionIncrement, string format, string tag, string unformattedCommitMessage, bool whatIf)
+        private static Task<int> OnPrepareReleaseCommand(string project, string nextVersion, string versionIncrement, string format, string tag, string unformattedCommitMessage, bool whatIf, bool noMerge)
         {
             // validate project path property
             string searchPath = GetSpecifiedOrCurrentDirectoryPath(project);
@@ -1055,7 +1061,7 @@ namespace Nerdbank.GitVersioning.Tool
             {
                 var releaseManager = new ReleaseManager(Console.Out, Console.Error);
 
-                ReleaseManager.ReleaseInfo releaseInfo = releaseManager.PrepareRelease(searchPath, tag, nextVersionParsed, versionIncrementParsed, outputMode, unformattedCommitMessage, whatIf);
+                ReleaseManager.ReleaseInfo releaseInfo = releaseManager.PrepareRelease(searchPath, tag, nextVersionParsed, versionIncrementParsed, outputMode, unformattedCommitMessage, whatIf, mergeReleaseBranch: !noMerge);
 
                 if (whatIf && outputMode == ReleaseManager.ReleaseManagerOutputMode.Json)
                 {

--- a/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -472,6 +472,24 @@ public abstract class ReleaseManagerTests : RepoTestBase
     }
 
     [Fact]
+    public void PrepareRelease_DoesNotMergeReleaseBranchWhenDisabled()
+    {
+        this.InitializeSourceControl();
+        this.WriteVersionFile(new VersionOptions() { Version = SemanticVersion.Parse("1.0-beta") });
+
+        Commit tipBeforePrepareRelease = this.LibGit2Repository.Head.Tip;
+        var releaseManager = new ReleaseManager();
+        releaseManager.PrepareRelease(this.RepoPath, null, null, null, default, null, whatIf: false, mergeReleaseBranch: false);
+
+        Commit developmentTip = this.LibGit2Repository.Head.Tip;
+        Commit releaseTip = this.LibGit2Repository.Branches["v1.0"].Tip;
+        Assert.Single(developmentTip.Parents);
+        Assert.Equal(tipBeforePrepareRelease.Id, developmentTip.Parents.Single().Id);
+        Assert.Single(releaseTip.Parents);
+        Assert.Equal(tipBeforePrepareRelease.Id, releaseTip.Parents.Single().Id);
+    }
+
+    [Fact]
     public void PrepareRelease_JsonOutput()
     {
         // create and configure repository

--- a/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -479,7 +479,7 @@ public abstract class ReleaseManagerTests : RepoTestBase
 
         Commit tipBeforePrepareRelease = this.LibGit2Repository.Head.Tip;
         var releaseManager = new ReleaseManager();
-        releaseManager.PrepareRelease(this.RepoPath, null, null, null, default, null, whatIf: false, mergeReleaseBranch: false);
+        releaseManager.PrepareRelease(this.RepoPath, mergeReleaseBranch: false);
 
         Commit developmentTip = this.LibGit2Repository.Head.Tip;
         Commit releaseTip = this.LibGit2Repository.Branches["v1.0"].Tip;


### PR DESCRIPTION
The `prepare-release` command always merges the new release branch back into the development branch, which adds an unnecessary merge commit for release-flow workflows that cherry-pick fixes from main into release branches.

Add a `--no-merge` option that skips only the final merge after both branches have been updated. Existing behavior remains the default. The `ReleaseManager` API exposes the same choice through an optional parameter, with commit-graph coverage for the unmerged result and CLI documentation for the new workflow.

Fixes #543