### PR TITLE
Respect path filters for version commit IDs

### DIFF
--- a/src/NerdBank.GitVersioning/DisabledGit/DisabledGitContext.cs
+++ b/src/NerdBank.GitVersioning/DisabledGit/DisabledGitContext.cs
@@ -40,7 +40,10 @@ internal class DisabledGitContext : GitContext
 
     public override bool TrySelectCommit(string committish) => true;
 
-    internal override int CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion) => 0;
+    /// <inheritdoc/>
+    internal override string GetShortUniqueCommitId(string commitId, int minLength) => "nerdbankdisabled";
 
-    internal override Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, int versionHeight) => Version0;
+    internal override VersionHeightCalculation CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion) => new(0, null);
+
+    internal override Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, VersionHeightCalculation versionHeight) => Version0;
 }

--- a/src/NerdBank.GitVersioning/GitContext.cs
+++ b/src/NerdBank.GitVersioning/GitContext.cs
@@ -297,9 +297,17 @@ public abstract class GitContext : IDisposable
         return true;
     }
 
-    internal abstract int CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion);
+    /// <summary>
+    /// Gets the shortest string that uniquely identifies a specified commit.
+    /// </summary>
+    /// <param name="commitId">The commit ID to shorten.</param>
+    /// <param name="minLength">A minimum length.</param>
+    /// <returns>A string that is at least <paramref name="minLength"/> in length but may be more as required to uniquely identify the commit.</returns>
+    internal abstract string GetShortUniqueCommitId(string commitId, int minLength);
 
-    internal abstract Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, int versionHeight);
+    internal abstract VersionHeightCalculation CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion);
+
+    internal abstract Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, VersionHeightCalculation versionHeight);
 
     internal string GetRepoRelativePath(string absolutePath, bool replaceBackslashes = false)
     {
@@ -422,5 +430,32 @@ public abstract class GitContext : IDisposable
     {
         string? githubActorEnvVar = Environment.GetEnvironmentVariable("GITHUB_ACTOR");
         return string.Equals(githubActorEnvVar, "copilot-swe-agent[bot]", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Describes the version height and the commit that last contributed to it.
+    /// </summary>
+    internal readonly struct VersionHeightCalculation
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VersionHeightCalculation"/> struct.
+        /// </summary>
+        /// <param name="height">The calculated version height.</param>
+        /// <param name="commitId">The commit that last contributed to the height.</param>
+        internal VersionHeightCalculation(int height, string? commitId)
+        {
+            this.Height = height;
+            this.CommitId = commitId;
+        }
+
+        /// <summary>
+        /// Gets the calculated version height.
+        /// </summary>
+        internal int Height { get; }
+
+        /// <summary>
+        /// Gets the commit that last contributed to the height.
+        /// </summary>
+        internal string? CommitId { get; }
     }
 }

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
@@ -130,7 +130,10 @@ public class LibGit2Context : GitContext
     public override string GetShortUniqueCommitId(int minLength) => this.Repository.ObjectDatabase.ShortenObjectId(this.Commit, minLength);
 
     /// <inheritdoc/>
-    internal override int CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion)
+    internal override string GetShortUniqueCommitId(string commitId, int minLength) => this.Repository.ObjectDatabase.ShortenObjectId(this.Repository.Lookup<Commit>(commitId), minLength);
+
+    /// <inheritdoc/>
+    internal override VersionHeightCalculation CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion)
     {
         SemanticVersion? headCommitVersion = committedVersion?.Version ?? SemVer0;
 
@@ -142,7 +145,7 @@ public class LibGit2Context : GitContext
             {
                 // The working copy has changed the major.minor version.
                 // So by definition the version height is 0, since no commit represents it yet.
-                return 0;
+                return new VersionHeightCalculation(0, this.GitCommitId);
             }
         }
 
@@ -150,11 +153,12 @@ public class LibGit2Context : GitContext
     }
 
     /// <inheritdoc/>
-    internal override System.Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, int versionHeight)
+    internal override System.Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, VersionHeightCalculation versionHeight)
     {
         VersionOptions? version = IsVersionFileChangedInWorkingTree(committedVersion, workingVersion) ? workingVersion : committedVersion;
 
-        return this.Commit.GetIdAsVersionHelper(version, versionHeight);
+        Commit? versionCommit = versionHeight.CommitId is not null ? this.Repository.Lookup<Commit>(versionHeight.CommitId) : this.Commit;
+        return versionCommit.GetIdAsVersionHelper(version, versionHeight.Height);
     }
 
     /// <inheritdoc />

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
@@ -61,7 +61,7 @@ public static class LibGit2GitExtensions
     {
         Verify.Operation(context.Commit is object, "No commit is selected.");
         var tracker = new GitWalkTracker(context);
-        return GetCommitHeight(context.Commit, tracker, continueStepping);
+        return GetCommitHeight(context.Commit, tracker, continueStepping).Height;
     }
 
     /// <summary>
@@ -171,11 +171,11 @@ public static class LibGit2GitExtensions
     /// <param name="context">The git context to read from.</param>
     /// <param name="baseVersion">Optional base version to calculate the height. If not specified, the base version will be calculated by scanning the repository.</param>
     /// <returns>The height of the commit. Always a positive integer.</returns>
-    internal static int GetVersionHeight(LibGit2Context context, Version? baseVersion = null)
+    internal static GitContext.VersionHeightCalculation GetVersionHeight(LibGit2Context context, Version? baseVersion = null)
     {
         if (context.Commit is null)
         {
-            return 0;
+            return new GitContext.VersionHeightCalculation(0, null);
         }
 
         var tracker = new GitWalkTracker(context);
@@ -183,7 +183,7 @@ public static class LibGit2GitExtensions
         VersionOptions? versionOptions = tracker.GetVersion(context.Commit);
         if (versionOptions is null)
         {
-            return 0;
+            return new GitContext.VersionHeightCalculation(0, context.GitCommitId);
         }
 
         SemanticVersion? baseSemVer =
@@ -193,11 +193,10 @@ public static class LibGit2GitExtensions
         SemanticVersion.Position? versionHeightPosition = versionOptions.VersionHeightPosition;
         if (versionHeightPosition.HasValue)
         {
-            int height = GetHeight(context, c => CommitMatchesVersion(c, baseSemVer, versionHeightPosition.Value, tracker));
-            return height;
+            return GetCommitHeight(context.Commit, tracker, c => CommitMatchesVersion(c, baseSemVer, versionHeightPosition.Value, tracker));
         }
 
-        return 0;
+        return new GitContext.VersionHeightCalculation(0, context.GitCommitId);
     }
 
     /// <summary>
@@ -345,7 +344,7 @@ public static class LibGit2GitExtensions
             int expectedVersionHeight = SemanticVersion.ReadVersionPosition(version, position.Value);
 
             int actualVersionOffset = versionOptions.EffectiveVersionHeightOffset;
-            int actualVersionHeight = GetCommitHeight(commit, tracker, c => CommitMatchesVersion(c, version, position.Value - 1, tracker));
+            int actualVersionHeight = GetCommitHeight(commit, tracker, c => CommitMatchesVersion(c, version, position.Value - 1, tracker)).Height;
             return expectedVersionHeight != actualVersionHeight + actualVersionOffset;
         }
 
@@ -430,14 +429,14 @@ public static class LibGit2GitExtensions
     /// May be null to count the height to the original commit.
     /// </param>
     /// <returns>The height of the branch.</returns>
-    private static int GetCommitHeight(Commit startingCommit, GitWalkTracker tracker, Func<Commit, bool>? continueStepping)
+    private static GitContext.VersionHeightCalculation GetCommitHeight(Commit startingCommit, GitWalkTracker tracker, Func<Commit, bool>? continueStepping)
     {
         Requires.NotNull(startingCommit, nameof(startingCommit));
         Requires.NotNull(tracker, nameof(tracker));
 
         if (continueStepping is object && !continueStepping(startingCommit))
         {
-            return 0;
+            return new GitContext.VersionHeightCalculation(0, startingCommit.Sha);
         }
 
         var commitsToEvaluate = new Stack<Commit>();
@@ -445,10 +444,11 @@ public static class LibGit2GitExtensions
         {
             // Get max height among all parents, or schedule all missing parents for their own evaluation and return false.
             int maxHeightAmongParents = 0;
+            string? versionCommitId = null;
             bool parentMissing = false;
             foreach (Commit parent in commit.Parents)
             {
-                if (!tracker.TryGetVersionHeight(parent, out int parentHeight))
+                if (!tracker.TryGetVersionHeight(parent, out GitContext.VersionHeightCalculation parentCalculation))
                 {
                     if (continueStepping is object && !continueStepping(parent))
                     {
@@ -461,7 +461,11 @@ public static class LibGit2GitExtensions
                 }
                 else
                 {
-                    maxHeightAmongParents = Math.Max(maxHeightAmongParents, parentHeight);
+                    if (parentCalculation.Height > maxHeightAmongParents)
+                    {
+                        maxHeightAmongParents = parentCalculation.Height;
+                        versionCommitId = parentCalculation.CommitId;
+                    }
                 }
             }
 
@@ -527,7 +531,12 @@ public static class LibGit2GitExtensions
                 }
             }
 
-            tracker.RecordHeight(commit, height + maxHeightAmongParents);
+            if (height > 0)
+            {
+                versionCommitId = commit.Sha;
+            }
+
+            tracker.RecordHeight(commit, new GitContext.VersionHeightCalculation(height + maxHeightAmongParents, versionCommitId));
             return true;
         }
 
@@ -541,7 +550,7 @@ public static class LibGit2GitExtensions
             }
         }
 
-        Assumes.True(tracker.TryGetVersionHeight(startingCommit, out int result));
+        Assumes.True(tracker.TryGetVersionHeight(startingCommit, out GitContext.VersionHeightCalculation result));
         return result;
     }
 
@@ -605,7 +614,7 @@ public static class LibGit2GitExtensions
     {
         private readonly Dictionary<ObjectId, VersionOptions?> commitVersionCache = new Dictionary<ObjectId, VersionOptions?>();
         private readonly Dictionary<ObjectId, VersionOptions?> blobVersionCache = new Dictionary<ObjectId, VersionOptions?>();
-        private readonly Dictionary<ObjectId, int> heights = new Dictionary<ObjectId, int>();
+        private readonly Dictionary<ObjectId, GitContext.VersionHeightCalculation> heights = new Dictionary<ObjectId, GitContext.VersionHeightCalculation>();
         private readonly LibGit2Context context;
 
         internal GitWalkTracker(LibGit2Context context)
@@ -613,9 +622,9 @@ public static class LibGit2GitExtensions
             this.context = context;
         }
 
-        internal bool TryGetVersionHeight(Commit commit, out int height) => this.heights.TryGetValue(commit.Id, out height);
+        internal bool TryGetVersionHeight(Commit commit, out GitContext.VersionHeightCalculation height) => this.heights.TryGetValue(commit.Id, out height);
 
-        internal void RecordHeight(Commit commit, int height) => this.heights.Add(commit.Id, height);
+        internal void RecordHeight(Commit commit, GitContext.VersionHeightCalculation height) => this.heights.Add(commit.Id, height);
 
         internal VersionOptions? GetVersion(Commit commit)
         {

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2GitExtensions.cs
@@ -461,7 +461,8 @@ public static class LibGit2GitExtensions
                 }
                 else
                 {
-                    if (parentCalculation.Height > maxHeightAmongParents)
+                    if (parentCalculation.Height > maxHeightAmongParents
+                        || (parentCalculation.Height == maxHeightAmongParents && versionCommitId is null && parentCalculation.CommitId is not null))
                     {
                         maxHeightAmongParents = parentCalculation.Height;
                         versionCommitId = parentCalculation.CommitId;

--- a/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
@@ -123,7 +123,8 @@ internal static class GitExtensions
                 }
                 else
                 {
-                    if (parentCalculation.Height > maxHeightAmongParents)
+                    if (parentCalculation.Height > maxHeightAmongParents
+                        || (parentCalculation.Height == maxHeightAmongParents && versionCommitId is null && parentCalculation.CommitId is not null))
                     {
                         maxHeightAmongParents = parentCalculation.Height;
                         versionCommitId = parentCalculation.CommitId;

--- a/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
+++ b/src/NerdBank.GitVersioning/Managed/GitExtensions.cs
@@ -30,7 +30,7 @@ internal static class GitExtensions
     {
         Verify.Operation(context.Commit.HasValue, "No commit is selected.");
         var tracker = new GitWalkTracker(context);
-        return GetCommitHeight(context.Repository, context.Commit.Value, tracker, continueStepping);
+        return GetCommitHeight(context.Repository, context.Commit.Value, tracker, continueStepping).Height;
     }
 
     /// <summary>
@@ -52,11 +52,11 @@ internal static class GitExtensions
     /// <param name="context">The git context for which to calculate the height.</param>
     /// <param name="baseVersion">Optional base version to calculate the height. If not specified, the base version will be calculated by scanning the repository.</param>
     /// <returns>The height of the commit. Always a positive integer.</returns>
-    internal static int GetVersionHeight(ManagedGitContext context, Version? baseVersion = null)
+    internal static GitContext.VersionHeightCalculation GetVersionHeight(ManagedGitContext context, Version? baseVersion = null)
     {
         if (context.Commit is null)
         {
-            return 0;
+            return new GitContext.VersionHeightCalculation(0, null);
         }
 
         var tracker = new GitWalkTracker(context);
@@ -64,7 +64,7 @@ internal static class GitExtensions
         VersionOptions? versionOptions = tracker.GetVersion(context.Commit.Value);
         if (versionOptions is null)
         {
-            return 0;
+            return new GitContext.VersionHeightCalculation(0, context.GitCommitId);
         }
 
         SemanticVersion? baseSemVer =
@@ -74,11 +74,10 @@ internal static class GitExtensions
         SemanticVersion.Position? versionHeightPosition = versionOptions.VersionHeightPosition;
         if (versionHeightPosition.HasValue)
         {
-            int height = GetHeight(context, c => CommitMatchesVersion(c, baseSemVer, versionHeightPosition.Value, tracker));
-            return height;
+            return GetCommitHeight(context.Repository, context.Commit.Value, tracker, c => CommitMatchesVersion(c, baseSemVer, versionHeightPosition.Value, tracker));
         }
 
-        return 0;
+        return new GitContext.VersionHeightCalculation(0, context.GitCommitId);
     }
 
     /// <summary>
@@ -94,11 +93,11 @@ internal static class GitExtensions
     /// May be null to count the height to the original commit.
     /// </param>
     /// <returns>The height of the branch.</returns>
-    private static int GetCommitHeight(GitRepository repository, GitCommit startingCommit, GitWalkTracker tracker, Func<GitCommit, bool>? continueStepping)
+    private static GitContext.VersionHeightCalculation GetCommitHeight(GitRepository repository, GitCommit startingCommit, GitWalkTracker tracker, Func<GitCommit, bool>? continueStepping)
     {
         if (continueStepping is object && !continueStepping(startingCommit))
         {
-            return 0;
+            return new GitContext.VersionHeightCalculation(0, startingCommit.Sha.ToString());
         }
 
         var commitsToEvaluate = new Stack<GitCommit>();
@@ -106,11 +105,12 @@ internal static class GitExtensions
         {
             // Get max height among all parents, or schedule all missing parents for their own evaluation and return false.
             int maxHeightAmongParents = 0;
+            string? versionCommitId = null;
             bool parentMissing = false;
             foreach (GitObjectId parentId in commit.Parents)
             {
                 GitCommit parent = repository.GetCommit(parentId);
-                if (!tracker.TryGetVersionHeight(parent, out int parentHeight))
+                if (!tracker.TryGetVersionHeight(parent, out GitContext.VersionHeightCalculation parentCalculation))
                 {
                     if (continueStepping is object && !continueStepping(parent))
                     {
@@ -123,7 +123,11 @@ internal static class GitExtensions
                 }
                 else
                 {
-                    maxHeightAmongParents = Math.Max(maxHeightAmongParents, parentHeight);
+                    if (parentCalculation.Height > maxHeightAmongParents)
+                    {
+                        maxHeightAmongParents = parentCalculation.Height;
+                        versionCommitId = parentCalculation.CommitId;
+                    }
                 }
             }
 
@@ -166,7 +170,12 @@ internal static class GitExtensions
                 }
             }
 
-            tracker.RecordHeight(commit, height + maxHeightAmongParents);
+            if (height > 0)
+            {
+                versionCommitId = commit.Sha.ToString();
+            }
+
+            tracker.RecordHeight(commit, new GitContext.VersionHeightCalculation(height + maxHeightAmongParents, versionCommitId));
             return true;
         }
 
@@ -180,7 +189,7 @@ internal static class GitExtensions
             }
         }
 
-        Assumes.True(tracker.TryGetVersionHeight(startingCommit, out int result));
+        Assumes.True(tracker.TryGetVersionHeight(startingCommit, out GitContext.VersionHeightCalculation result));
         return result;
     }
 
@@ -314,7 +323,7 @@ internal static class GitExtensions
     {
         private readonly Dictionary<GitObjectId, VersionOptions?> commitVersionCache = new Dictionary<GitObjectId, VersionOptions?>();
         private readonly Dictionary<GitObjectId, VersionOptions?> blobVersionCache = new Dictionary<GitObjectId, VersionOptions?>();
-        private readonly Dictionary<GitObjectId, int> heights = new Dictionary<GitObjectId, int>();
+        private readonly Dictionary<GitObjectId, GitContext.VersionHeightCalculation> heights = new Dictionary<GitObjectId, GitContext.VersionHeightCalculation>();
         private readonly ManagedGitContext context;
 
         internal GitWalkTracker(ManagedGitContext context)
@@ -322,9 +331,9 @@ internal static class GitExtensions
             this.context = context;
         }
 
-        internal bool TryGetVersionHeight(GitCommit commit, out int height) => this.heights.TryGetValue(commit.Sha, out height);
+        internal bool TryGetVersionHeight(GitCommit commit, out GitContext.VersionHeightCalculation height) => this.heights.TryGetValue(commit.Sha, out height);
 
-        internal void RecordHeight(GitCommit commit, int height) => this.heights.Add(commit.Sha, height);
+        internal void RecordHeight(GitCommit commit, GitContext.VersionHeightCalculation height) => this.heights.Add(commit.Sha, height);
 
         internal VersionOptions? GetVersion(GitCommit commit)
         {

--- a/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
+++ b/src/NerdBank.GitVersioning/Managed/ManagedGitContext.cs
@@ -108,7 +108,10 @@ public class ManagedGitContext : GitContext
     }
 
     /// <inheritdoc/>
-    internal override int CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion)
+    internal override string GetShortUniqueCommitId(string commitId, int minLength) => this.Repository.ShortenObjectId(GitObjectId.Parse(commitId), minLength);
+
+    /// <inheritdoc/>
+    internal override VersionHeightCalculation CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion)
     {
         SemanticVersion? headCommitVersion = committedVersion?.Version ?? SemVer0;
 
@@ -120,7 +123,7 @@ public class ManagedGitContext : GitContext
             {
                 // The working copy has changed the major.minor version.
                 // So by definition the version height is 0, since no commit represents it yet.
-                return 0;
+                return new VersionHeightCalculation(0, this.GitCommitId);
             }
         }
 
@@ -128,11 +131,12 @@ public class ManagedGitContext : GitContext
     }
 
     /// <inheritdoc/>
-    internal override Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, int versionHeight)
+    internal override Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, VersionHeightCalculation versionHeight)
     {
         VersionOptions? version = IsVersionFileChangedInWorkingTree(committedVersion, workingVersion) ? workingVersion : committedVersion;
 
-        return this.GetIdAsVersionHelper(version, versionHeight);
+        GitCommit? versionCommit = versionHeight.CommitId is not null ? this.Repository.GetCommit(GitObjectId.Parse(versionHeight.CommitId)) : this.Commit;
+        return GetIdAsVersionHelper(versionCommit, version, versionHeight.Height);
     }
 
     /// <inheritdoc/>
@@ -150,6 +154,7 @@ public class ManagedGitContext : GitContext
     /// Encodes a commit from history in a <see cref="Version"/>
     /// so that the original commit can be found later.
     /// </summary>
+    /// <param name="commit">The commit whose ID should be encoded.</param>
     /// <param name="versionOptions">The version options applicable at this point (either from commit or working copy).</param>
     /// <param name="versionHeight">The version height, previously calculated.</param>
     /// <returns>
@@ -161,7 +166,7 @@ public class ManagedGitContext : GitContext
     /// the height of the git commit while the <see cref="Version.Revision"/>
     /// component is the first four bytes of the git commit id (forced to be a positive integer).
     /// </remarks>
-    private Version GetIdAsVersionHelper(VersionOptions? versionOptions, int versionHeight)
+    private static Version GetIdAsVersionHelper(GitCommit? commit, VersionOptions? versionOptions, int versionHeight)
     {
         Version? baseVersion = versionOptions?.Version?.Version ?? Version0;
         int buildNumber = baseVersion.Build;
@@ -194,8 +199,8 @@ public class ManagedGitContext : GitContext
             switch (commitIdPosition.Value)
             {
                 case SemanticVersion.Position.Revision:
-                    revision = this.Commit.HasValue
-                        ? Math.Min(MaximumBuildNumberOrRevisionComponent, this.Commit.Value.GetTruncatedCommitIdAsUInt16())
+                    revision = commit.HasValue
+                        ? Math.Min(MaximumBuildNumberOrRevisionComponent, commit.Value.GetTruncatedCommitIdAsUInt16())
                         : 0;
                     break;
             }

--- a/src/NerdBank.GitVersioning/NoGit/NoGitContext.cs
+++ b/src/NerdBank.GitVersioning/NoGit/NoGitContext.cs
@@ -53,8 +53,11 @@ internal class NoGitContext : GitContext
     public override bool TrySelectCommit(string committish) => throw new InvalidOperationException(NotAGitRepoMessage);
 
     /// <inheritdoc/>
-    internal override int CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion) => 0;
+    internal override string GetShortUniqueCommitId(string commitId, int minLength) => throw new InvalidOperationException(NotAGitRepoMessage);
 
     /// <inheritdoc/>
-    internal override Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, int versionHeight) => throw new NotImplementedException();
+    internal override VersionHeightCalculation CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion) => new(0, null);
+
+    /// <inheritdoc/>
+    internal override Version GetIdAsVersion(VersionOptions? committedVersion, VersionOptions? workingVersion, VersionHeightCalculation versionHeight) => throw new NotImplementedException();
 }

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -23,12 +23,18 @@ public class VersionOracle
 
     private readonly GitContext context;
 
-    private readonly ICloudBuild? cloudBuild;
+    private readonly string? gitCommitId;
+
+    private readonly string? versionGitCommitId;
+
+    private readonly string? versionGitCommitIdShort;
 
     /// <summary>
     /// The number of version components (up to the 4 integers) to include in <see cref="AssemblyInformationalVersion"/>.
     /// </summary>
     private readonly int assemblyInformationalVersionComponentCount;
+
+    private readonly Version assemblyInformationalVersion;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="VersionOracle"/> class.
@@ -39,7 +45,7 @@ public class VersionOracle
     public VersionOracle(GitContext context, ICloudBuild? cloudBuild = null, int? overrideVersionHeightOffset = null)
     {
         this.context = context;
-        this.cloudBuild = cloudBuild;
+        this.gitCommitId = context.GitCommitId ?? cloudBuild?.GitCommitId;
 
         this.CommittedVersion = context.VersionFile.GetVersion();
 
@@ -64,7 +70,9 @@ public class VersionOracle
 
         try
         {
-            this.VersionHeight = context.CalculateVersionHeight(this.CommittedVersion, this.WorkingVersion);
+            GitContext.VersionHeightCalculation versionHeight = context.CalculateVersionHeight(this.CommittedVersion, this.WorkingVersion);
+            this.VersionHeight = versionHeight.Height;
+            this.versionGitCommitId = versionHeight.CommitId ?? this.gitCommitId;
         }
         catch (GitException ex) when (context.IsShallow && ex.ErrorCode == GitException.ErrorCodes.ObjectNotFound)
         {
@@ -86,7 +94,14 @@ public class VersionOracle
         // Override the typedVersion with the special build number and revision components, when available.
         if (context.IsRepository)
         {
-            this.Version = context.GetIdAsVersion(this.CommittedVersion, this.WorkingVersion, this.VersionHeight);
+            GitContext.VersionHeightCalculation versionHeight = new(this.VersionHeight, this.versionGitCommitId);
+            this.Version = context.GetIdAsVersion(this.CommittedVersion, this.WorkingVersion, versionHeight);
+            GitContext.VersionHeightCalculation headVersionHeight = new(this.VersionHeight, context.GitCommitId);
+            this.assemblyInformationalVersion = context.GetIdAsVersion(this.CommittedVersion, this.WorkingVersion, headVersionHeight);
+        }
+        else
+        {
+            this.assemblyInformationalVersion = this.Version;
         }
 
         this.CloudBuildNumberOptions = this.VersionOptions?.CloudBuild?.BuildNumberOrDefault ?? VersionOptions.CloudBuildNumberOptions.DefaultInstance;
@@ -98,9 +113,18 @@ public class VersionOracle
             int gitCommitIdShortAutoMinimum = this.VersionOptions?.GitCommitIdShortAutoMinimum ?? 0;
 
             // Get it from the git repository if there is a repository present and it is enabled.
-            this.GitCommitIdShort = this.GitCommitId is object && gitCommitIdShortAutoMinimum > 0
+            this.GitCommitIdShort = gitCommitIdShortAutoMinimum > 0
                 ? this.context.GetShortUniqueCommitId(gitCommitIdShortAutoMinimum)
                 : this.GitCommitId!.Substring(0, gitCommitIdShortFixedLength);
+        }
+
+        if (!string.IsNullOrEmpty(this.versionGitCommitId))
+        {
+            int gitCommitIdShortFixedLength = this.VersionOptions?.GitCommitIdShortFixedLength ?? VersionOptions.DefaultGitCommitIdShortFixedLength;
+            int gitCommitIdShortAutoMinimum = this.VersionOptions?.GitCommitIdShortAutoMinimum ?? 0;
+            this.versionGitCommitIdShort = gitCommitIdShortAutoMinimum > 0
+                ? this.context.GetShortUniqueCommitId(this.versionGitCommitId!, gitCommitIdShortAutoMinimum)
+                : this.versionGitCommitId!.Substring(0, gitCommitIdShortFixedLength);
         }
 
         if (this.VersionOptions?.PublicReleaseRefSpec?.Count > 0)
@@ -139,7 +163,7 @@ public class VersionOracle
                                    this.VersionOptions?.Version?.VersionHeightPosition == SemanticVersion.Position.Revision ||
                                    this.VersionOptions?.Version?.Version.Revision != -1;
 
-            string buildNumberMetadata = FormatBuildMetadata(commitIdInBuildMetadata ? this.BuildMetadataWithCommitId : this.BuildMetadata);
+            string buildNumberMetadata = FormatBuildMetadata(commitIdInBuildMetadata ? this.VersionBuildMetadataWithCommitId : this.BuildMetadata);
 
             Version buildNumberVersion = includeRevision ? this.Version : this.SimpleVersion;
             return $"{buildNumberVersion}{this.PrereleaseVersion}{buildNumberMetadata}";
@@ -197,7 +221,7 @@ public class VersionOracle
     /// Gets the version string to use for the <see cref="System.Reflection.AssemblyInformationalVersionAttribute"/>.
     /// </summary>
     public string AssemblyInformationalVersion =>
-        $"{this.Version.ToStringSafe(this.assemblyInformationalVersionComponentCount)}{this.PrereleaseVersion}{FormatBuildMetadata(this.BuildMetadataWithCommitId)}";
+        $"{this.assemblyInformationalVersion.ToStringSafe(this.assemblyInformationalVersionComponentCount)}{this.PrereleaseVersion}{FormatBuildMetadata(this.BuildMetadataWithCommitId)}";
 
     /// <summary>
     /// Gets or sets a value indicating whether the project is building
@@ -277,7 +301,7 @@ public class VersionOracle
     /// <summary>
     /// Gets the Git revision control commit id for HEAD (the current source code version).
     /// </summary>
-    public string? GitCommitId => this.context.GitCommitId ?? this.cloudBuild?.GitCommitId;
+    public string? GitCommitId => this.gitCommitId;
 
     /// <summary>
     /// Gets the first several characters of the Git revision control commit id for HEAD (the current source code version).
@@ -418,7 +442,7 @@ public class VersionOracle
     /// <summary>
     /// Gets the +buildMetadata fragment for the semantic version.
     /// </summary>
-    public string BuildMetadataFragment => FormatBuildMetadata(this.BuildMetadataWithCommitId);
+    public string BuildMetadataFragment => FormatBuildMetadata(this.VersionBuildMetadataWithCommitId);
 
     /// <summary>
     /// Gets the version to use for NuGet packages.
@@ -472,6 +496,22 @@ public class VersionOracle
     /// </summary>
     protected VersionOptions? WorkingVersion { get; }
 
+    private IEnumerable<string> VersionBuildMetadataWithCommitId
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(this.versionGitCommitIdShort))
+            {
+                yield return this.versionGitCommitIdShort!;
+            }
+
+            foreach (string identifier in this.BuildMetadata)
+            {
+                yield return identifier;
+            }
+        }
+    }
+
     /// <summary>
     /// Gets the build metadata, compliant to the NuGet-compatible subset of SemVer 1.0.
     /// </summary>
@@ -482,13 +522,13 @@ public class VersionOracle
     /// See <see href="https://github.com/dotnet/Nerdbank.GitVersioning/issues/260#issuecomment-445511898">this discussion</see>.
     /// </remarks>
     private string NuGetSemVer1BuildMetadata =>
-        this.PublicRelease ? string.Empty : $"-{this.VersionOptions?.GitCommitIdPrefix ?? "g"}{this.GitCommitIdShort}";
+        this.PublicRelease ? string.Empty : $"-{this.VersionOptions?.GitCommitIdPrefix ?? "g"}{this.versionGitCommitIdShort}";
 
     /// <summary>
     /// Gets the build metadata, compliant to SemVer 1.0.
     /// </summary>
     private string SemVer1BuildMetadata =>
-        this.PublicRelease ? string.Empty : $"-{this.GitCommitIdShort}";
+        this.PublicRelease ? string.Empty : $"-{this.versionGitCommitIdShort}";
 
     /// <summary>
     /// Gets a SemVer 1.0 compliant string that represents this version, including the -gCOMMITID suffix
@@ -549,7 +589,7 @@ public class VersionOracle
     /// The prefix to the commit ID is to remain SemVer2 compliant particularly when the partial commit ID we use is made up entirely of numerals.
     /// SemVer2 forbids numerals to begin with leading zeros, but a git commit just might, so we begin with prefix always to avoid failures when the commit ID happens to be problematic.
     /// </remarks>
-    private string GitCommitIdShortForNonPublicPrereleaseTag => (string.IsNullOrEmpty(this.PrereleaseVersion) ? "-" : ".") + (this.VersionOptions?.GitCommitIdPrefix ?? "g") + this.GitCommitIdShort;
+    private string GitCommitIdShortForNonPublicPrereleaseTag => (string.IsNullOrEmpty(this.PrereleaseVersion) ? "-" : ".") + (this.VersionOptions?.GitCommitIdPrefix ?? "g") + this.versionGitCommitIdShort;
 
     private int VersionHeightWithOffset => this.VersionHeight + this.VersionHeightOffset;
 

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -68,9 +68,10 @@ public class VersionOracle
 
         this.BuildingRef = cloudBuild?.BuildingTag ?? cloudBuild?.BuildingBranch ?? context.HeadCanonicalName;
 
+        GitContext.VersionHeightCalculation versionHeight;
         try
         {
-            GitContext.VersionHeightCalculation versionHeight = context.CalculateVersionHeight(this.CommittedVersion, this.WorkingVersion);
+            versionHeight = context.CalculateVersionHeight(this.CommittedVersion, this.WorkingVersion);
             this.VersionHeight = versionHeight.Height;
             this.versionGitCommitId = versionHeight.CommitId ?? this.gitCommitId;
         }
@@ -94,7 +95,6 @@ public class VersionOracle
         // Override the typedVersion with the special build number and revision components, when available.
         if (context.IsRepository)
         {
-            GitContext.VersionHeightCalculation versionHeight = new(this.VersionHeight, this.versionGitCommitId);
             this.Version = context.GetIdAsVersion(this.CommittedVersion, this.WorkingVersion, versionHeight);
             GitContext.VersionHeightCalculation headVersionHeight = new(this.VersionHeight, context.GitCommitId);
             this.assemblyInformationalVersion = context.GetIdAsVersion(this.CommittedVersion, this.WorkingVersion, headVersionHeight);

--- a/test/Nerdbank.GitVersioning.Tests/RepoTestBase.Helpers.cs
+++ b/test/Nerdbank.GitVersioning.Tests/RepoTestBase.Helpers.cs
@@ -31,7 +31,7 @@ public partial class RepoTestBase
     /// <returns>The height of the repo at HEAD. Always a positive integer.</returns>
     protected int GetVersionHeight(string? repoRelativeProjectDirectory = null) => this.GetVersionHeight(committish: null, repoRelativeProjectDirectory);
 
-    private class FakeCloudBuild : ICloudBuild
+    protected class FakeCloudBuild : ICloudBuild
     {
         public FakeCloudBuild(string gitCommitId)
         {

--- a/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
@@ -59,6 +59,18 @@ public abstract class VersionOracleTests : RepoTestBase
     }
 
     [Fact]
+    public void EmptyRepoWithCloudCommitNotInRepository()
+    {
+        this.InitializeSourceControl(withInitialCommit: false);
+        const string CloudCommitId = "4a89d8fdbc350fdcf20e0e839d35ddbe638a9315";
+
+        var oracle = new VersionOracle(this.Context, new FakeCloudBuild(CloudCommitId));
+
+        Assert.Equal(0, oracle.VersionHeight);
+        Assert.Equal(CloudCommitId, oracle.GitCommitId);
+    }
+
+    [Fact]
     public void Submodule_RecognizedWithCorrectVersion()
     {
         using (TestUtilities.ExpandedRepo expandedRepo = TestUtilities.ExtractRepoArchive("submodules"))

--- a/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/VersionOracleTests.cs
@@ -1051,14 +1051,25 @@ public abstract class VersionOracleTests : RepoTestBase
         var versionData = VersionOptions.FromVersion(new Version("1.2"));
         versionData.PathFilters = new[] { new FilterPath(includeFilter, relativeDirectory) };
         this.WriteVersionFile(versionData, relativeDirectory);
+        string versionCommitId = this.LibGit2Repository.Head.Tip.Sha;
         Assert.Equal(1, this.GetVersionHeight(relativeDirectory));
 
         // Expect commit outside of project tree to not affect version height
         string otherFilePath = Path.Combine(this.RepoPath, "my-file.txt");
         File.WriteAllText(otherFilePath, "hello");
         Commands.Stage(this.LibGit2Repository, otherFilePath);
-        this.LibGit2Repository.Commit("Add other file outside of project root", this.Signer, this.Signer);
+        Commit headCommit = this.LibGit2Repository.Commit("Add other file outside of project root", this.Signer, this.Signer);
         Assert.Equal(1, this.GetVersionHeight(relativeDirectory));
+
+        VersionOracle oracle = this.GetVersionOracle(relativeDirectory);
+        string versionCommitIdShort = versionCommitId.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength);
+        string headCommitIdShort = headCommit.Sha.Substring(0, VersionOptions.DefaultGitCommitIdShortFixedLength);
+        Assert.Equal(headCommit.Sha, oracle.GitCommitId);
+        Assert.Equal(headCommitIdShort, oracle.GitCommitIdShort);
+        Assert.EndsWith($"-g{versionCommitIdShort}", oracle.NuGetPackageVersion);
+        Assert.Equal($"+{versionCommitIdShort}", oracle.BuildMetadataFragment);
+        Assert.Equal(GitObjectId.Parse(versionCommitId).AsUInt16(), oracle.Version.Revision);
+        Assert.EndsWith($"+{headCommitIdShort}", oracle.AssemblyInformationalVersion);
 
         // Expect commit inside project tree to affect version height
         string containedFilePath = Path.Combine(this.RepoPath, relativeDirectory, "another-file.txt");


### PR DESCRIPTION
Path-filtered components should not receive a new package version merely because HEAD changed outside their relevant paths. This updates version identity to use the last commit that contributed to the filtered version height.

The existing version-height graph walk now carries the last contributing commit ID alongside each cached height, avoiding a second history traversal. Package suffixes, build metadata, and encoded revision components use that filtered commit. Public source metadata and `AssemblyInformationalVersion` continue to report the actual commit at HEAD.

Regression coverage exercises both the managed and LibGit2 engines.

Fixes #643