### PR TITLE
Fix performance testing on Linux and macOS

### DIFF
--- a/test/Nerdbank.GitVersioning.Benchmarks/GetVersionBenchmarks.cs
+++ b/test/Nerdbank.GitVersioning.Benchmarks/GetVersionBenchmarks.cs
@@ -5,12 +5,9 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 
 namespace Nerdbank.GitVersioning.Benchmarks
 {
-    [SimpleJob(RuntimeMoniker.Net90)]
-    [SimpleJob(RuntimeMoniker.Net472, baseline: true)]
     public class GetVersionBenchmarks
     {
         // You must manually clone these repositories:

--- a/test/Nerdbank.GitVersioning.Benchmarks/Program.cs
+++ b/test/Nerdbank.GitVersioning.Benchmarks/Program.cs
@@ -2,13 +2,26 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 
 namespace Nerdbank.GitVersioning.Benchmarks
 {
     internal class Program
     {
-        private static void Main(string[] args) =>
-                   BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        private static void Main(string[] args)
+        {
+            ManualConfig config = ManualConfig.Create(DefaultConfig.Instance)
+                .AddJob(Job.Default.WithRuntime(CoreRuntime.Core90).AsBaseline());
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                config.AddJob(Job.Default.WithRuntime(ClrRuntime.Net472));
+            }
+
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- configure BenchmarkDotNet runtime jobs based on the host operating system
- run .NET 9 benchmarks on Linux and macOS
- retain .NET Framework 4.7.2 benchmark coverage on Windows

Fixes #1143

## Validation

- built the benchmark project in Release configuration
- ran a shortened benchmark on Linux and confirmed that .NET 9 measurements and reports are produced
