### PR TITLE
Dispose LibGit2 tree diffs promptly

### DIFF
--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
@@ -491,15 +491,6 @@ public static class LibGit2GitExtensions
             var excludePaths = pathFilters?.Where(filter => filter.IsExclude).ToList();
 
             bool ignoreCase = commit.GetRepository().Config.Get<bool>("core.ignorecase")?.Value ?? false;
-            bool ContainsRelevantChanges(IEnumerable<TreeEntryChanges> changes) =>
-                !hasWildcardIncludes && excludePaths?.Count == 0
-                    ? changes.Any()
-                    //// If there is a single change that isn't excluded,
-                    //// then this commit is relevant.
-                    : changes.Any(change =>
-                        (!hasWildcardIncludes || pathFilters!.Any(include => include.Includes(change.Path, ignoreCase))) &&
-                        !excludePaths!.Any(exclude => exclude.Excludes(change.Path, ignoreCase)));
-
             int height = 1;
 
             if (includePaths is not null)
@@ -517,10 +508,18 @@ public static class LibGit2GitExtensions
                 // A no-parent commit is relevant if it introduces anything in the filtered path.
                 bool relevantCommit =
                     commit.Parents.Any()
-                        ? commit.Parents.Any(parent => ContainsRelevantChanges(commit.GetRepository().Diff
-                            .Compare<TreeChanges>(parent.Tree, commit.Tree, diffInclude, DiffOptions)))
-                        : ContainsRelevantChanges(commit.GetRepository().Diff
-                            .Compare<TreeChanges>(null, commit.Tree, diffInclude, DiffOptions));
+                        ? commit.Parents.Any(parent => ContainsRelevantChanges(
+                            commit.GetRepository().Diff.Compare<TreeChanges>(parent.Tree, commit.Tree, diffInclude, DiffOptions),
+                            hasWildcardIncludes,
+                            pathFilters!,
+                            excludePaths!,
+                            ignoreCase))
+                        : ContainsRelevantChanges(
+                            commit.GetRepository().Diff.Compare<TreeChanges>(null, commit.Tree, diffInclude, DiffOptions),
+                            hasWildcardIncludes,
+                            pathFilters!,
+                            excludePaths!,
+                            ignoreCase);
 
                 if (!relevantCommit)
                 {
@@ -544,6 +543,25 @@ public static class LibGit2GitExtensions
 
         Assumes.True(tracker.TryGetVersionHeight(startingCommit, out int result));
         return result;
+    }
+
+    private static bool ContainsRelevantChanges(
+        TreeChanges changes,
+        bool hasWildcardIncludes,
+        IReadOnlyList<FilterPath> pathFilters,
+        IReadOnlyList<FilterPath> excludePaths,
+        bool ignoreCase)
+    {
+        using (changes)
+        {
+            return !hasWildcardIncludes && excludePaths.Count == 0
+                ? changes.Any()
+                //// If there is a single change that isn't excluded,
+                //// then this commit is relevant.
+                : changes.Any(change =>
+                    (!hasWildcardIncludes || pathFilters.Any(include => include.Includes(change.Path, ignoreCase))) &&
+                    !excludePaths.Any(exclude => exclude.Excludes(change.Path, ignoreCase)));
+        }
     }
 
     /// <summary>

--- a/test/Nerdbank.GitVersioning.Tests/LibGit2GitExtensionsTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/LibGit2GitExtensionsTests.cs
@@ -6,6 +6,8 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using LibGit2Sharp;
 using Nerdbank.GitVersioning;
 using Nerdbank.GitVersioning.LibGit2;
@@ -71,6 +73,46 @@ public class LibGit2GitExtensionsTests : RepoTestBase
 
         // This time stop in both branches of history, and verify that we count the taller one.
         Assert.Equal(3, LibGit2GitExtensions.GetHeight(this.Context, c => c != secondCommit && c != branchCommits[2]));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ContainsRelevantChangesDisposesTreeChanges(bool hasChanges)
+    {
+        Commit parent = this.LibGit2Repository.Commit("Parent", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
+        Commit child;
+        if (hasChanges)
+        {
+            string filePath = Path.Combine(this.RepoPath, "file.txt");
+            File.WriteAllText(filePath, "content");
+            Commands.Stage(this.LibGit2Repository, filePath);
+            child = this.LibGit2Repository.Commit("Add file", this.Signer, this.Signer);
+        }
+        else
+        {
+            child = this.LibGit2Repository.Commit("Empty child", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
+        }
+
+        TreeChanges changes = this.LibGit2Repository.Diff.Compare<TreeChanges>(parent.Tree, child.Tree);
+        try
+        {
+            FieldInfo diffField = typeof(TreeChanges).GetField("diff", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(diffField);
+            SafeHandle diffHandle = Assert.IsAssignableFrom<SafeHandle>(diffField.GetValue(changes));
+            MethodInfo containsRelevantChanges = typeof(LibGit2GitExtensions).GetMethod("ContainsRelevantChanges", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(containsRelevantChanges);
+
+            object result = containsRelevantChanges.Invoke(null, new object[] { changes, false, Array.Empty<FilterPath>(), Array.Empty<FilterPath>(), false });
+            Assert.NotNull(result);
+
+            Assert.Equal(hasChanges, Assert.IsType<bool>(result));
+            Assert.True(diffHandle.IsClosed);
+        }
+        finally
+        {
+            changes.Dispose();
+        }
     }
 
     [Fact]

--- a/test/Nerdbank.GitVersioning.Tests/LibGit2GitExtensionsTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/LibGit2GitExtensionsTests.cs
@@ -100,7 +100,12 @@ public class LibGit2GitExtensionsTests : RepoTestBase
             FieldInfo diffField = typeof(TreeChanges).GetField("diff", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(diffField);
             SafeHandle diffHandle = Assert.IsAssignableFrom<SafeHandle>(diffField.GetValue(changes));
-            MethodInfo containsRelevantChanges = typeof(LibGit2GitExtensions).GetMethod("ContainsRelevantChanges", BindingFlags.Static | BindingFlags.NonPublic);
+            MethodInfo containsRelevantChanges = typeof(LibGit2GitExtensions).GetMethod(
+                "ContainsRelevantChanges",
+                BindingFlags.Static | BindingFlags.NonPublic,
+                binder: null,
+                new[] { typeof(TreeChanges), typeof(bool), typeof(IReadOnlyList<FilterPath>), typeof(IReadOnlyList<FilterPath>), typeof(bool) },
+                modifiers: null);
             Assert.NotNull(containsRelevantChanges);
 
             object result = containsRelevantChanges.Invoke(null, new object[] { changes, false, Array.Empty<FilterPath>(), Array.Empty<FilterPath>(), false });

--- a/test/Nerdbank.GitVersioning.Tests/RepoTestBase.cs
+++ b/test/Nerdbank.GitVersioning.Tests/RepoTestBase.cs
@@ -84,12 +84,6 @@ public abstract partial class RepoTestBase : IDisposable
             this.LibGit2Repository?.Dispose();
             this.Context?.Dispose();
 
-            // LibGit2Sharp may still hold native file handles even after Dispose().
-            // Force a GC cycle to release any lingering native handles before
-            // attempting to delete the temporary directories.
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-
             foreach (string dir in this.repoDirectories)
             {
                 try


### PR DESCRIPTION
## Summary

Path-filtered version-height calculation created a `TreeChanges` (and native `git_diff` handle) for every evaluated parent without disposing it. The leaked handles were eventually finalized, potentially concurrently with active LibGit2 calls in parallel tests. That matches the sporadic native memory corruption seen in [Ubuntu job 93296530082](https://github.com/dotnet/Nerdbank.GitVersioning/actions/runs/31333937050/job/93296530082), where the `AccessViolationException` surfaced later in managed JSON code.

This change disposes each `TreeChanges` immediately after its lazy `Any` evaluation, preserving short-circuiting across both changes and parents. It also removes the forced test-cleanup GC/finalizer sweep that could trigger native finalization during parallel tests.

A deterministic regression test exercises real empty and non-empty diffs and asserts their underlying `SafeHandle` is closed before the walk continues.

## Testing

- `LibGit2GitExtensionsTests` on net472 and net10.0
- `VersionOracleLibGit2Tests` and `VersionFileLibGit2Tests` on net472 and net10.0
- Full net10.0 test suite