### PR TITLE
Stop racing on global LibGit2 config paths

### DIFF
--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
@@ -23,19 +23,28 @@ public class LibGit2Context : GitContext
         : base(workingTreeDirectory, dotGitPath)
     {
         // LibGit2Sharp config search paths are process-global, so do not reset them while other contexts may be active.
-        this.Repository = new Repository(workingTreeDirectory);
-        if (this.Repository.Info.WorkingDirectory is null)
+        Repository repository = new(workingTreeDirectory);
+        try
         {
-            throw new ArgumentException("Bare repositories not supported.", nameof(workingTreeDirectory));
-        }
+            if (repository.Info.WorkingDirectory is null)
+            {
+                throw new ArgumentException("Bare repositories not supported.", nameof(workingTreeDirectory));
+            }
 
-        this.Commit = committish is null ? this.Repository.Head.Tip : this.Repository.Lookup<Commit>(committish);
-        if (this.Commit is null && committish is object)
+            this.Repository = repository;
+            this.Commit = committish is null ? repository.Head.Tip : repository.Lookup<Commit>(committish);
+            if (this.Commit is null && committish is object)
+            {
+                throw new ArgumentException("No matching commit found.", nameof(committish));
+            }
+
+            this.VersionFile = new LibGit2VersionFile(this);
+        }
+        catch
         {
-            throw new ArgumentException("No matching commit found.", nameof(committish));
+            repository.Dispose();
+            throw;
         }
-
-        this.VersionFile = new LibGit2VersionFile(this);
     }
 
     /// <inheritdoc />

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2Context.cs
@@ -22,7 +22,8 @@ public class LibGit2Context : GitContext
     internal LibGit2Context(string workingTreeDirectory, string dotGitPath, string? committish = null)
         : base(workingTreeDirectory, dotGitPath)
     {
-        this.Repository = OpenGitRepo(workingTreeDirectory, useDefaultConfigSearchPaths: true);
+        // LibGit2Sharp config search paths are process-global, so do not reset them while other contexts may be active.
+        this.Repository = new Repository(workingTreeDirectory);
         if (this.Repository.Info.WorkingDirectory is null)
         {
             throw new ArgumentException("Bare repositories not supported.", nameof(workingTreeDirectory));
@@ -118,50 +119,6 @@ public class LibGit2Context : GitContext
 
     /// <inheritdoc/>
     public override string GetShortUniqueCommitId(int minLength) => this.Repository.ObjectDatabase.ShortenObjectId(this.Commit, minLength);
-
-    /// <summary>
-    /// Opens a <see cref="Repository"/> found at or above a specified path.
-    /// </summary>
-    /// <param name="path">The path to the .git directory or the working directory.</param>
-    /// <param name="useDefaultConfigSearchPaths">
-    /// Specifies whether to use default settings for looking up global and system settings.
-    /// <para>
-    /// By default (<paramref name="useDefaultConfigSearchPaths"/> == <see langword="false"/>), the repository will be configured to only
-    /// use the repository-level configuration ignoring system or user-level configuration (set using <c>git config --global</c>.
-    /// Thus only settings explicitly set for the repo will be available.
-    /// </para>
-    /// <para>
-    /// For example using <c>Repository.Configuration.Get{string}("user.name")</c> to get the user's name will
-    /// return the value set in the repository config or <see langword="null"/> if the user name has not been explicitly set for the repository.
-    /// </para>
-    /// <para>
-    /// When the caller specifies to use the default configuration search paths (<paramref name="useDefaultConfigSearchPaths"/> == <see langword="true"/>)
-    /// both repository level and global configuration will be available to the repo as well.
-    /// </para>
-    /// <para>
-    /// In this mode, using <c>Repository.Configuration.Get{string}("user.name")</c> will return the
-    /// value set in the user's global git configuration unless set on the repository level,
-    /// matching the behavior of the <c>git</c> command.
-    /// </para>
-    /// </param>
-    /// <returns>The <see cref="Repository"/> found for the specified path, or <see langword="null"/> if no git repo is found.</returns>
-    internal static Repository OpenGitRepo(string path, bool useDefaultConfigSearchPaths = false)
-    {
-        if (useDefaultConfigSearchPaths)
-        {
-            // pass null to reset to defaults
-            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, null);
-            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.System, null);
-        }
-        else
-        {
-            // Override Config Search paths to empty path to avoid new Repository instance to lookup for Global\System .gitconfig file
-            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, string.Empty);
-            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.System, string.Empty);
-        }
-
-        return new Repository(path);
-    }
 
     /// <inheritdoc/>
     internal override int CalculateVersionHeight(VersionOptions? committedVersion, VersionOptions? workingVersion)

--- a/src/NerdBank.GitVersioning/LibGit2/LibGit2VersionFile.cs
+++ b/src/NerdBank.GitVersioning/LibGit2/LibGit2VersionFile.cs
@@ -51,7 +51,8 @@ internal class LibGit2VersionFile : VersionFile
             {
                 if (blobVersionCache is null || !blobVersionCache.TryGetValue(versionTxtBlob.Id, out VersionOptions? result))
                 {
-                    result = TryReadVersionFile(new StreamReader(versionTxtBlob.GetContentStream()));
+                    using var reader = new StreamReader(versionTxtBlob.GetContentStream());
+                    result = TryReadVersionFile(reader);
                     if (blobVersionCache is object)
                     {
                         result?.Freeze();

--- a/test/Nerdbank.GitVersioning.Tests/BuildCollectionDefinition.cs
+++ b/test/Nerdbank.GitVersioning.Tests/BuildCollectionDefinition.cs
@@ -1,0 +1,9 @@
+// Copyright (c) .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+[CollectionDefinition("Build", DisableParallelization = true)]
+public class BuildCollectionDefinition
+{
+}

--- a/test/Nerdbank.GitVersioning.Tests/LibGit2GlobalSettingsCollectionDefinition.cs
+++ b/test/Nerdbank.GitVersioning.Tests/LibGit2GlobalSettingsCollectionDefinition.cs
@@ -1,0 +1,9 @@
+// Copyright (c) .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+[CollectionDefinition("LibGit2 global settings", DisableParallelization = true)]
+public class LibGit2GlobalSettingsCollectionDefinition
+{
+}

--- a/test/Nerdbank.GitVersioning.Tests/LibGit2GlobalSettingsTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/LibGit2GlobalSettingsTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Linq;
+using LibGit2Sharp;
+using Nerdbank.GitVersioning;
+using Xunit;
+
+[Collection("LibGit2 global settings")]
+public class LibGit2GlobalSettingsTests
+{
+    [Fact]
+    public void CreatingContextDoesNotAlterConfigSearchPaths()
+    {
+        string[] originalGlobalPaths = GlobalSettings.GetConfigSearchPaths(ConfigurationLevel.Global).ToArray();
+        string[] originalSystemPaths = GlobalSettings.GetConfigSearchPaths(ConfigurationLevel.System).ToArray();
+        string testDirectory = Path.Combine(Path.GetTempPath(), $"{nameof(LibGit2GlobalSettingsTests)}_{Path.GetRandomFileName()}");
+        string repositoryPath = Path.Combine(testDirectory, "repo");
+
+        try
+        {
+            Directory.CreateDirectory(testDirectory);
+            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, testDirectory);
+            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.System, testDirectory);
+            Repository.Init(repositoryPath);
+
+            using GitContext context = GitContext.Create(repositoryPath, engine: GitContext.Engine.ReadWrite);
+
+            Assert.Equal(new[] { testDirectory }, GlobalSettings.GetConfigSearchPaths(ConfigurationLevel.Global));
+            Assert.Equal(new[] { testDirectory }, GlobalSettings.GetConfigSearchPaths(ConfigurationLevel.System));
+        }
+        finally
+        {
+            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, originalGlobalPaths);
+            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.System, originalSystemPaths);
+            TestUtilities.DeleteDirectory(testDirectory);
+        }
+    }
+}

--- a/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitRepositoryTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ManagedGit/GitRepositoryTests.cs
@@ -232,12 +232,12 @@ public class GitRepositoryTests : RepoTestBase
 
         string alternate1Path = this.CreateDirectoryForNewRepo();
         this.InitializeSourceControl(alternate1Path).Dispose();
-        var alternate1 = new Repository(alternate1Path);
+        using var alternate1 = new Repository(alternate1Path);
         Commit alternate1Commit = alternate1.Commit("Alternate 1", this.Signer, this.Signer, new CommitOptions() { AllowEmptyCommit = true });
 
         string alternate2Path = this.CreateDirectoryForNewRepo();
         this.InitializeSourceControl(alternate2Path).Dispose();
-        var alternate2 = new Repository(alternate2Path);
+        using var alternate2 = new Repository(alternate2Path);
         Commit alternate2Commit = alternate2.Commit("Alternate 2", this.Signer, this.Signer, new CommitOptions() { AllowEmptyCommit = true });
 
         string objectDatabasePath = Path.Combine(this.RepoPath, ".git", "objects");

--- a/test/Nerdbank.GitVersioning.Tests/NbgvInstallTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/NbgvInstallTests.cs
@@ -66,6 +66,7 @@ public class NbgvInstallTests : RepoTestBase
         listener.Stop();
         await serverTask;
 
+        this.Logger.WriteLine("nbgv standard error:{0}{1}", Environment.NewLine, standardError);
         Assert.NotEqual(0, process.ExitCode);
         Assert.Contains($"Failed to query NuGet package sources: Unable to load the service index for source {source}.", standardError);
         Assert.Contains("Use the '--source' option", standardError);

--- a/test/Nerdbank.GitVersioning.Tests/RepoTestBase.cs
+++ b/test/Nerdbank.GitVersioning.Tests/RepoTestBase.cs
@@ -100,6 +100,8 @@ public abstract partial class RepoTestBase : IDisposable
 
     protected virtual void InitializeSourceControl(bool withInitialCommit = true)
     {
+        this.LibGit2Repository?.Dispose();
+        this.LibGit2Repository = null;
         this.Context?.Dispose();
         this.Context = this.InitializeSourceControl(this.RepoPath, withInitialCommit);
         this.LibGit2Repository = new Repository(this.RepoPath);

--- a/test/Nerdbank.GitVersioning.Tests/SomeGitBuildIntegrationTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/SomeGitBuildIntegrationTests.cs
@@ -71,7 +71,7 @@ public abstract class SomeGitBuildIntegrationTests : BuildIntegrationTests
     public async Task GetBuildVersion_In_Git_But_Without_Commits()
     {
         Repository.Init(this.RepoPath);
-        var repo = new Repository(this.RepoPath); // do not assign Repo property to avoid commits being generated later
+        using var repo = new Repository(this.RepoPath); // do not assign Repo property to avoid commits being generated later
         this.WriteVersionFile("3.4");
         Assumes.False(repo.Head.Commits.Any()); // verification that the test is doing what it claims
         BuildResults buildResult = await this.BuildAsync();
@@ -83,7 +83,7 @@ public abstract class SomeGitBuildIntegrationTests : BuildIntegrationTests
     public async Task GetBuildVersion_In_Git_But_Head_Lacks_VersionFile()
     {
         Repository.Init(this.RepoPath);
-        var repo = new Repository(this.RepoPath); // do not assign Repo property to avoid commits being generated later
+        using var repo = new Repository(this.RepoPath); // do not assign Repo property to avoid commits being generated later
         repo.Commit("empty", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
         this.WriteVersionFile("3.4");
         Assumes.True(repo.Index[VersionFile.JsonFileName] is null);
@@ -110,7 +110,7 @@ public abstract class SomeGitBuildIntegrationTests : BuildIntegrationTests
     public async Task GetBuildVersion_In_Git_No_VersionFile_At_All()
     {
         Repository.Init(this.RepoPath);
-        var repo = new Repository(this.RepoPath); // do not assign Repo property to avoid commits being generated later
+        using var repo = new Repository(this.RepoPath); // do not assign Repo property to avoid commits being generated later
         repo.Commit("empty", this.Signer, this.Signer, new CommitOptions { AllowEmptyCommit = true });
         BuildResults buildResult = await this.BuildAsync();
         Assert.Equal("0.0.0." + this.GetVersion().Revision, buildResult.BuildVersion);


### PR DESCRIPTION
Recent `main` builds have intermittently terminated with `AccessViolationException` at unrelated managed call sites. The failures occur while tests create LibGit2 contexts concurrently, and each context was rewriting libgit2's process-global configuration search paths.

This change opens repositories without mutating those global settings and removes the now-unused helper. It also adds an isolated regression test that configures custom search paths and verifies that creating a context preserves them.

Validation included both target frameworks, five repeated runs of the LibGit2-heavy test classes, and the full .NET 10 test suite.