### PR TITLE
Support signed commits in nbgv prepare-release

### DIFF
--- a/docfx/docs/nbgv-cli.md
+++ b/docfx/docs/nbgv-cli.md
@@ -74,6 +74,10 @@ This will:
    This avoids having to resolve the conflict when merging the branch at a later
    time.
 
+If Git configuration enables `commit.gpgSign`, `prepare-release` uses the `git`
+executable on `PATH` to sign every commit it creates, including the merge commit.
+When commit signing is not enabled, `git` is not required.
+
 To leave the release and main branches unmerged, pass `--no-merge`:
 
 ```ps1

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using LibGit2Sharp;
 using Nerdbank.GitVersioning.LibGit2;
@@ -14,7 +16,8 @@ namespace Nerdbank.GitVersioning;
 /// Methods for creating releases.
 /// </summary>
 /// <remarks>
-/// This class authors git commits, branches, etc. and thus must use libgit2 rather than our internal managed implementation which is read-only.
+/// This class authors git commits, branches, etc. and thus uses libgit2 rather than our internal managed implementation which is read-only.
+/// When commit signing is enabled, it uses the Git CLI to create signed commits.
 /// </remarks>
 public class ReleaseManager
 {
@@ -86,6 +89,11 @@ public class ReleaseManager
         /// The versionIncrement setting cannot be applied to the current version.
         /// </summary>
         InvalidVersionIncrementSetting,
+
+        /// <summary>
+        /// A Git command required to sign a commit failed.
+        /// </summary>
+        GitCommandFailed,
     }
 
     /// <summary>
@@ -319,12 +327,26 @@ public class ReleaseManager
         if (mergeReleaseBranch)
         {
             // Merge the release branch now to resolve the version.json conflict in favor of the development branch.
-            var mergeOptions = new MergeOptions()
+            if (this.ShouldSignCommits(repository))
             {
-                CommitOnSuccess = true,
-                MergeFileFavor = MergeFileFavor.Ours,
-            };
-            repository.Merge(releaseBranch, this.GetSignature(repository), mergeOptions);
+                this.RunGit(
+                    repository,
+                    "merge",
+                    "--gpg-sign",
+                    "--no-edit",
+                    "--no-verify",
+                    "--strategy-option=ours",
+                    releaseBranch.CanonicalName);
+            }
+            else
+            {
+                var mergeOptions = new MergeOptions()
+                {
+                    CommitOnSuccess = true,
+                    MergeFileFavor = MergeFileFavor.Ours,
+                };
+                repository.Merge(releaseBranch, this.GetSignature(repository), mergeOptions);
+            }
         }
 
         if (outputMode == ReleaseManagerOutputMode.Json)
@@ -395,10 +417,97 @@ public class ReleaseManager
                 }
 
                 string commitMessage = string.Format(CultureInfo.CurrentCulture, unformattedCommitMessage, versionOptions.Version);
-                context.Repository.Commit(commitMessage, signature, signature, new CommitOptions() { AllowEmptyCommit = false });
+                if (this.ShouldSignCommits(context.Repository))
+                {
+                    this.RunGit(context.Repository, "commit", "--gpg-sign", "--no-verify", "--message", commitMessage);
+                }
+                else
+                {
+                    context.Repository.Commit(commitMessage, signature, signature, new CommitOptions() { AllowEmptyCommit = false });
+                }
             }
         }
     }
+
+    private bool ShouldSignCommits(Repository repository)
+        => repository.Config.Get<bool>("commit.gpgSign")?.Value ?? false;
+
+    private void RunGit(Repository repository, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo("git")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            WorkingDirectory = repository.Info.WorkingDirectory,
+        };
+
+#if NET
+        foreach (string argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+#else
+        startInfo.Arguments = string.Join(" ", arguments.Select(this.QuoteArgument));
+#endif
+
+        try
+        {
+            using Process process = Process.Start(startInfo);
+            Task<string> standardOutputTask = process.StandardOutput.ReadToEndAsync();
+            Task<string> standardErrorTask = process.StandardError.ReadToEndAsync();
+            process.WaitForExit();
+            string standardOutput = standardOutputTask.GetAwaiter().GetResult();
+            string standardError = standardErrorTask.GetAwaiter().GetResult();
+            if (process.ExitCode != 0)
+            {
+                string error = string.IsNullOrWhiteSpace(standardError) ? standardOutput : standardError;
+                this.stderr.WriteLine($"Git failed while creating a signed commit: {error.Trim()}");
+                throw new ReleasePreparationException(ReleasePreparationError.GitCommandFailed);
+            }
+        }
+        catch (Win32Exception ex)
+        {
+            this.stderr.WriteLine($"Commit signing is enabled, but Git could not be started: {ex.Message}");
+            throw new ReleasePreparationException(ReleasePreparationError.GitCommandFailed, ex);
+        }
+    }
+
+#if !NET
+    private string QuoteArgument(string argument)
+    {
+        if (argument.Length > 0 && !argument.Any(char.IsWhiteSpace) && !argument.Contains('"'))
+        {
+            return argument;
+        }
+
+        var result = new System.Text.StringBuilder("\"");
+        int backslashes = 0;
+        foreach (char character in argument)
+        {
+            if (character == '\\')
+            {
+                backslashes++;
+            }
+            else if (character == '"')
+            {
+                result.Append('\\', (backslashes * 2) + 1);
+                result.Append(character);
+                backslashes = 0;
+            }
+            else
+            {
+                result.Append('\\', backslashes);
+                result.Append(character);
+                backslashes = 0;
+            }
+        }
+
+        result.Append('\\', backslashes * 2);
+        result.Append('"');
+        return result.ToString();
+    }
+#endif
 
     private Signature GetSignature(Repository repository)
     {

--- a/src/NerdBank.GitVersioning/ReleaseManager.cs
+++ b/src/NerdBank.GitVersioning/ReleaseManager.cs
@@ -462,7 +462,7 @@ public class ReleaseManager
             if (process.ExitCode != 0)
             {
                 string error = string.IsNullOrWhiteSpace(standardError) ? standardOutput : standardError;
-                this.stderr.WriteLine($"Git failed while creating a signed commit: {error.Trim()}");
+                this.stderr.WriteLine($"Git {arguments[0]} failed while creating a signed commit: {error.Trim()}");
                 throw new ReleasePreparationException(ReleasePreparationError.GitCommandFailed);
             }
         }

--- a/src/nbgv/Program.cs
+++ b/src/nbgv/Program.cs
@@ -1103,6 +1103,8 @@ namespace Nerdbank.GitVersioning.Tool
                         return Task.FromResult((int)ExitCodes.DetachedHead);
                     case ReleaseManager.ReleasePreparationError.InvalidVersionIncrementSetting:
                         return Task.FromResult((int)ExitCodes.InvalidVersionIncrementSetting);
+                    case ReleaseManager.ReleasePreparationError.GitCommandFailed:
+                        return Task.FromResult((int)ExitCodes.InternalError);
                     default:
                         Report.Fail($"{nameof(ReleaseManager.ReleasePreparationError)}: {ex.Error}");
                         return Task.FromResult(-1);

--- a/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -502,7 +502,7 @@ public abstract class ReleaseManagerTests : RepoTestBase
         this.RunProcess(keyDirectory, "ssh-keygen", "-q", "-t", "ed25519", "-N", string.Empty, "-f", privateKeyPath);
 
         this.LibGit2Repository.Config.Set("gpg.format", "ssh", ConfigurationLevel.Local);
-        this.LibGit2Repository.Config.Set("user.signingKey", privateKeyPath + ".pub", ConfigurationLevel.Local);
+        this.LibGit2Repository.Config.Set("user.signingKey", privateKeyPath, ConfigurationLevel.Local);
         this.LibGit2Repository.Config.Set("commit.gpgSign", true, ConfigurationLevel.Local);
 
         new ReleaseManager().PrepareRelease(this.RepoPath);
@@ -992,7 +992,7 @@ public abstract class ReleaseManagerTests : RepoTestBase
         string standardOutput = process.StandardOutput.ReadToEnd();
         string standardError = process.StandardError.ReadToEnd();
         process.WaitForExit();
-        Assert.True(process.ExitCode == 0, standardError);
+        Assert.True(process.ExitCode == 0, string.IsNullOrWhiteSpace(standardError) ? standardOutput : standardError);
         return standardOutput;
     }
 }

--- a/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
+++ b/test/Nerdbank.GitVersioning.Tests/ReleaseManagerTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using LibGit2Sharp;
@@ -489,6 +491,30 @@ public abstract class ReleaseManagerTests : RepoTestBase
         Assert.Equal(tipBeforePrepareRelease.Id, releaseTip.Parents.Single().Id);
     }
 
+    [Fact(SkipExceptions = [typeof(Win32Exception)])]
+    public void PrepareRelease_SignsCommitsWhenConfigured()
+    {
+        this.InitializeSourceControl();
+        this.WriteVersionFile(new VersionOptions() { Version = SemanticVersion.Parse("1.0-beta") });
+
+        string keyDirectory = this.CreateDirectoryForNewRepo();
+        string privateKeyPath = Path.Combine(keyDirectory, "signing-key");
+        this.RunProcess(keyDirectory, "ssh-keygen", "-q", "-t", "ed25519", "-N", string.Empty, "-f", privateKeyPath);
+
+        this.LibGit2Repository.Config.Set("gpg.format", "ssh", ConfigurationLevel.Local);
+        this.LibGit2Repository.Config.Set("user.signingKey", privateKeyPath + ".pub", ConfigurationLevel.Local);
+        this.LibGit2Repository.Config.Set("commit.gpgSign", true, ConfigurationLevel.Local);
+
+        new ReleaseManager().PrepareRelease(this.RepoPath);
+
+        Commit mergeCommit = this.LibGit2Repository.Head.Tip;
+        Commit developmentCommit = mergeCommit.Parents.First();
+        Commit releaseCommit = this.LibGit2Repository.Branches["v1.0"].Tip;
+        this.AssertCommitSigned(this.RepoPath, releaseCommit);
+        this.AssertCommitSigned(this.RepoPath, developmentCommit);
+        this.AssertCommitSigned(this.RepoPath, mergeCommit);
+    }
+
     [Fact]
     public void PrepareRelease_JsonOutput()
     {
@@ -934,5 +960,39 @@ public abstract class ReleaseManagerTests : RepoTestBase
     {
         ReleasePreparationException ex = Assert.Throws<ReleasePreparationException>(testCode);
         Assert.Equal(expectedError, ex.Error);
+    }
+
+    private void AssertCommitSigned(string repositoryPath, Commit commit)
+    {
+        string commitContents = this.RunProcess(repositoryPath, "git", "cat-file", "commit", commit.Sha);
+        Assert.Contains("gpgsig -----BEGIN SSH SIGNATURE-----", commitContents);
+    }
+
+    private string RunProcess(string workingDirectory, string fileName, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo(fileName)
+        {
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory,
+        };
+
+#if NET
+        foreach (string argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+#else
+        startInfo.Arguments = string.Join(" ", arguments.Select(argument => $"\"{argument.Replace("\"", "\\\"")}\""));
+#endif
+
+        using Process process = Process.Start(startInfo);
+        string standardOutput = process.StandardOutput.ReadToEnd();
+        string standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, standardError);
+        return standardOutput;
     }
 }

--- a/test/Nerdbank.GitVersioning.Tests/RepoTestBase.cs
+++ b/test/Nerdbank.GitVersioning.Tests/RepoTestBase.cs
@@ -118,6 +118,7 @@ public abstract partial class RepoTestBase : IDisposable
 
         repo.Config.Set("user.name", this.Signer.Name, ConfigurationLevel.Local);
         repo.Config.Set("user.email", this.Signer.Email, ConfigurationLevel.Local);
+        repo.Config.Set("commit.gpgSign", false, ConfigurationLevel.Local);
         foreach (StatusEntry? file in repo.RetrieveStatus().Untracked)
         {
             if (!Path.GetFileName(file.FilePath).StartsWith("_git2_", StringComparison.Ordinal))


### PR DESCRIPTION
Repositories that require signed commits cannot currently use `nbgv prepare-release` without rewriting the commits it creates.

This change detects the resolved `commit.gpgSign` setting and uses the Git CLI for commit-producing operations only when signing is enabled. The normal LibGit2Sharp path remains unchanged, so `git` is not searched for or invoked unless signing is expected. Git handles the configured signing format and key for release-version commits, development-version commits, and the merge commit, while failures are surfaced through the CLI.

The coverage generates a temporary SSH signing key and verifies signatures in all three generated commit objects on .NET and .NET Framework. The CLI documentation now describes the conditional Git dependency.

Fixes #594