### PR TITLE
Fix package version queries in Visual Studio

### DIFF
--- a/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
+++ b/src/Nerdbank.GitVersioning.Tasks/build/Nerdbank.GitVersioning.targets
@@ -19,7 +19,7 @@
     </GenerateNuspecDependsOn>
 
     <GetPackageVersionDependsOn>
-      GetBuildVersion;
+      NBGV_GetPackageVersion;
       $(GetPackageVersionDependsOn)
     </GetPackageVersionDependsOn>
 
@@ -148,6 +148,16 @@
   </Target>
 
   <Target Name="GetNuGetPackageVersion" DependsOnTargets="GetBuildVersion" Returns="$(NuGetPackageVersion)" />
+
+  <!-- NuGet only needs PackageVersion when querying project references. Avoid the full target because Visual Studio
+       may issue this query with an empty TargetFramework global property, which causes SDK validation to fail. -->
+  <Target Name="NBGV_GetPackageVersion" DependsOnTargets="InvokeGetBuildVersionTask">
+    <CreateProperty
+      Value="%(NBGV_PropertyItems.Value)"
+      Condition=" '%(NBGV_PropertyItems.Identity)' == 'NuGetPackageVersion' ">
+      <Output TaskParameter="Value" PropertyName="PackageVersion" />
+    </CreateProperty>
+  </Target>
 
   <Target Name="GenerateAssemblyNBGVVersionInfo" DependsOnTargets="GetBuildVersion" Condition=" '$(_NBGV_LanguageMode)' == 'Managed' and '$(GenerateAssemblyVersionInfo)' != 'false' ">
     <PropertyGroup>

--- a/test/Nerdbank.GitVersioning.Tests/BuildIntegrationDisabledTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/BuildIntegrationDisabledTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Nerdbank.GitVersioning;
 using Xunit;
@@ -41,6 +43,36 @@ public class BuildIntegrationDisabledTests : BuildIntegrationTests
         BuildResults result = await this.BuildAsync(Targets.GenerateAssemblyNBGVVersionInfo);
 
         Assert.DoesNotContain(result.LoggedEvents.OfType<BuildWarningEventArgs>(), warning => warning.Code == "NBGV1001");
+    }
+
+    [Fact]
+    public async Task GetPackageVersionWithEmptyTargetFrameworkGlobalProperty()
+    {
+        this.WriteVersionFile("3.4");
+        ProjectRootElement sdkProject = ProjectRootElement.Create(this.projectCollection);
+        sdkProject.Sdk = "Microsoft.NET.Sdk";
+        sdkProject.FullPath = Path.Combine(this.projectDirectory, "sdk.csproj");
+        sdkProject.AddProperty("TargetFramework", "net10.0");
+        sdkProject.AddImport(Path.Combine(this.RepoPath, GitVersioningPropsFileName));
+        sdkProject.AddImport(Path.Combine(this.RepoPath, GitVersioningTargetsFileName));
+        sdkProject.Save();
+
+        var globalProperties = new Dictionary<string, string>(this.globalProperties)
+        {
+            ["TargetFramework"] = string.Empty,
+        };
+        this.ApplyGlobalProperties(globalProperties);
+        BuildResult result = await this.buildManager.BuildAsync(
+            this.Logger,
+            this.projectCollection,
+            sdkProject,
+            "_GetProjectVersion",
+            globalProperties,
+            additionalLoggers: Array.Empty<ILogger>());
+
+        Assert.Equal(BuildResultCode.Success, result.OverallResult);
+        Assert.Equal("3.4.0-g", result.ProjectStateAfterBuild.GetPropertyValue("PackageVersion"));
+        Assert.Empty(result.ProjectStateAfterBuild.GetPropertyValue("BuildVersion"));
     }
 
     protected override GitContext CreateGitContext(string path, string committish = null)


### PR DESCRIPTION
Visual Studio can query a referenced project's package version with an empty `TargetFramework` global property. Running the full `GetBuildVersion` target for that query causes SDK target-framework validation to fail with NETSDK1013 when a multi-targeted, pack-on-build project references a single-targeted project.

Use a dedicated target for NuGet's project-reference version query. It invokes version computation but exports only `PackageVersion`, avoiding the problematic `GetBuildVersion` target request while preserving the correct dependency version. Add an integration test for the empty-`TargetFramework` query.

Related: #1221

Closes #1330