### PR TITLE
Handle unavailable NuGet sources during install

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="Nerdbank.GitVersioning.LKG" Version="3.8.80-alpha" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NuGet.PackageManagement" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.10" />
     <PackageVersion Include="System.Drawing.Common" Version="10.0.10" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />

--- a/src/Nerdbank.GitVersioning.Tasks/GitLoaderContext.cs
+++ b/src/Nerdbank.GitVersioning.Tasks/GitLoaderContext.cs
@@ -21,6 +21,7 @@ namespace Nerdbank.GitVersioning
     {
         public const string RuntimePath = "./runtimes";
         private readonly string nativeDependencyBasePath;
+        private readonly string? managedDependencyBasePath;
 
         private (string?, IntPtr) lastLoadedLibrary;
 
@@ -28,18 +29,32 @@ namespace Nerdbank.GitVersioning
         /// Initializes a new instance of the <see cref="GitLoaderContext"/> class.
         /// </summary>
         /// <param name="nativeDependencyBasePath">The path to the directory that contains the "runtimes" folder.</param>
-        public GitLoaderContext(string nativeDependencyBasePath)
+        /// <param name="managedDependencyBasePath">An optional path to probe for managed dependencies that are supplied by the .NET SDK.</param>
+        public GitLoaderContext(string nativeDependencyBasePath, string? managedDependencyBasePath = null)
         {
             this.nativeDependencyBasePath = nativeDependencyBasePath;
+            this.managedDependencyBasePath = managedDependencyBasePath;
         }
 
         /// <inheritdoc/>
         protected override Assembly Load(AssemblyName assemblyName)
         {
             string path = Path.Combine(Path.GetDirectoryName(typeof(GitLoaderContext).Assembly.Location)!, assemblyName.Name + ".dll");
-            return File.Exists(path)
-                ? this.LoadFromAssemblyPath(path)
-                : Default.LoadFromAssemblyName(assemblyName);
+            if (File.Exists(path))
+            {
+                return this.LoadFromAssemblyPath(path);
+            }
+
+            if (this.managedDependencyBasePath is not null)
+            {
+                path = Path.Combine(this.managedDependencyBasePath, assemblyName.Name + ".dll");
+                if (File.Exists(path))
+                {
+                    return this.LoadFromAssemblyPath(path);
+                }
+            }
+
+            return Default.LoadFromAssemblyName(assemblyName);
         }
 
         protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -72,10 +72,23 @@ namespace Nerdbank.GitVersioning.Tool
 
         public static int Main(string[] args)
         {
-            VisualStudioInstance msbuildInstance = MSBuildLocator.RegisterDefaults();
+            VisualStudioInstance msbuildInstance = null;
+            try
+            {
+                if (!MSBuildLocator.IsRegistered)
+                {
+                    msbuildInstance = MSBuildLocator.RegisterDefaults();
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                Console.Error.WriteLine($"Failed to locate MSBuild: {ex.Message}");
+                return (int)ExitCodes.InternalError;
+            }
+
             string thisAssemblyPath = typeof(Program).GetTypeInfo().Assembly.Location;
 
-            GitLoaderContext loaderContext = new(Path.GetDirectoryName(thisAssemblyPath), msbuildInstance.MSBuildPath);
+            GitLoaderContext loaderContext = new(Path.GetDirectoryName(thisAssemblyPath), msbuildInstance?.MSBuildPath);
             Assembly inContextAssembly = loaderContext.LoadFromAssemblyPath(thisAssemblyPath);
             Type innerProgramType = inContextAssembly.GetType(typeof(Program).FullName);
             object innerProgram = Activator.CreateInstance(innerProgramType);
@@ -1448,7 +1461,8 @@ namespace Nerdbank.GitVersioning.Tool
 
             return versions
                 .Where(version => !version.IsPrerelease)
-                .Max()
+                .OrderByDescending(version => version)
+                .FirstOrDefault()
                 ?.ToNormalizedString();
         }
 

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -14,9 +14,7 @@ using Nerdbank.GitVersioning.LibGit2;
 using Newtonsoft.Json;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.PackageManagement;
 using NuGet.Protocol.Core.Types;
-using NuGet.Resolver;
 using Validation;
 
 namespace Nerdbank.GitVersioning.Tool
@@ -74,9 +72,10 @@ namespace Nerdbank.GitVersioning.Tool
 
         public static int Main(string[] args)
         {
+            VisualStudioInstance msbuildInstance = MSBuildLocator.RegisterDefaults();
             string thisAssemblyPath = typeof(Program).GetTypeInfo().Assembly.Location;
 
-            GitLoaderContext loaderContext = new(Path.GetDirectoryName(thisAssemblyPath));
+            GitLoaderContext loaderContext = new(Path.GetDirectoryName(thisAssemblyPath), msbuildInstance.MSBuildPath);
             Assembly inContextAssembly = loaderContext.LoadFromAssemblyPath(thisAssemblyPath);
             Type innerProgramType = inContextAssembly.GetType(typeof(Program).FullName);
             object innerProgram = Activator.CreateInstance(innerProgramType);
@@ -466,20 +465,6 @@ namespace Nerdbank.GitVersioning.Tool
 
         private static int MainInner(string[] args)
         {
-            // Register MSBuild locator to ensure SDK resolvers are available for project evaluation.
-            // This must be called before any MSBuild code is loaded.
-            if (!MSBuildLocator.IsRegistered)
-            {
-                try
-                {
-                    MSBuildLocator.RegisterDefaults();
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine($"Warning: Failed to register MSBuildLocator: {ex.Message}");
-                }
-            }
-
             try
             {
                 RootCommand rootCommand = BuildCommandLine();
@@ -542,6 +527,38 @@ namespace Nerdbank.GitVersioning.Tool
                 path = context.WorkingTreePath;
             }
 
+            // Validate given sources
+            foreach (string src in source)
+            {
+                // TODO: Can declare Option<Uri> to validate argument during parsing.
+                if (!Uri.TryCreate(src, UriKind.Absolute, out Uri _))
+                {
+                    Console.Error.WriteLine($"\"{src}\" is not a valid NuGet package source.");
+                    return (int)ExitCodes.InvalidNuGetPackageSource;
+                }
+            }
+
+            string packageVersion;
+            try
+            {
+                packageVersion = await GetLatestPackageVersionAsync(PackageId, path, source);
+            }
+            catch (FatalProtocolException ex)
+            {
+                Console.Error.WriteLine($"Failed to query NuGet package sources: {ex.Message}");
+                Console.Error.WriteLine("Use the '--source' option to override the sources configured in NuGet.Config files.");
+                return (int)ExitCodes.PackageIdNotFound;
+            }
+
+            if (string.IsNullOrEmpty(packageVersion))
+            {
+                string verifyPhrase = source.Any()
+                    ? "Please verify the given 'source' option(s)."
+                    : "Please verify the package sources in the NuGet.Config files.";
+                Console.Error.WriteLine($"Latest stable version of the {PackageId} package could not be determined. " + verifyPhrase);
+                return (int)ExitCodes.PackageIdNotFound;
+            }
+
             VersionOptions existingOptions = context.VersionFile.GetVersion();
             if (existingOptions is not null)
             {
@@ -565,27 +582,6 @@ namespace Nerdbank.GitVersioning.Tool
             ProjectRootElement propsFile = File.Exists(directoryBuildPropsPath)
                 ? ProjectRootElement.Open(directoryBuildPropsPath)
                 : ProjectRootElement.Create(directoryBuildPropsPath);
-
-            // Validate given sources
-            foreach (string src in source)
-            {
-                // TODO: Can declare Option<Uri> to validate argument during parsing.
-                if (!Uri.TryCreate(src, UriKind.Absolute, out Uri _))
-                {
-                    Console.Error.WriteLine($"\"{src}\" is not a valid NuGet package source.");
-                    return (int)ExitCodes.InvalidNuGetPackageSource;
-                }
-            }
-
-            string packageVersion = GetLatestPackageVersionAsync(PackageId, path, source).GetAwaiter().GetResult();
-            if (string.IsNullOrEmpty(packageVersion))
-            {
-                string verifyPhrase = source.Any()
-                    ? "Please verify the given 'source' option(s)."
-                    : "Please verify the package sources in the NuGet.Config files.";
-                Console.Error.WriteLine($"Latest stable version of the {PackageId} package could not be determined. " + verifyPhrase);
-                return (int)ExitCodes.PackageIdNotFound;
-            }
 
             const string PackageReferenceItemType = "PackageReference";
             const string PrivateAssetsMetadataName = "PrivateAssets";
@@ -1442,25 +1438,18 @@ namespace Nerdbank.GitVersioning.Tool
                 packageSources.AddRange(availableSources);
             }
 
-            SourceRepository[] sourceRepositories = packageSources.Select(sourceRepositoryProvider.CreateRepository).ToArray();
-            var resolutionContext = new ResolutionContext(
-                DependencyBehavior.Highest,
-                includePrelease: false,
-                includeUnlisted: false,
-                VersionConstraints.None);
+            using var cacheContext = new SourceCacheContext();
+            var versions = new List<NuGet.Versioning.NuGetVersion>();
+            foreach (SourceRepository sourceRepository in packageSources.Select(sourceRepositoryProvider.CreateRepository))
+            {
+                FindPackageByIdResource resource = await sourceRepository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
+                versions.AddRange(await resource.GetAllVersionsAsync(packageId, cacheContext, NullLogger.Instance, cancellationToken));
+            }
 
-            // The target framework doesn't matter, since our package doesn't depend on this for its target projects.
-            var framework = new NuGet.Frameworks.NuGetFramework("net45");
-
-            ResolvedPackage pkg = await NuGetPackageManager.GetLatestVersionAsync(
-                packageId,
-                framework,
-                resolutionContext,
-                sourceRepositories,
-                NullLogger.Instance,
-                cancellationToken);
-
-            return pkg.LatestVersion?.ToNormalizedString();
+            return versions
+                .Where(version => !version.IsPrerelease)
+                .Max()
+                ?.ToNormalizedString();
         }
 
         private static bool IsCentralPackageManagementEnabled(string path)

--- a/src/nbgv/nbgv.csproj
+++ b/src/nbgv/nbgv.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.PackageManagement" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Protocol" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Nerdbank.GitVersioning.LKG" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" PrivateAssets="all" />

--- a/test/Nerdbank.GitVersioning.Tests/NbgvInstallTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/NbgvInstallTests.cs
@@ -45,19 +45,22 @@ public class NbgvInstallTests : RepoTestBase
             .GetCustomAttributes<AssemblyMetadataAttribute>()
             .Single(attribute => attribute.Key == "NbgvToolPath")
             .Value!;
-        var startInfo = new ProcessStartInfo(nbgvToolPath)
+        var startInfo = new ProcessStartInfo("dotnet")
         {
             RedirectStandardError = true,
             RedirectStandardOutput = true,
             UseShellExecute = false,
         };
+        startInfo.ArgumentList.Add(nbgvToolPath);
         startInfo.ArgumentList.Add("install");
         startInfo.ArgumentList.Add("--path");
         startInfo.ArgumentList.Add(this.RepoPath);
 
         using Process process = Process.Start(startInfo)!;
-        string standardError = await process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
-        await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+        Task<string> standardOutputTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+        Task<string> standardErrorTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+        await Task.WhenAll(standardOutputTask, standardErrorTask, process.WaitForExitAsync(TestContext.Current.CancellationToken));
+        string standardError = await standardErrorTask;
 
         await cancellationSource.CancelAsync();
         listener.Stop();

--- a/test/Nerdbank.GitVersioning.Tests/NbgvInstallTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/NbgvInstallTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET10_0
+#nullable enable
+
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text;
+using System.Xml.Linq;
+using Nerdbank.GitVersioning;
+using Xunit;
+
+public class NbgvInstallTests : RepoTestBase
+{
+    public NbgvInstallTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public async Task UnauthorizedNuGetSourceDoesNotModifyRepository()
+    {
+        this.InitializeSourceControl(withInitialCommit: false);
+
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        using var cancellationSource = new CancellationTokenSource();
+        Task serverTask = ServeUnauthorizedResponsesAsync(listener, cancellationSource.Token);
+
+        string source = $"http://127.0.0.1:{port}/v3/index.json";
+        var nugetConfig = new XDocument(
+            new XElement(
+                "configuration",
+                new XElement(
+                    "packageSources",
+                    new XElement("clear"),
+                    new XElement("add", new XAttribute("key", "unauthorized"), new XAttribute("value", source), new XAttribute("allowInsecureConnections", "true")))));
+        nugetConfig.Save(Path.Combine(this.RepoPath, "NuGet.Config"));
+
+        string nbgvToolPath = typeof(NbgvInstallTests).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(attribute => attribute.Key == "NbgvToolPath")
+            .Value!;
+        var startInfo = new ProcessStartInfo(nbgvToolPath)
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("install");
+        startInfo.ArgumentList.Add("--path");
+        startInfo.ArgumentList.Add(this.RepoPath);
+
+        using Process process = Process.Start(startInfo)!;
+        string standardError = await process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+        await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+        await cancellationSource.CancelAsync();
+        listener.Stop();
+        await serverTask;
+
+        Assert.NotEqual(0, process.ExitCode);
+        Assert.Contains($"Failed to query NuGet package sources: Unable to load the service index for source {source}.", standardError);
+        Assert.Contains("Use the '--source' option", standardError);
+        Assert.DoesNotContain("Unhandled exception", standardError, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(Path.Combine(this.RepoPath, VersionFile.JsonFileName)));
+        Assert.False(File.Exists(Path.Combine(this.RepoPath, "Directory.Build.props")));
+    }
+
+    protected override GitContext CreateGitContext(string path, string? committish = null)
+        => GitContext.Create(path, committish, engine: GitContext.Engine.ReadWrite);
+
+    private static async Task ServeUnauthorizedResponsesAsync(TcpListener listener, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                using TcpClient client = await listener.AcceptTcpClientAsync(cancellationToken);
+                await using NetworkStream stream = client.GetStream();
+                byte[] response = Encoding.ASCII.GetBytes("HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+                await stream.WriteAsync(response, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+}
+#endif

--- a/test/Nerdbank.GitVersioning.Tests/Nerdbank.GitVersioning.Tests.csproj
+++ b/test/Nerdbank.GitVersioning.Tests/Nerdbank.GitVersioning.Tests.csproj
@@ -36,7 +36,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>NbgvToolPath</_Parameter1>
-      <_Parameter2>$(RepoRootPath)bin\nbgv\$(Configuration)\net10.0\nbgv.exe</_Parameter2>
+      <_Parameter2>$(RepoRootPath)bin\nbgv\$(Configuration)\net10.0\nbgv.dll</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>

--- a/test/Nerdbank.GitVersioning.Tests/Nerdbank.GitVersioning.Tests.csproj
+++ b/test/Nerdbank.GitVersioning.Tests/Nerdbank.GitVersioning.Tests.csproj
@@ -31,6 +31,13 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Nerdbank.GitVersioning.Tasks\Nerdbank.GitVersioning.Tasks.csproj" />
     <ProjectReference Include="..\..\src\NerdBank.GitVersioning\Nerdbank.GitVersioning.csproj" />
+    <ProjectReference Include="..\..\src\nbgv\nbgv.csproj" ReferenceOutputAssembly="false" Condition="'$(TargetFramework)' == 'net10.0'" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>NbgvToolPath</_Parameter1>
+      <_Parameter2>$(RepoRootPath)bin\nbgv\$(Configuration)\net10.0\nbgv.exe</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" />


### PR DESCRIPTION
`nbgv install` currently aborts with an unhandled exception when an enabled NuGet source is unavailable or returns an authentication error. It also writes and stages `version.json` before package resolution succeeds, leaving the repository partially modified.

This change:
- resolves the latest stable package version before modifying repository files
- reports NuGet protocol failures concisely and points users to `--source` for overriding configured feeds
- uses the NuGet assemblies from the SDK selected by `MSBuildLocator`, avoiding additional NuGet or MSBuild assemblies in the tool package
- adds an end-to-end regression test using a local source that returns HTTP 401

The packed tool contains no newly added assemblies compared with the baseline; `Microsoft.Build.Locator.dll` remains the only `Microsoft.Build*` assembly and was already packaged.

Fixes #541