### PR TITLE
Support wildcards in path filters

### DIFF
--- a/docfx/docs/path-filters.md
+++ b/docfx/docs/path-filters.md
@@ -50,13 +50,18 @@ Path filters take on a variety of formats, and can specify paths relative to the
 
 Multiple path filters may also be specified. The order is irrelevant. After a path matches any non-exclude path filter, it will be run through all exclude path filter. If it matches, the path is ignored.
 
-| Path filter                                                                        | Description                                                                                                |
-| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `./quux.txt`<br>`file-here.txt`<br>`sub-dir/foo.txt`<br>`../sibling/inclusion.txt` | File will be included. Path is relative to the `version.json` file.                                        |
-| `./`<br>`sub-dir`<br>`../sibling`                                                  | Directory will be included. Path is relative to the `version.json` file.                                   |
-| `/root-file.txt`<br>`:/dir/file.txt`                                               | File will be included. Path is absolute (i.e., relative to the root of the repository).                    |
-| `:!bar.txt`<br>`:^../foo/baz.txt`                                                  | File will be excluded. Path is relative to the `version.json` file. `:!` and `:^` prefixes are synonymous. |
-| `:!/root-file.txt`                                                                 | File will be excluded. Path is absolute (i.e., relative to the root of the repository).                    |
+| Path filter                                                                        | Description                                                                                                                      |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `./quux.txt`<br>`file-here.txt`<br>`sub-dir/foo.txt`<br>`../sibling/inclusion.txt` | File will be included. Path is relative to the `version.json` file.                                                              |
+| `./`<br>`sub-dir`<br>`../sibling`                                                  | Directory will be included. Path is relative to the `version.json` file.                                                         |
+| `/root-file.txt`<br>`:/dir/file.txt`                                               | File will be included. Path is absolute (i.e., relative to the root of the repository).                                          |
+| `loc/*/MyProduct.*`                                                                | Matching paths will be included. `*` matches exactly one path segment and any number of characters within that segment.          |
+| `src/**/generated?.cs`                                                             | Matching paths will be included. A complete `**` segment matches zero or more path segments, and `?` matches one character.      |
+| `:!bar.txt`<br>`:^../foo/baz.txt`                                                  | File will be excluded. Path is relative to the `version.json` file. `:!` and `:^` prefixes are synonymous.                       |
+| `:!/root-file.txt`                                                                 | File will be excluded. Path is absolute (i.e., relative to the root of the repository).                                          |
+| `:!/loc/**/generated.*`                                                            | Matching paths will be excluded. Wildcards have the same meaning in inclusion and exclusion filters.                            |
+
+Wildcard matching is applied to each `/`-delimited path segment. `*` matches zero or more characters without crossing a `/`, `?` matches exactly one character without crossing a `/`, and a segment consisting only of `**` matches zero or more complete path segments. Matching honors the repository's `core.ignorecase` setting. As with a path without wildcards, when a filter matches a directory, all paths beneath that directory are included or excluded.
 
 ## Managing path filters with `nbgv path-filters`
 

--- a/src/NerdBank.GitVersioning/FilterPath.cs
+++ b/src/NerdBank.GitVersioning/FilterPath.cs
@@ -12,6 +12,7 @@ namespace Nerdbank.GitVersioning;
 public class FilterPath
 {
     private readonly bool hasWildcard;
+    private readonly string[] wildcardSegments;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FilterPath"/> class
@@ -74,6 +75,10 @@ public class FilterPath
         this.hasWildcard =
             this.RepoRelativePath.IndexOf('*') >= 0 ||
             this.RepoRelativePath.IndexOf('?') >= 0;
+        if (this.hasWildcard)
+        {
+            this.wildcardSegments = this.RepoRelativePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        }
     }
 
     /// <summary>
@@ -212,7 +217,7 @@ public class FilterPath
 
         if (this.HasWildcard)
         {
-            return true;
+            return this.MatchesWildcard(repoRelativePath, ignoreCase, matchDescendants: true);
         }
 
         StringComparison stringComparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
@@ -381,12 +386,12 @@ public class FilterPath
     private static bool CharactersEqual(char left, char right, bool ignoreCase) =>
         left == right || (ignoreCase && char.ToUpperInvariant(left) == char.ToUpperInvariant(right));
 
-    private bool MatchesWildcard(string repoRelativePath, bool ignoreCase)
+    private bool MatchesWildcard(string repoRelativePath, bool ignoreCase, bool matchDescendants = false)
     {
         string[] candidateSegments = repoRelativePath
             .Replace('\\', '/')
             .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-        string[] filterSegments = this.RepoRelativePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        string[] filterSegments = this.wildcardSegments!;
         var matches = new bool[filterSegments.Length + 1, candidateSegments.Length + 1];
 
         // A filter that identifies a directory also includes every path beneath it.
@@ -399,7 +404,8 @@ public class FilterPath
         {
             bool isRecursiveWildcard = filterSegments[filterIndex] == "**";
             matches[filterIndex, candidateSegments.Length] =
-                isRecursiveWildcard && matches[filterIndex + 1, candidateSegments.Length];
+                matchDescendants ||
+                (isRecursiveWildcard && matches[filterIndex + 1, candidateSegments.Length]);
 
             for (int candidateIndex = candidateSegments.Length - 1; candidateIndex >= 0; candidateIndex--)
             {

--- a/src/NerdBank.GitVersioning/FilterPath.cs
+++ b/src/NerdBank.GitVersioning/FilterPath.cs
@@ -11,6 +11,8 @@ namespace Nerdbank.GitVersioning;
 /// </summary>
 public class FilterPath
 {
+    private readonly bool hasWildcard;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="FilterPath"/> class
     /// from a pathspec-like string and a relative path within the repository.
@@ -26,7 +28,12 @@ public class FilterPath
     /// <item><c>:!relative/exclusion.txt</c></item>
     /// <item><c>:^relative/exclusion.txt</c></item>
     /// <item><c>:^/absolute/exclusion.txt</c></item>
+    /// <item><c>localization/*/messages.json</c></item>
+    /// <item><c>src/**/generated?.cs</c></item>
     /// </list>
+    /// Asterisks match zero or more characters within a path segment, question marks match one
+    /// character within a path segment, and a path segment consisting of two asterisks matches
+    /// zero or more path segments.
     /// </param>
     /// <param name="relativeTo">
     /// Path (relative to the root of the repository) that <paramref name="pathSpec"/> is relative to.
@@ -64,6 +71,9 @@ public class FilterPath
             this.RepoRelativePath
                 .Replace('\\', '/')
                 .TrimEnd('/');
+        this.hasWildcard =
+            this.RepoRelativePath.IndexOf('*') >= 0 ||
+            this.RepoRelativePath.IndexOf('?') >= 0;
     }
 
     /// <summary>
@@ -93,6 +103,11 @@ public class FilterPath
     internal bool IsRelative { get; }
 
     /// <summary>
+    /// Gets a value indicating whether this filter contains wildcard characters.
+    /// </summary>
+    internal bool HasWildcard => this.hasWildcard;
+
+    /// <summary>
     /// Determines if <paramref name="repoRelativePath"/> should be excluded by this <see cref="FilterPath"/>.
     /// </summary>
     /// <param name="repoRelativePath">Forward-slash delimited path (repo relative).</param>
@@ -114,6 +129,11 @@ public class FilterPath
         if (!this.IsExclude)
         {
             return false;
+        }
+
+        if (this.HasWildcard)
+        {
+            return this.MatchesWildcard(repoRelativePath, ignoreCase);
         }
 
         StringComparison stringComparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
@@ -150,6 +170,11 @@ public class FilterPath
             return true;
         }
 
+        if (this.HasWildcard)
+        {
+            return this.MatchesWildcard(repoRelativePath, ignoreCase);
+        }
+
         StringComparison stringComparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         return this.RepoRelativePath.Equals(repoRelativePath, stringComparison) ||
                repoRelativePath.StartsWith(this.RepoRelativePath + "/", stringComparison);
@@ -181,6 +206,11 @@ public class FilterPath
         }
 
         if (this.IsRoot)
+        {
+            return true;
+        }
+
+        if (this.HasWildcard)
         {
             return true;
         }
@@ -315,5 +345,71 @@ public class FilterPath
         result.Insert(0, "../", dirsToAscend);
         result.Append(string.Join("/", pathParts.Skip(commonParts)));
         return (dirsToAscend, result);
+    }
+
+    private static bool MatchesSegment(string pattern, string value, bool ignoreCase)
+    {
+        var matches = new bool[pattern.Length + 1, value.Length + 1];
+        matches[pattern.Length, value.Length] = true;
+
+        for (int patternIndex = pattern.Length - 1; patternIndex >= 0; patternIndex--)
+        {
+            if (pattern[patternIndex] == '*')
+            {
+                matches[patternIndex, value.Length] = matches[patternIndex + 1, value.Length];
+            }
+
+            for (int valueIndex = value.Length - 1; valueIndex >= 0; valueIndex--)
+            {
+                if (pattern[patternIndex] == '*')
+                {
+                    matches[patternIndex, valueIndex] =
+                        matches[patternIndex + 1, valueIndex] ||
+                        matches[patternIndex, valueIndex + 1];
+                }
+                else if (pattern[patternIndex] == '?' ||
+                    CharactersEqual(pattern[patternIndex], value[valueIndex], ignoreCase))
+                {
+                    matches[patternIndex, valueIndex] = matches[patternIndex + 1, valueIndex + 1];
+                }
+            }
+        }
+
+        return matches[0, 0];
+    }
+
+    private static bool CharactersEqual(char left, char right, bool ignoreCase) =>
+        left == right || (ignoreCase && char.ToUpperInvariant(left) == char.ToUpperInvariant(right));
+
+    private bool MatchesWildcard(string repoRelativePath, bool ignoreCase)
+    {
+        string[] candidateSegments = repoRelativePath
+            .Replace('\\', '/')
+            .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        string[] filterSegments = this.RepoRelativePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        var matches = new bool[filterSegments.Length + 1, candidateSegments.Length + 1];
+
+        // A filter that identifies a directory also includes every path beneath it.
+        for (int candidateIndex = 0; candidateIndex <= candidateSegments.Length; candidateIndex++)
+        {
+            matches[filterSegments.Length, candidateIndex] = true;
+        }
+
+        for (int filterIndex = filterSegments.Length - 1; filterIndex >= 0; filterIndex--)
+        {
+            bool isRecursiveWildcard = filterSegments[filterIndex] == "**";
+            matches[filterIndex, candidateSegments.Length] =
+                isRecursiveWildcard && matches[filterIndex + 1, candidateSegments.Length];
+
+            for (int candidateIndex = candidateSegments.Length - 1; candidateIndex >= 0; candidateIndex--)
+            {
+                matches[filterIndex, candidateIndex] = isRecursiveWildcard
+                    ? matches[filterIndex + 1, candidateIndex] || matches[filterIndex, candidateIndex + 1]
+                    : MatchesSegment(filterSegments[filterIndex], candidateSegments[candidateIndex], ignoreCase)
+                        && matches[filterIndex + 1, candidateIndex + 1];
+            }
+        }
+
+        return matches[0, 0];
     }
 }

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
@@ -473,21 +473,32 @@ public static class LibGit2GitExtensions
             VersionOptions? versionOptions = tracker.GetVersion(commit);
             IReadOnlyList<FilterPath>? pathFilters = versionOptions?.PathFilters;
 
-            var includePaths =
-                pathFilters
-                    ?.Where(filter => !filter.IsExclude)
-                    .Select(filter => filter.RepoRelativePath)
-                    .ToList();
+            List<string>? includePaths = null;
+            bool hasWildcardIncludes = false;
+            if (pathFilters is not null)
+            {
+                includePaths = new List<string>();
+                foreach (FilterPath filter in pathFilters)
+                {
+                    if (filter.IsInclude)
+                    {
+                        includePaths.Add(filter.RepoRelativePath);
+                        hasWildcardIncludes |= filter.HasWildcard;
+                    }
+                }
+            }
 
             var excludePaths = pathFilters?.Where(filter => filter.IsExclude).ToList();
 
             bool ignoreCase = commit.GetRepository().Config.Get<bool>("core.ignorecase")?.Value ?? false;
             bool ContainsRelevantChanges(IEnumerable<TreeEntryChanges> changes) =>
-                excludePaths?.Count == 0
+                !hasWildcardIncludes && excludePaths?.Count == 0
                     ? changes.Any()
                     //// If there is a single change that isn't excluded,
                     //// then this commit is relevant.
-                    : changes.Any(change => !excludePaths!.Any(exclude => exclude.Excludes(change.Path, ignoreCase)));
+                    : changes.Any(change =>
+                        (!hasWildcardIncludes || pathFilters!.Any(include => include.Includes(change.Path, ignoreCase))) &&
+                        !excludePaths!.Any(exclude => exclude.Excludes(change.Path, ignoreCase)));
 
             int height = 1;
 
@@ -497,7 +508,7 @@ public static class LibGit2GitExtensions
                 // paths refer to the root of the repository, then do not
                 // filter the diff at all.
                 List<string>? diffInclude =
-                    includePaths.Count == 0 || pathFilters!.Any(filter => filter.IsRoot)
+                    includePaths.Count == 0 || hasWildcardIncludes || pathFilters!.Any(filter => filter.IsRoot)
                         ? null
                         : includePaths;
 

--- a/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
@@ -135,16 +135,6 @@ internal static class GitExtensions
             VersionOptions? versionOptions = tracker.GetVersion(commit);
             IReadOnlyList<FilterPath>? pathFilters = versionOptions?.PathFilters;
 
-            var includePaths =
-                pathFilters
-                    ?.Where(filter => !filter.IsExclude)
-                    .Select(filter => filter.RepoRelativePath)
-                    .ToList();
-
-            var excludePaths = pathFilters?.Where(filter => filter.IsExclude).ToList();
-
-            bool ignoreCase = repository.IgnoreCase;
-
             int height = 1;
 
             if (pathFilters is not null)
@@ -261,11 +251,30 @@ internal static class GitExtensions
             foreach (KeyValuePair<string, GitTreeEntry> child in parent.Children)
             {
                 // Determine whether the change was relevant.
-                string? fullPath = Path.Combine(relativePath, child.Key);
+                string fullPath = Path.Combine(relativePath, child.Key);
 
                 bool isRelevant =
                     filters.Any(f => f.Includes(fullPath, repository.IgnoreCase))
                     && !filters.Any(f => f.Excludes(fullPath, repository.IgnoreCase));
+                bool useWildcardMatching = !isRelevant && filters.Any(f => f.HasWildcard);
+
+                if (useWildcardMatching)
+                {
+                    isRelevant =
+                        (!filters.Any(f => f.IsInclude) || filters.Any(f => f.Includes(fullPath, repository.IgnoreCase))
+                         || (!child.Value.IsFile && filters.Any(f => f.IncludesChildren(fullPath, repository.IgnoreCase))))
+                        && !filters.Any(f => f.Excludes(fullPath, repository.IgnoreCase));
+                }
+
+                if (useWildcardMatching && isRelevant && !child.Value.IsFile)
+                {
+                    isRelevant = IsRelevantCommit(
+                        repository,
+                        GitTree.Empty,
+                        repository.GetTree(child.Value.Sha),
+                        $"{fullPath}/",
+                        filters);
+                }
 
                 if (isRelevant)
                 {

--- a/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
@@ -254,19 +254,13 @@ internal static class GitExtensions
                 string fullPath = Path.Combine(relativePath, child.Key);
 
                 bool isRelevant =
-                    filters.Any(f => f.Includes(fullPath, repository.IgnoreCase))
+                    //// Either there are no include filters at all (i.e. everything is included), or there's an explicit include filter
+                    (!filters.Any(f => f.IsInclude) || filters.Any(f => f.Includes(fullPath, repository.IgnoreCase))
+                     || (!child.Value.IsFile && filters.Any(f => f.IncludesChildren(fullPath, repository.IgnoreCase))))
+                    //// The path is not excluded by any filters
                     && !filters.Any(f => f.Excludes(fullPath, repository.IgnoreCase));
-                bool useWildcardMatching = !isRelevant && filters.Any(f => f.HasWildcard);
 
-                if (useWildcardMatching)
-                {
-                    isRelevant =
-                        (!filters.Any(f => f.IsInclude) || filters.Any(f => f.Includes(fullPath, repository.IgnoreCase))
-                         || (!child.Value.IsFile && filters.Any(f => f.IncludesChildren(fullPath, repository.IgnoreCase))))
-                        && !filters.Any(f => f.Excludes(fullPath, repository.IgnoreCase));
-                }
-
-                if (useWildcardMatching && isRelevant && !child.Value.IsFile)
+                if (isRelevant && !child.Value.IsFile)
                 {
                     isRelevant = IsRelevantCommit(
                         repository,

--- a/src/NerdBank.GitVersioning/version.schema.json
+++ b/src/NerdBank.GitVersioning/version.schema.json
@@ -209,7 +209,7 @@
         },
         "pathFilters": {
           "type": "array",
-          "description": "An array of pathspec-like strings that are used to filter commits when calculating the version height. A commit will not increment the version height if its changed files are not included by these filters.\nPaths are relative to this file. Paths relative to the root of the repository can be specified with the `:/` prefix.\nExclusions can be specified with a `:^` prefix for relative paths, or a `:^/` prefix for paths relative to the root of the repository.\nAfter a path matches any non-exclude filter, it will be run through all exclude filters. If it matches, the path is ignored.",
+          "description": "An array of pathspec-like strings that are used to filter commits when calculating the version height. A commit will not increment the version height if its changed files are not included by these filters.\nPaths are relative to this file. Paths relative to the root of the repository can be specified with the `:/` prefix.\nExclusions can be specified with a `:^` prefix for relative paths, or a `:^/` prefix for paths relative to the root of the repository.\n`*` matches zero or more characters within one path segment, `?` matches one character within a path segment, and a complete `**` segment matches zero or more path segments.\nAfter a path matches any non-exclude filter, it will be run through all exclude filters. If it matches, the path is ignored.",
           "items": {
             "type": "string",
             "pattern": "^(:\\^|:!|:/|[^:])"

--- a/test/Nerdbank.GitVersioning.Tests/FilterPathTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/FilterPathTests.cs
@@ -152,6 +152,27 @@ public class FilterPathTests
         Assert.False(filter.Excludes("loc/en/generated.cs", false));
     }
 
+    [Theory]
+    [InlineData("loc")]
+    [InlineData("loc/en")]
+    [InlineData("loc/en/MyProduct.resources")]
+    public void WildcardFilterMayIncludeChildren(string repoRelativePath)
+    {
+        var filter = new FilterPath(":/loc/*/MyProduct.*", string.Empty);
+
+        Assert.True(filter.IncludesChildren(repoRelativePath, false));
+    }
+
+    [Theory]
+    [InlineData("localization")]
+    [InlineData("docs")]
+    public void WildcardFilterCannotIncludeChildren(string repoRelativePath)
+    {
+        var filter = new FilterPath(":/loc/*/MyProduct.*", string.Empty);
+
+        Assert.False(filter.IncludesChildren(repoRelativePath, false));
+    }
+
     [Fact]
     public void InvalidPathspecsThrow()
     {

--- a/test/Nerdbank.GitVersioning.Tests/FilterPathTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/FilterPathTests.cs
@@ -26,6 +26,8 @@ public class FilterPathTests
     [InlineData(":/", "foo", "")]
     [InlineData(":/absolutepath.txt", "foo", "absolutepath.txt")]
     [InlineData(":/bar/absolutepath.txt", "foo", "bar/absolutepath.txt")]
+    [InlineData(":/loc/*/MyProduct.*", "foo", "loc/*/MyProduct.*")]
+    [InlineData("../**/generated?.cs", "foo/bar", "foo/**/generated?.cs")]
     public void CanBeParsedToRepoRelativePath(string pathSpec, string relativeTo, string expected)
     {
         Assert.Equal(expected, new FilterPath(pathSpec, relativeTo).RepoRelativePath);
@@ -107,6 +109,49 @@ public class FilterPathTests
         Assert.False(new FilterPath(pathSpec, relativeTo).Excludes(repoRelativePath, false));
     }
 
+    [Theory]
+    [InlineData(":/loc/*/MyProduct.*", "loc/en/MyProduct.resx")]
+    [InlineData(":/loc/*/MyProduct.*", "loc/en/MyProduct.")]
+    [InlineData(":/loc/?/MyProduct.*", "loc/e/MyProduct.resx")]
+    [InlineData(":/loc/**/MyProduct.*", "loc/MyProduct.resx")]
+    [InlineData(":/loc/**/MyProduct.*", "loc/en/subdir/MyProduct.resx")]
+    [InlineData(":/**/MyProduct.*", "MyProduct.resx")]
+    [InlineData("localization/*/messages.json", "src/localization/en/messages.json")]
+    [InlineData(":/eng/*", "eng/product/src/file.cs")]
+    public void PathsCanBeIncludedWithWildcards(string pathSpec, string repoRelativePath)
+    {
+        Assert.True(new FilterPath(pathSpec, "src").Includes(repoRelativePath, false));
+    }
+
+    [Theory]
+    [InlineData(":/loc/*/MyProduct.*", "loc/en/subdir/MyProduct.resx")]
+    [InlineData(":/loc/?/MyProduct.*", "loc/en/MyProduct.resx")]
+    [InlineData(":/loc/*/MyProduct.*", "loc/en/OtherProduct.resx")]
+    [InlineData(":/loc/*/MyProduct.*", "loc/EN/myproduct.resx")]
+    public void PathsDoNotMatchWildcards(string pathSpec, string repoRelativePath)
+    {
+        Assert.False(new FilterPath(pathSpec, string.Empty).Includes(repoRelativePath, false));
+    }
+
+    [Fact]
+    public void WildcardMatchingCanIgnoreCase()
+    {
+        var filter = new FilterPath(":/loc/*/MyProduct.*", string.Empty);
+
+        Assert.True(filter.Includes("LOC/en/myproduct.resx", true));
+        Assert.False(filter.Includes("LOC/en/myproduct.resx", false));
+    }
+
+    [Fact]
+    public void PathsCanBeExcludedWithWildcards()
+    {
+        var filter = new FilterPath(":^/loc/**/generated?.cs", string.Empty);
+
+        Assert.True(filter.Excludes("loc/generated1.cs", false));
+        Assert.True(filter.Excludes("loc/en/subdir/generatedA.cs", false));
+        Assert.False(filter.Excludes("loc/en/generated.cs", false));
+    }
+
     [Fact]
     public void InvalidPathspecsThrow()
     {
@@ -129,6 +174,8 @@ public class FilterPathTests
     [InlineData("../Directory.Build.props", "./foo", "../Directory.Build.props")]
     [InlineData(":!/Directory.Build.props", "./foo", ":!/Directory.Build.props")]
     [InlineData(":!relative.txt", "./foo", ":!relative.txt")]
+    [InlineData(":/loc/*/MyProduct.*", "./foo", "/loc/*/MyProduct.*")]
+    [InlineData("../**/generated?.cs", "./foo", "../**/generated?.cs")]
     public void ToPathSpec(string pathSpec, string relativeTo, string expectedPathSpec)
     {
         Assert.Equal(expectedPathSpec, new FilterPath(pathSpec, relativeTo).ToPathSpec(relativeTo));

--- a/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
@@ -935,6 +935,52 @@ public abstract class VersionOracleTests : RepoTestBase
     }
 
     [Fact]
+    public void GetVersionHeight_DeletingDirectoryWithLiteralDescendantInclude()
+    {
+        this.InitializeSourceControl();
+
+        var versionData = VersionOptions.FromVersion(new Version("1.2"));
+        versionData.PathFilters = new[] { new FilterPath(":/included/tracked.txt", string.Empty) };
+        this.WriteVersionFile(versionData);
+        int initialHeight = this.GetVersionHeight();
+
+        string includedFilePath = Path.Combine(this.RepoPath, "included", "tracked.txt");
+        Directory.CreateDirectory(Path.GetDirectoryName(includedFilePath));
+        File.WriteAllText(includedFilePath, "hello");
+        Commands.Stage(this.LibGit2Repository, includedFilePath);
+        this.LibGit2Repository.Commit("Add included directory", this.Signer, this.Signer);
+        Assert.Equal(initialHeight + 1, this.GetVersionHeight());
+
+        Directory.Delete(Path.GetDirectoryName(includedFilePath), recursive: true);
+        Commands.Stage(this.LibGit2Repository, includedFilePath);
+        this.LibGit2Repository.Commit("Delete included directory", this.Signer, this.Signer);
+        Assert.Equal(initialHeight + 2, this.GetVersionHeight());
+    }
+
+    [Fact]
+    public void GetVersionHeight_DeletingDirectoryWithExcludeOnlyFilter()
+    {
+        this.InitializeSourceControl();
+
+        var versionData = VersionOptions.FromVersion(new Version("1.2"));
+        versionData.PathFilters = new[] { new FilterPath(":^/excluded", string.Empty) };
+        this.WriteVersionFile(versionData);
+        int initialHeight = this.GetVersionHeight();
+
+        string includedFilePath = Path.Combine(this.RepoPath, "included", "tracked.txt");
+        Directory.CreateDirectory(Path.GetDirectoryName(includedFilePath));
+        File.WriteAllText(includedFilePath, "hello");
+        Commands.Stage(this.LibGit2Repository, includedFilePath);
+        this.LibGit2Repository.Commit("Add included directory", this.Signer, this.Signer);
+        Assert.Equal(initialHeight + 1, this.GetVersionHeight());
+
+        Directory.Delete(Path.GetDirectoryName(includedFilePath), recursive: true);
+        Commands.Stage(this.LibGit2Repository, includedFilePath);
+        this.LibGit2Repository.Commit("Delete included directory", this.Signer, this.Signer);
+        Assert.Equal(initialHeight + 2, this.GetVersionHeight());
+    }
+
+    [Fact]
     public void GetVersionHeight_IncludeExcludeFilter()
     {
         this.InitializeSourceControl();

--- a/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
@@ -895,6 +895,46 @@ public abstract class VersionOracleTests : RepoTestBase
     }
 
     [Fact]
+    public void GetVersionHeight_WildcardIncludeFilter()
+    {
+        this.InitializeSourceControl();
+
+        var versionData = VersionOptions.FromVersion(new Version("1.2"));
+        versionData.PathFilters = new[]
+        {
+            new FilterPath(":/loc/*/MyProduct.*", string.Empty),
+            new FilterPath(":^/loc/ignored/**", string.Empty),
+        };
+        this.WriteVersionFile(versionData);
+        int initialHeight = this.GetVersionHeight();
+
+        string nonMatchingFilePath = Path.Combine(this.RepoPath, "loc", "en", "subdir", "MyProduct.resx");
+        Directory.CreateDirectory(Path.GetDirectoryName(nonMatchingFilePath));
+        File.WriteAllText(nonMatchingFilePath, "hello");
+        Commands.Stage(this.LibGit2Repository, nonMatchingFilePath);
+        this.LibGit2Repository.Commit("Add non-matching localization file", this.Signer, this.Signer);
+        Assert.Equal(initialHeight, this.GetVersionHeight());
+
+        string excludedFilePath = Path.Combine(this.RepoPath, "loc", "ignored", "MyProduct.resx");
+        Directory.CreateDirectory(Path.GetDirectoryName(excludedFilePath));
+        File.WriteAllText(excludedFilePath, "hello");
+        Commands.Stage(this.LibGit2Repository, excludedFilePath);
+        this.LibGit2Repository.Commit("Add excluded localization file", this.Signer, this.Signer);
+        Assert.Equal(initialHeight, this.GetVersionHeight());
+
+        string matchingFilePath = Path.Combine(this.RepoPath, "loc", "en", "MyProduct.resx");
+        File.WriteAllText(matchingFilePath, "hello");
+        Commands.Stage(this.LibGit2Repository, matchingFilePath);
+        this.LibGit2Repository.Commit("Add matching localization file", this.Signer, this.Signer);
+        Assert.Equal(initialHeight + 1, this.GetVersionHeight());
+
+        File.Delete(matchingFilePath);
+        Commands.Stage(this.LibGit2Repository, matchingFilePath);
+        this.LibGit2Repository.Commit("Delete matching localization file", this.Signer, this.Signer);
+        Assert.Equal(initialHeight + 2, this.GetVersionHeight());
+    }
+
+    [Fact]
     public void GetVersionHeight_IncludeExcludeFilter()
     {
         this.InitializeSourceControl();


### PR DESCRIPTION
Path filters currently require exact paths, making it impractical to include families of files such as localized resources across language directories. This adds segment-aware wildcard matching while preserving existing path-filter behavior.

- `*` matches zero or more characters within one path segment.
- `?` matches exactly one character within one path segment.
- A complete `**` segment matches zero or more path segments.
- Wildcards work in both inclusion and exclusion filters and honor `core.ignorecase`.
- Managed Git and LibGit2 apply the same matching semantics to additions, modifications, and deletions.

The non-wildcard hot path remains effectively unchanged: literal filters continue using the original string comparisons and LibGit2 native pathspec prefiltering. Wildcard segment arrays, matching tables, and broader diff processing are only used when a wildcard is present.

The schema and path-filter documentation describe the syntax, and tests cover parsing, matching, exclusions, case sensitivity, recursive matching, serialization, and version-height behavior across both Git engines and target frameworks.

Fixes #655